### PR TITLE
[main<] Fix link typo

### DIFF
--- a/pages/client-libraries/go.mdx
+++ b/pages/client-libraries/go.mdx
@@ -524,7 +524,7 @@ for _, path := range result.Records {
 }
 ```
 
-Path will contain [Nodes](#process-the-node-result) and [Relationships[#process-the-relationship-result], that can be accessed in the same way as in the previous examples, by casting them to the relevant type.
+Path will contain [Nodes](#process-the-node-result) and [Relationships](#process-the-relationship-result), that can be accessed in the same way as in the previous examples, by casting them to the relevant type.
 
 #### Types mapping and casting
 


### PR DESCRIPTION
### Description

Fix typo when linking to a section in Go guide.

### Pull request type

Please check what kind of PR this is:

- [x] Fix or improvement of an existing page
- [ ] New documentation page, release related

### Checklist:

- [x] Check all content with Grammarly
- [x] Perform a self-review of my code
- [x] Make corresponding changes to the rest of the documentation (consult with the DX team)
- [x] The build passes locally
- [x] My changes generate no new warnings or errors
- [x] Add a corresponding label

