### PR TITLE
[main < redirect -fix-20230823] Fix redirect for /docs

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -910,11 +910,6 @@ module.exports = withNextra({
         permanent: true
       },
       {
-        source: '/',
-        destination: '/docs',
-        permanent: true
-      },
-      {
         source: '/cypher-manual/working-with-memgraph',
         destination: '/docs',
         permanent: true


### PR DESCRIPTION
We have added the base URL, but at the same time, a redirect from `/` to `/docs` was left in the config file. Due to that, visiting `/docs` would take you to `/docs/docs` which produced 404 page. This is now fixed.