### PR TITLE
[memgraph-2-12-1 < ] Change query plan cache flag

### DIFF
--- a/pages/configuration/configuration-settings.mdx
+++ b/pages/configuration/configuration-settings.mdx
@@ -100,7 +100,7 @@ execution in Memgraph.
 | --query-execution-timeout-sec=180                         | Maximum allowed query execution time. <br/>Queries exceeding this limit will be aborted. Value of 0 means no limit.                                              | `[uint64]` |
 | --query-max-plans=1000                                    | Maximum number of generated plans for a query.                                                                                                                   | `[uint64]` |
 | --query-modules-directory=/usr/lib/memgraph/query_modules | Directory where modules with custom query procedures are stored. NOTE: Multiple comma-separated directories can be defined.                                      | `[string]` |
-| --query-plan-cache-ttl=60                                 | Time to live for cached query plans, in seconds.                                                                                                                 | `[int32]`  |
+| --query-plan-cache-max-size=1000                          | Maximum number of query plans to cache.                                                                                                                          | `[int32]`  |
 | --query-vertex-count-to-expand-existing=10                | Maximum count of indexed vertices which provoke indexed lookup and then expand to existing, <br/>instead of a regular expand. Default is 10, to turn off use -1. | `[int64]`  |
 
 ## Storage


### PR DESCRIPTION
### Description

I changed a query-plan-cache-ttl flag into query-plan-cache-max-size because we don't use ttl anymore.

### Pull request type

Please check what kind of PR this is:


- [x] Fix or improvement of an existing page
- [ ] New documentation page, release related

### Related PRs and issues

PR this doc page is related to: 
[memgraph/memgrapg/#1348](https://github.com/memgraph/memgraph/pull/1348)
(especially necessary if the PR is related to a release)

Closes:
(paste the link to the issue it closes)


### Checklist:

- [x] Check all content with Grammarly
- [x] Perform a self-review of my code
- [x] Make corresponding changes to the rest of the documentation (consult with the DX team)
- [x] The build passes locally
- [x] My changes generate no new warnings or errors
- [x] Add a corresponding label
- [x] If release-related, add a product and version label
- [x] If release-related, add release note on product PR
