### PR TITLE
[memgraph-v2-11 < 160] Add bulk property-setting to query module APIs docs

### DIFF
--- a/pages/custom-query-modules/c/c-api.mdx
+++ b/pages/custom-query-modules/c/c-api.mdx
@@ -1642,7 +1642,7 @@ enum mgp_error mgp_vertex_set_property(
 
 Set the value of a property on a vertex.
 
-When the value is `null`, then the property is removed from the vertex. Return MGP_ERROR_UNABLE_TO_ALLOCATE if unable to allocate memory for storing the property. Return MGP_ERROR_IMMUTABLE_OBJECT if `v` is immutable. Return MGP_ERROR_DELETED_OBJECT if `v` has been deleted. Return MGP_ERROR_SERIALIZATION_ERROR if `v` has been modified by another transaction. Return MGP_ERROR_VALUE_CONVERSION if `property_value` is vertex, edge or path.
+When the value is `null`, the property is removed from the vertex. Return MGP_ERROR_UNABLE_TO_ALLOCATE if unable to allocate memory for storing the property. Return MGP_ERROR_IMMUTABLE_OBJECT if `v` is immutable. Return MGP_ERROR_DELETED_OBJECT if `v` has been deleted. Return MGP_ERROR_SERIALIZATION_ERROR if `v` has been modified by another transaction. Return MGP_ERROR_VALUE_CONVERSION if `property_value` is vertex, edge or path.
 
 
 ### mgp_vertex_set_properties [#function-mgp-vertex-set-properties]
@@ -1988,7 +1988,7 @@ enum mgp_error mgp_edge_set_property(
 
 Set the value of a property on an edge.
 
-When the value is `null`, then the property is removed from the edge. Return MGP_ERROR_UNABLE_TO_ALLOCATE if unable to allocate memory for storing the property. Return MGP_ERROR_IMMUTABLE_OBJECT if `e` is immutable. Return MGP_ERROR_DELETED_OBJECT if `e` has been deleted. Return MGP_ERROR_LOGIC_ERROR if properties on edges are disabled. Return MGP_ERROR_SERIALIZATION_ERROR if `e` has been modified by another transaction. Return MGP_ERROR_VALUE_CONVERSION if `property_value` is vertex, edge or path.
+When the value is `null`, the property is removed from the edge. Return MGP_ERROR_UNABLE_TO_ALLOCATE if unable to allocate memory for storing the property. Return MGP_ERROR_IMMUTABLE_OBJECT if `e` is immutable. Return MGP_ERROR_DELETED_OBJECT if `e` has been deleted. Return MGP_ERROR_LOGIC_ERROR if properties on edges are disabled. Return MGP_ERROR_SERIALIZATION_ERROR if `e` has been modified by another transaction. Return MGP_ERROR_VALUE_CONVERSION if `property_value` is vertex, edge or path.
 
 
 ### mgp_edge_set_properties [#function-mgp-edge-set-properties]

--- a/pages/custom-query-modules/c/c-api.mdx
+++ b/pages/custom-query-modules/c/c-api.mdx
@@ -141,6 +141,7 @@ Memgraph in order to use them.
 | enum [mgp_error](#variable-mgp-error) | **[mgp_vertex_get_id](#function-mgp-vertex-get-id)**(struct mgp_vertex * v, struct [mgp_vertex_id](#mgp_vertex_id) * result)<br/>Get the ID of given vertex.  |
 | enum [mgp_error](#variable-mgp-error) | **[mgp_vertex_underlying_graph_is_mutable](#function-mgp-vertex-underlying-graph-is-mutable)**(struct mgp_vertex * v, int * result)<br/>Result is non-zero if the vertex can be modified.  |
 | enum [mgp_error](#variable-mgp-error) | **[mgp_vertex_set_property](#function-mgp-vertex-set-property)**(struct mgp_vertex * v, const char * property_name, struct mgp_value * property_value)<br/>Set the value of a property on a vertex.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_vertex_set_properties](#function-mgp-vertex-set-properties)**(struct mgp_vertex *v, struct mgp_map *properties)<br/>Set the properties of the given vertex.  |
 | enum [mgp_error](#variable-mgp-error) | **[mgp_vertex_add_label](#function-mgp-vertex-add-label)**(struct mgp_vertex * v, struct [mgp_label](#mgp_label) label)<br/>Add the label to the vertex.  |
 | enum [mgp_error](#variable-mgp-error) | **[mgp_vertex_remove_label](#function-mgp-vertex-remove-label)**(struct mgp_vertex * v, struct [mgp_label](#mgp_label) label)<br/>Remove the label from the vertex.  |
 | enum [mgp_error](#variable-mgp-error) | **[mgp_vertex_copy](#function-mgp-vertex-copy)**(struct mgp_vertex * v, struct mgp_memory * memory, struct mgp_vertex ** result)<br/>Copy a mgp_vertex.  |
@@ -167,6 +168,7 @@ Memgraph in order to use them.
 | enum [mgp_error](#variable-mgp-error) | **[mgp_edge_get_to](#function-mgp-edge-get-to)**(struct mgp_edge * e, struct mgp_vertex ** result)<br/>Get the destination vertex of the given edge.  |
 | enum [mgp_error](#variable-mgp-error) | **[mgp_edge_get_property](#function-mgp-edge-get-property)**(struct mgp_edge * e, const char * property_name, struct mgp_memory * memory, struct mgp_value ** result)<br/>Get a copy of a edge property mapped to a given name.  |
 | enum [mgp_error](#variable-mgp-error) | **[mgp_edge_set_property](#function-mgp-edge-set-property)**(struct mgp_edge * e, const char * property_name, struct mgp_value * property_value)<br/>Set the value of a property on an edge.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_edge_set_properties](#function-mgp-edge-set-properties)**(struct mgp_edge *e, struct mgp_map *properties)<br/>Set the properties of the given edge.  |
 | enum [mgp_error](#variable-mgp-error) | **[mgp_edge_iter_properties](#function-mgp-edge-iter-properties)**(struct mgp_edge * e, struct mgp_memory * memory, struct mgp_properties_iterator ** result)<br/>Start iterating over properties stored in the given edge.  |
 | enum [mgp_error](#variable-mgp-error) | **[mgp_graph_get_vertex_by_id](#function-mgp-graph-get-vertex-by-id)**(struct mgp_graph * g, struct [mgp_vertex_id](#mgp_vertex_id) id, struct mgp_memory * memory, struct mgp_vertex ** result)<br/>Get the vertex corresponding to given ID, or NULL if no such vertex exists.  |
 | enum [mgp_error](#variable-mgp-error) | **[mgp_graph_is_mutable](#function-mgp-graph-is-mutable)**(struct mgp_graph * graph, int * result)<br/>Result is non-zero if the graph can be modified.  |
@@ -1643,6 +1645,19 @@ Set the value of a property on a vertex.
 When the value is `null`, then the property is removed from the vertex. Return MGP_ERROR_UNABLE_TO_ALLOCATE if unable to allocate memory for storing the property. Return MGP_ERROR_IMMUTABLE_OBJECT if `v` is immutable. Return MGP_ERROR_DELETED_OBJECT if `v` has been deleted. Return MGP_ERROR_SERIALIZATION_ERROR if `v` has been modified by another transaction. Return MGP_ERROR_VALUE_CONVERSION if `property_value` is vertex, edge or path.
 
 
+### mgp_vertex_set_properties [#function-mgp-vertex-set-properties]
+```cpp
+enum mgp_error mgp_vertex_set_properties(
+    struct mgp_vertex * v,
+    struct mgp_map * properties
+)
+```
+
+Update the properties of the given vertex.
+
+Return MGP_ERROR_UNABLE_TO_ALLOCATE if unable to allocate memory for storing the property. Return MGP_ERROR_IMMUTABLE_OBJECT if `v` is immutable. Return MGP_ERROR_DELETED_OBJECT if `v` has been deleted. Return MGP_ERROR_SERIALIZATION_ERROR if `v` has been modified by another transaction.
+
+
 ### mgp_vertex_add_label [#function-mgp-vertex-add-label]
 ```cpp
 enum mgp_error mgp_vertex_add_label(
@@ -1974,6 +1989,19 @@ enum mgp_error mgp_edge_set_property(
 Set the value of a property on an edge.
 
 When the value is `null`, then the property is removed from the edge. Return MGP_ERROR_UNABLE_TO_ALLOCATE if unable to allocate memory for storing the property. Return MGP_ERROR_IMMUTABLE_OBJECT if `e` is immutable. Return MGP_ERROR_DELETED_OBJECT if `e` has been deleted. Return MGP_ERROR_LOGIC_ERROR if properties on edges are disabled. Return MGP_ERROR_SERIALIZATION_ERROR if `e` has been modified by another transaction. Return MGP_ERROR_VALUE_CONVERSION if `property_value` is vertex, edge or path.
+
+
+### mgp_edge_set_properties [#function-mgp-edge-set-properties]
+```cpp
+enum mgp_error mgp_edge_set_properties(
+    struct mgp_edge * e,
+    struct mgp_map * properties
+)
+```
+
+Update the properties of the given vertex.
+
+Return MGP_ERROR_UNABLE_TO_ALLOCATE if unable to allocate memory for storing the property. Return MGP_ERROR_IMMUTABLE_OBJECT if `v` is immutable. Return MGP_ERROR_DELETED_OBJECT if `v` has been deleted. Return MGP_ERROR_SERIALIZATION_ERROR if `v` has been modified by another transaction. Return MGP_ERROR_LOGIC_ERROR if properties on edges are disabled.
 
 
 ### mgp_edge_iter_properties [#function-mgp-edge-iter-properties]
@@ -3648,6 +3676,8 @@ enum mgp_error mgp_vertex_underlying_graph_is_mutable(struct mgp_vertex *v, int 
 enum mgp_error mgp_vertex_set_property(struct mgp_vertex *v, const char *property_name,
                                        struct mgp_value *property_value);
 
+enum mgp_error mgp_vertex_set_properties(struct mgp_vertex *v, struct mgp_map *properties);
+
 enum mgp_error mgp_vertex_add_label(struct mgp_vertex *v, struct mgp_label label);
 
 enum mgp_error mgp_vertex_remove_label(struct mgp_vertex *v, struct mgp_label label);
@@ -3708,6 +3738,8 @@ enum mgp_error mgp_edge_get_property(struct mgp_edge *e, const char *property_na
                                      struct mgp_value **result);
 
 enum mgp_error mgp_edge_set_property(struct mgp_edge *e, const char *property_name, struct mgp_value *property_value);
+
+enum mgp_error mgp_edge_set_properties(struct mgp_edge *e, struct mgp_map *properties);
 
 enum mgp_error mgp_edge_iter_properties(struct mgp_edge *e, struct mgp_memory *memory,
                                         struct mgp_properties_iterator **result);

--- a/pages/custom-query-modules/cpp/cpp-api.md
+++ b/pages/custom-query-modules/cpp/cpp-api.md
@@ -631,7 +631,8 @@ Node(Node &&other) noexcept
 | `OutRelationships` | Returns an iterable structure of the node’s outbound relationships. |
 | `AddLabel`         | Adds a label to the node.                                           |
 | `RemoveLabel`      | Removes a label from the node.                                      |
-| `SetProperty`      | Set value of node's property                                        |
+| `SetProperty`      | Set the value of the node's property.                               |
+| `SetProperties`    | Update the node's properties.                                       |
 | `GetProperty`      | Get value of node's property                                        |
 | `RemoveProperty`   | Removes the node's property                                         |
 
@@ -664,7 +665,7 @@ bool HasLabel(std::string_view label) const
 Returns an iterable & indexable structure of the node’s properties.
 
 ```cpp
-std::map<std::string, mgp::Value> Properties() const
+std::unordered_map<std::string, mgp::Value> Properties() const
 ```
 
 ##### GetProperty
@@ -677,10 +678,18 @@ mgp::value GetProperty(const std::string& property) const
 
 ##### SetProperty
 
-Sets value of node's property.
+Sets the value of the node's property.
 
 ```cpp
-void SetProperty(std::string key, std::string value) const
+void SetProperty(std::string key, std::string value)
+```
+
+##### SetProperties
+
+Updates the node's properties with the given map.
+
+```cpp
+void SetProperties(std::unordered_map<std::string_view, Value> properties)
 ```
 
 ##### RemoveProperty
@@ -763,7 +772,8 @@ Relationship(Relationship &&other) noexcept
 | `Id`               | Returns the relationship’s ID.                                              |
 | `Type`             | Returns the relationship’s type.                                            |
 | `Properties`       | Returns an iterable & indexable structure of the relationship’s properties. |
-| `SetProperty`      | Set value of relationship's property.                                       |
+| `SetProperty`      | Set the value of the relationship's property.                               |
+| `SetProperties`    | Update the relationship's properties.                                       |
 | `RemoveProperty`   | Removes the relationship's property.                                        |
 | `GetProperty`      | Get value of relationship's property.                                       |
 | `From`             | Returns the relationship’s source node.                                     |
@@ -790,7 +800,7 @@ std::string_view Type() const
 Returns an iterable & indexable structure of the relationship’s properties.
 
 ```cpp
-std::map<std::string, mgp::Value> Properties() const
+std::unordered_map<std::string, mgp::Value> Properties() const
 ```
 ##### GetProperty
 
@@ -802,10 +812,18 @@ mgp::value GetProperty(const std::string& property) const
 
 ##### SetProperty
 
-Sets value of the relationship's property.
+Sets the value of the relationship's property.
 
 ```cpp
-void SetProperty(std::string key, std::string value) const
+void SetProperty(std::string key, std::string value)
+```
+
+##### SetProperties
+
+Updates the relationship's properties with the given map.
+
+```cpp
+void SetProperties(std::unordered_map<std::string_view, Value> properties)
 ```
 
 ##### RemoveProperty

--- a/pages/custom-query-modules/python/python-api.mdx
+++ b/pages/custom-query-modules/python/python-api.mdx
@@ -305,6 +305,35 @@ property is removed.
   edge.properties.set(property_name, value)
   ```
 
+### set_properties()
+
+```python
+def set_properties(props: dict) -> None
+```
+
+Updates the properties with the items from the given dictionary. For each item,
+the key-value pair becomes the property name and value.
+
+
+**Arguments**:
+
+- `props` - A dictionary of property names and values.
+
+**Raises**:
+
+- `UnableToAllocateError` - If unable to allocate memory for storing the property.
+- `ImmutableObjectError` - If the object is immutable.
+- `DeletedObjectError` - If the object has been deleted.
+- `SerializationError` - If the object has been modified by another transaction.
+  
+
+**Examples**:
+
+  ```
+  vertex.properties.set_properties(props)
+  edge.properties.set_properties(props)
+  ```
+
 ### items()
 
 ```python


### PR DESCRIPTION
### Description

Memgraph 2.11 makes it possible to set node and relationship properties in bulk ([memgraph#1131](https://github.com/memgraph/memgraph/pull/1131)) with all query module APIs. This PR documents that and corrects similar methods’ signatures.

### Pull request type

Please check what kind of PR this is:

- [x] Fix or improvement of an existing page

### Related PRs and issues

PR this doc page is related to: [memgraph#1131](https://github.com/memgraph/memgraph/pull/1131)

### Checklist:

- [x] Check all content with Grammarly
- [x] Perform a self-review of my code
- [x] Make corresponding changes to the rest of the documentation (consult with the DX team)
- [x] The build passes locally
- [x] My changes generate no new warnings or errors
- [x] Add a corresponding label
- [x] If release-related, add a product and version label
- [x] If release-related, add release note on product PR
