### PR TITLE
[memgraph-v2-13 < 361] Document query module behavior in analytical mode

### DIFF
--- a/pages/custom-query-modules/c/c-api.mdx
+++ b/pages/custom-query-modules/c/c-api.mdx
@@ -12,21 +12,21 @@ of all functions that can be used to implement a query module procedure. The
 source file can be found in the Memgraph installation directory, under
 `/usr/include/memgraph`.
 
-<Callout>
+        <Callout>
 
-For an example of how to implement query modules in C, take a look at [the
+                For an example of how to implement query modules in C, take a look at [the
 example we
 provided](/custom-query-modules/c/c-example).
 
-</Callout>
+        </Callout>
 
-<Callout>
+        <Callout>
 
-If you install any C modules after running Memgraph, you'll have to [load
+                If you install any C modules after running Memgraph, you'll have to [load
 them into Memgraph](/custom-query-modules/manage-query-modules#loading-query-modules) or restart
 Memgraph in order to use them.
 
-</Callout>
+        </Callout>
 
 ## Classes
 
@@ -46,247 +46,253 @@ Memgraph in order to use them.
 
 |                | Name           |
 | -------------- | -------------- |
-| enum| **[mgp_value_type](#enum-mgp-value-type)** &#123;MGP_VALUE_TYPE_NULL, MGP_VALUE_TYPE_BOOL, MGP_VALUE_TYPE_INT, MGP_VALUE_TYPE_DOUBLE, MGP_VALUE_TYPE_STRING, MGP_VALUE_TYPE_LIST, MGP_VALUE_TYPE_MAP, MGP_VALUE_TYPE_VERTEX, MGP_VALUE_TYPE_EDGE, MGP_VALUE_TYPE_PATH, MGP_VALUE_TYPE_DATE, MGP_VALUE_TYPE_LOCAL_TIME, MGP_VALUE_TYPE_LOCAL_DATE_TIME, MGP_VALUE_TYPE_DURATION&#125;<br/>All available types that can be stored in a mgp_value.  |
-| typedef void(*)(struct mgp_list *, struct mgp_graph *, struct mgp_result *, struct mgp_memory *) | **[mgp_proc_cb](#typedef-mgp-proc-cb)** <br/>Entry-point for a query module read procedure, invoked through openCypher.  |
-| typedef void(*)(struct mgp_list *, struct mgp_graph *, struct mgp_memory *) | **[mgp_proc_initializer](#typedef-mgp-proc-initializer)** <br/>Initialization point for a query module read procedure, invoked before procedure.  |
-| typedef void(*)() | **[mgp_proc_cleanup](#typedef-mgp-proc-cleanup)** <br/>Cleanup for a query module read procedure  |
-| typedef void(*)(struct mgp_messages *, struct mgp_graph *, struct mgp_result *, struct mgp_memory *) | **[mgp_trans_cb](#typedef-mgp-trans-cb)** <br/>Entry-point for a module transformation, invoked through a stream transformation.  |
+| enum| **[mgp_value_type](#enum-mgp-value-type)** &#123;MGP_VALUE_TYPE_NULL, MGP_VALUE_TYPE_BOOL, MGP_VALUE_TYPE_INT, MGP_VALUE_TYPE_DOUBLE, MGP_VALUE_TYPE_STRING, MGP_VALUE_TYPE_LIST, MGP_VALUE_TYPE_MAP, MGP_VALUE_TYPE_VERTEX, MGP_VALUE_TYPE_EDGE, MGP_VALUE_TYPE_PATH, MGP_VALUE_TYPE_DATE, MGP_VALUE_TYPE_LOCAL_TIME, MGP_VALUE_TYPE_LOCAL_DATE_TIME, MGP_VALUE_TYPE_DURATION&#125;<br />All available types that can be stored in a mgp_value.  |
+| typedef void(*)(struct mgp_list *, struct mgp_graph *, struct mgp_result *, struct mgp_memory *) | **[mgp_proc_cb](#typedef-mgp-proc-cb)** <br />Entry-point for a query module read procedure, invoked through openCypher.  |
+| typedef void(*)(struct mgp_list *, struct mgp_graph *, struct mgp_memory *) | **[mgp_proc_initializer](#typedef-mgp-proc-initializer)** <br />Initialization point for a query module read procedure, invoked before procedure.  |
+| typedef void(*)() | **[mgp_proc_cleanup](#typedef-mgp-proc-cleanup)** <br />Cleanup for a query module read procedure  |
+| typedef void(*)(struct mgp_messages *, struct mgp_graph *, struct mgp_result *, struct mgp_memory *) | **[mgp_trans_cb](#typedef-mgp-trans-cb)** <br />Entry-point for a module transformation, invoked through a stream transformation.  |
 
 ## Functions
 
 |                | Name           |
 | -------------- | -------------- |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_alloc](#function-mgp-alloc)**(struct mgp_memory * memory, size_t size_in_bytes, void ** result)<br/>Allocate a block of memory with given size in bytes.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_aligned_alloc](#function-mgp-aligned-alloc)**(struct mgp_memory * memory, size_t size_in_bytes, size_t alignment, void ** result)<br/>Allocate an aligned block of memory with given size in bytes.  |
-| void | **[mgp_free](#function-mgp-free)**(struct mgp_memory * memory, void * ptr)<br/>Deallocate an allocation from mgp_alloc or mgp_aligned_alloc.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_global_alloc](#function-mgp-global-alloc)**(size_t size_in_bytes, void ** result)<br/>Allocate a global block of memory with given size in bytes.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_global_aligned_alloc](#function-mgp-global-aligned-alloc)**(size_t size_in_bytes, size_t alignment, void ** result)<br/>Allocate an aligned global block of memory with given size in bytes.  |
-| void | **[mgp_global_free](#function-mgp-global-free)**(void * p)<br/>Deallocate an allocation from mgp_global_alloc or mgp_global_aligned_alloc.  |
-| void | **[mgp_value_destroy](#function-mgp-value-destroy)**(struct mgp_value * val)<br/>Free the memory used by the given mgp_value instance.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_value_make_null](#function-mgp-value-make-null)**(struct mgp_memory * memory, struct mgp_value ** result)<br/>Construct a value representing `null` in openCypher.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_value_make_bool](#function-mgp-value-make-bool)**(int val, struct mgp_memory * memory, struct mgp_value ** result)<br/>Construct a boolean value.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_value_make_int](#function-mgp-value-make-int)**(int64_t val, struct mgp_memory * memory, struct mgp_value ** result)<br/>Construct an integer value.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_value_make_double](#function-mgp-value-make-double)**(double val, struct mgp_memory * memory, struct mgp_value ** result)<br/>Construct a double floating point value.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_value_make_string](#function-mgp-value-make-string)**(const char * val, struct mgp_memory * memory, struct mgp_value ** result)<br/>Construct a character string value from a NULL terminated string.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_value_make_list](#function-mgp-value-make-list)**(struct mgp_list * val, struct mgp_value ** result)<br/>Create a mgp_value storing a mgp_list.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_value_make_map](#function-mgp-value-make-map)**(struct mgp_map * val, struct mgp_value ** result)<br/>Create a mgp_value storing a mgp_map.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_value_make_vertex](#function-mgp-value-make-vertex)**(struct mgp_vertex * val, struct mgp_value ** result)<br/>Create a mgp_value storing a mgp_vertex.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_value_make_edge](#function-mgp-value-make-edge)**(struct mgp_edge * val, struct mgp_value ** result)<br/>Create a mgp_value storing a mgp_edge.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_value_make_path](#function-mgp-value-make-path)**(struct mgp_path * val, struct mgp_value ** result)<br/>Create a mgp_value storing a mgp_path.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_value_make_date](#function-mgp-value-make-date)**(struct mgp_date * val, struct mgp_value ** result)<br/>Create a mgp_value storing a mgp_date.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_value_make_local_time](#function-mgp-value-make-local-time)**(struct mgp_local_time * val, struct mgp_value ** result)<br/>Create a mgp_value storing a mgp_local_time.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_value_make_local_date_time](#function-mgp-value-make-local-date-time)**(struct mgp_local_date_time * val, struct mgp_value ** result)<br/>Create a mgp_value storing a mgp_local_date_time.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_value_make_duration](#function-mgp-value-make-duration)**(struct mgp_duration * val, struct mgp_value ** result)<br/>Create a mgp_value storing a mgp_duration.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_value_get_type](#function-mgp-value-get-type)**(struct mgp_value * val, enum [mgp_value_type](#enum-mgp-value-type) * result)<br/>Get the type of the value contained in mgp_value.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_value_is_null](#function-mgp-value-is-null)**(struct mgp_value * val, int * result)<br/>Result is non-zero if the given mgp_value represents `null`.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_value_is_bool](#function-mgp-value-is-bool)**(struct mgp_value * val, int * result)<br/>Result is non-zero if the given mgp_value stores a boolean.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_value_is_int](#function-mgp-value-is-int)**(struct mgp_value * val, int * result)<br/>Result is non-zero if the given mgp_value stores an integer.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_value_is_double](#function-mgp-value-is-double)**(struct mgp_value * val, int * result)<br/>Result is non-zero if the given mgp_value stores a double floating-point.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_value_is_string](#function-mgp-value-is-string)**(struct mgp_value * val, int * result)<br/>Result is non-zero if the given mgp_value stores a character string.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_value_is_list](#function-mgp-value-is-list)**(struct mgp_value * val, int * result)<br/>Result is non-zero if the given mgp_value stores a list of values.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_value_is_map](#function-mgp-value-is-map)**(struct mgp_value * val, int * result)<br/>Result is non-zero if the given mgp_value stores a map of values.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_value_is_vertex](#function-mgp-value-is-vertex)**(struct mgp_value * val, int * result)<br/>Result is non-zero if the given mgp_value stores a vertex.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_value_is_edge](#function-mgp-value-is-edge)**(struct mgp_value * val, int * result)<br/>Result is non-zero if the given mgp_value stores an edge.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_value_is_path](#function-mgp-value-is-path)**(struct mgp_value * val, int * result)<br/>Result is non-zero if the given mgp_value stores a path.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_value_is_date](#function-mgp-value-is-date)**(struct mgp_value * val, int * result)<br/>Result is non-zero if the given mgp_value stores a date.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_value_is_local_time](#function-mgp-value-is-local-time)**(struct mgp_value * val, int * result)<br/>Result is non-zero if the given mgp_value stores a local time.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_value_is_local_date_time](#function-mgp-value-is-local-date-time)**(struct mgp_value * val, int * result)<br/>Result is non-zero if the given mgp_value stores a local date-time.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_value_is_duration](#function-mgp-value-is-duration)**(struct mgp_value * val, int * result)<br/>Result is non-zero if the given mgp_value stores a duration.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_value_get_bool](#function-mgp-value-get-bool)**(struct mgp_value * val, int * result)<br/>Get the contained boolean value.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_value_get_int](#function-mgp-value-get-int)**(struct mgp_value * val, int64_t * result)<br/>Get the contained integer.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_value_get_double](#function-mgp-value-get-double)**(struct mgp_value * val, double * result)<br/>Get the contained double floating-point.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_value_get_string](#function-mgp-value-get-string)**(struct mgp_value * val, const char ** result)<br/>Get the contained character string.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_value_get_list](#function-mgp-value-get-list)**(struct mgp_value * val, struct mgp_list ** result)<br/>Get the contained list of values.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_value_get_map](#function-mgp-value-get-map)**(struct mgp_value * val, struct mgp_map ** result)<br/>Get the contained map of values.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_value_get_vertex](#function-mgp-value-get-vertex)**(struct mgp_value * val, struct mgp_vertex ** result)<br/>Get the contained vertex.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_value_get_edge](#function-mgp-value-get-edge)**(struct mgp_value * val, struct mgp_edge ** result)<br/>Get the contained edge.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_value_get_path](#function-mgp-value-get-path)**(struct mgp_value * val, struct mgp_path ** result)<br/>Get the contained path.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_value_get_date](#function-mgp-value-get-date)**(struct mgp_value * val, struct mgp_date ** result)<br/>Get the contained date.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_value_get_local_time](#function-mgp-value-get-local-time)**(struct mgp_value * val, struct mgp_local_time ** result)<br/>Get the contained local time.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_value_get_local_date_time](#function-mgp-value-get-local-date-time)**(struct mgp_value * val, struct mgp_local_date_time ** result)<br/>Get the contained local date-time.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_value_get_duration](#function-mgp-value-get-duration)**(struct mgp_value * val, struct mgp_duration ** result)<br/>Get the contained duration.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_list_make_empty](#function-mgp-list-make-empty)**(size_t capacity, struct mgp_memory * memory, struct mgp_list ** result)<br/>Create an empty list with given capacity.  |
-| void | **[mgp_list_destroy](#function-mgp-list-destroy)**(struct mgp_list * list)<br/>Free the memory used by the given mgp_list and contained elements.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_list_append](#function-mgp-list-append)**(struct mgp_list * list, struct mgp_value * val)<br/>Append a copy of mgp_value to mgp_list if capacity allows.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_list_append_extend](#function-mgp-list-append-extend)**(struct mgp_list * list, struct mgp_value * val)<br/>Append a copy of mgp_value to mgp_list increasing capacity if needed.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_list_size](#function-mgp-list-size)**(struct mgp_list * list, size_t * result)<br/>Get the number of elements stored in mgp_list.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_list_capacity](#function-mgp-list-capacity)**(struct mgp_list * list, size_t * result)<br/>Get the total number of elements for which there's already allocated memory in mgp_list.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_list_at](#function-mgp-list-at)**(struct mgp_list * list, size_t index, struct mgp_value ** result)<br/>Get the element in mgp_list at given position.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_map_make_empty](#function-mgp-map-make-empty)**(struct mgp_memory * memory, struct mgp_map ** result)<br/>Create an empty map of character strings to mgp_value instances.  |
-| void | **[mgp_map_destroy](#function-mgp-map-destroy)**(struct mgp_map * map)<br/>Free the memory used by the given mgp_map and contained items.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_map_insert](#function-mgp-map-insert)**(struct mgp_map * map, const char * key, struct mgp_value * value)<br/>Insert a new mapping from a NULL terminated character string to a value.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_map_update](#function-mgp-map-update)**(struct mgp_map * map, const char * key, struct mgp_value * value)<br/>Insert a new mapping from a NULL terminated character string to a value, replacing the old value if it exists.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_map_erase](#function-mgp-map-erase)**(struct mgp_map * map, const char * key)<br/>Erase a mapping by key.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_map_size](#function-mgp-map-size)**(struct mgp_map * map, size_t * result)<br/>Get the number of items stored in mgp_map.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_map_at](#function-mgp-map-at)**(struct mgp_map * map, const char * key, struct mgp_value ** result)<br/>Get the mapped mgp_value to the given character string.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_map_item_key](#function-mgp-map-item-key)**(struct mgp_map_item * item, const char ** result)<br/>Get the key of the mapped item.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_map_item_value](#function-mgp-map-item-value)**(struct mgp_map_item * item, struct mgp_value ** result)<br/>Get the value of the mapped item.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_map_iter_items](#function-mgp-map-iter-items)**(struct mgp_map * map, struct mgp_memory * memory, struct mgp_map_items_iterator ** result)<br/>Start iterating over items contained in the given map.  |
-| void | **[mgp_map_items_iterator_destroy](#function-mgp-map-items-iterator-destroy)**(struct mgp_map_items_iterator * it)<br/>Deallocate memory used by mgp_map_items_iterator.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_map_items_iterator_get](#function-mgp-map-items-iterator-get)**(struct mgp_map_items_iterator * it, struct mgp_map_item ** result)<br/>Get the current item pointed to by the iterator.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_map_items_iterator_next](#function-mgp-map-items-iterator-next)**(struct mgp_map_items_iterator * it, struct mgp_map_item ** result)<br/>Advance the iterator to the next item stored in map and return it.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_path_make_with_start](#function-mgp-path-make-with-start)**(struct mgp_vertex * vertex, struct mgp_memory * memory, struct mgp_path ** result)<br/>Create a path with the copy of the given starting vertex.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_path_copy](#function-mgp-path-copy)**(struct mgp_path * path, struct mgp_memory * memory, struct mgp_path ** result)<br/>Copy a mgp_path.  |
-| void | **[mgp_path_destroy](#function-mgp-path-destroy)**(struct mgp_path * path)<br/>Free the memory used by the given mgp_path and contained vertices and edges.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_path_expand](#function-mgp-path-expand)**(struct mgp_path * path, struct mgp_edge * edge)<br/>Append an edge continuing from the last vertex on the path.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_path_pop](#function-mgp-path-pop)**(struct mgp_path * path)<br/>Remove the last node and the last relationship from the path.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_path_size](#function-mgp-path-size)**(struct mgp_path * path, size_t * result)<br/>Get the number of edges in a mgp_path.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_path_vertex_at](#function-mgp-path-vertex-at)**(struct mgp_path * path, size_t index, struct mgp_vertex ** result)<br/>Get the vertex from a path at given index.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_path_edge_at](#function-mgp-path-edge-at)**(struct mgp_path * path, size_t index, struct mgp_edge ** result)<br/>Get the edge from a path at given index.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_path_equal](#function-mgp-path-equal)**(struct mgp_path * p1, struct mgp_path * p2, int * result)<br/>Result is non-zero if given paths are equal, otherwise 0.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_result_set_error_msg](#function-mgp-result-set-error-msg)**(struct mgp_result * res, const char * error_msg)<br/>Set the error as the result of the procedure.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_result_new_record](#function-mgp-result-new-record)**(struct mgp_result * res, struct mgp_result_record ** result)<br/>Create a new record for results.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_result_record_insert](#function-mgp-result-record-insert)**(struct mgp_result_record * record, const char * field_name, struct mgp_value * val)<br/>Assign a value to a field in the given record.  |
-| void | **[mgp_properties_iterator_destroy](#function-mgp-properties-iterator-destroy)**(struct mgp_properties_iterator * it)<br/>Free the memory used by a mgp_properties_iterator.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_properties_iterator_get](#function-mgp-properties-iterator-get)**(struct mgp_properties_iterator * it, struct [mgp_property](#mgp_property) ** result)<br/>Get the current property pointed to by the iterator.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_properties_iterator_next](#function-mgp-properties-iterator-next)**(struct mgp_properties_iterator * it, struct [mgp_property](#mgp_property) ** result)<br/>Advance the iterator to the next property and return it.  |
-| void | **[mgp_edges_iterator_destroy](#function-mgp-edges-iterator-destroy)**(struct mgp_edges_iterator * it)<br/>Free the memory used by a mgp_edges_iterator.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_vertex_get_id](#function-mgp-vertex-get-id)**(struct mgp_vertex * v, struct [mgp_vertex_id](#mgp_vertex_id) * result)<br/>Get the ID of given vertex.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_vertex_get_in_degree](#function-mgp-vertex-get-in-degree)**(struct mgp_vertex * v, size_t * result)<br/> Get the in degree of the given vertex.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_vertex_get_out_degree](#function-mgp-vertex-get-out-degree)**(struct mgp_vertex * v, size_t * result)<br/> Get the out degree of the given vertex.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_vertex_underlying_graph_is_mutable](#function-mgp-vertex-underlying-graph-is-mutable)**(struct mgp_vertex * v, int * result)<br/>Result is non-zero if the vertex can be modified.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_vertex_set_property](#function-mgp-vertex-set-property)**(struct mgp_vertex * v, const char * property_name, struct mgp_value * property_value)<br/>Set the value of a property on a vertex.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_vertex_set_properties](#function-mgp-vertex-set-properties)**(struct mgp_vertex *v, struct mgp_map *properties)<br/>Set the properties of the given vertex.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_vertex_add_label](#function-mgp-vertex-add-label)**(struct mgp_vertex * v, struct [mgp_label](#mgp_label) label)<br/>Add the label to the vertex.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_vertex_remove_label](#function-mgp-vertex-remove-label)**(struct mgp_vertex * v, struct [mgp_label](#mgp_label) label)<br/>Remove the label from the vertex.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_vertex_copy](#function-mgp-vertex-copy)**(struct mgp_vertex * v, struct mgp_memory * memory, struct mgp_vertex ** result)<br/>Copy a mgp_vertex.  |
-| void | **[mgp_vertex_destroy](#function-mgp-vertex-destroy)**(struct mgp_vertex * v)<br/>Free the memory used by a mgp_vertex.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_vertex_equal](#function-mgp-vertex-equal)**(struct mgp_vertex * v1, struct mgp_vertex * v2, int * result)<br/>Result is non-zero if given vertices are equal, otherwise 0.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_vertex_labels_count](#function-mgp-vertex-labels-count)**(struct mgp_vertex * v, size_t * result)<br/>Get the number of labels a given vertex has.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_vertex_label_at](#function-mgp-vertex-label-at)**(struct mgp_vertex * v, size_t index, struct [mgp_label](#mgp_label) * result)<br/>Get [mgp_label](#mgp_label) in mgp_vertex at given index.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_vertex_has_label](#function-mgp-vertex-has-label)**(struct mgp_vertex * v, struct [mgp_label](#mgp_label) label, int * result)<br/>Result is non-zero if the given vertex has the given label.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_vertex_has_label_named](#function-mgp-vertex-has-label-named)**(struct mgp_vertex * v, const char * label_name, int * result)<br/>Result is non-zero if the given vertex has a label with given name.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_vertex_get_property](#function-mgp-vertex-get-property)**(struct mgp_vertex * v, const char * property_name, struct mgp_memory * memory, struct mgp_value ** result)<br/>Get a copy of a vertex property mapped to a given name.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_vertex_iter_properties](#function-mgp-vertex-iter-properties)**(struct mgp_vertex * v, struct mgp_memory * memory, struct mgp_properties_iterator ** result)<br/>Start iterating over properties stored in the given vertex.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_vertex_iter_in_edges](#function-mgp-vertex-iter-in-edges)**(struct mgp_vertex * v, struct mgp_memory * memory, struct mgp_edges_iterator ** result)<br/>Start iterating over inbound edges of the given vertex.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_vertex_iter_out_edges](#function-mgp-vertex-iter-out-edges)**(struct mgp_vertex * v, struct mgp_memory * memory, struct mgp_edges_iterator ** result)<br/>Start iterating over outbound edges of the given vertex.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_edges_iterator_underlying_graph_is_mutable](#function-mgp-edges-iterator-underlying-graph-is-mutable)**(struct mgp_edges_iterator * it, int * result)<br/>Result is non-zero if the edges returned by this iterator can be modified.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_edges_iterator_get](#function-mgp-edges-iterator-get)**(struct mgp_edges_iterator * it, struct mgp_edge ** result)<br/>Get the current edge pointed to by the iterator.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_edges_iterator_next](#function-mgp-edges-iterator-next)**(struct mgp_edges_iterator * it, struct mgp_edge ** result)<br/>Advance the iterator to the next edge and return it.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_edge_get_id](#function-mgp-edge-get-id)**(struct mgp_edge * e, struct [mgp_edge_id](#mgp_edge_id) * result)<br/>Get the ID of given edge.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_edge_underlying_graph_is_mutable](#function-mgp-edge-underlying-graph-is-mutable)**(struct mgp_edge * e, int * result)<br/>Result is non-zero if the edge can be modified.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_edge_copy](#function-mgp-edge-copy)**(struct mgp_edge * e, struct mgp_memory * memory, struct mgp_edge ** result)<br/>Copy a mgp_edge.  |
-| void | **[mgp_edge_destroy](#function-mgp-edge-destroy)**(struct mgp_edge * e)<br/>Free the memory used by a mgp_edge.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_edge_equal](#function-mgp-edge-equal)**(struct mgp_edge * e1, struct mgp_edge * e2, int * result)<br/>Result is non-zero if given edges are equal, otherwise 0.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_edge_get_type](#function-mgp-edge-get-type)**(struct mgp_edge * e, struct [mgp_edge_type](#mgp_edge_type) * result)<br/>Get the type of the given edge.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_edge_get_from](#function-mgp-edge-get-from)**(struct mgp_edge * e, struct mgp_vertex ** result)<br/>Get the source vertex of the given edge.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_edge_get_to](#function-mgp-edge-get-to)**(struct mgp_edge * e, struct mgp_vertex ** result)<br/>Get the destination vertex of the given edge.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_edge_get_property](#function-mgp-edge-get-property)**(struct mgp_edge * e, const char * property_name, struct mgp_memory * memory, struct mgp_value ** result)<br/>Get a copy of a edge property mapped to a given name.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_edge_set_property](#function-mgp-edge-set-property)**(struct mgp_edge * e, const char * property_name, struct mgp_value * property_value)<br/>Set the value of a property on an edge.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_edge_set_properties](#function-mgp-edge-set-properties)**(struct mgp_edge *e, struct mgp_map *properties)<br/>Set the properties of the given edge.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_edge_iter_properties](#function-mgp-edge-iter-properties)**(struct mgp_edge * e, struct mgp_memory * memory, struct mgp_properties_iterator ** result)<br/>Start iterating over properties stored in the given edge.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_graph_get_vertex_by_id](#function-mgp-graph-get-vertex-by-id)**(struct mgp_graph * g, struct [mgp_vertex_id](#mgp_vertex_id) id, struct mgp_memory * memory, struct mgp_vertex ** result)<br/>Get the vertex corresponding to given ID, or NULL if no such vertex exists.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_graph_is_mutable](#function-mgp-graph-is-mutable)**(struct mgp_graph * graph, int * result)<br/>Result is non-zero if the graph can be modified.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_graph_create_vertex](#function-mgp-graph-create-vertex)**(struct mgp_graph * graph, struct mgp_memory * memory, struct mgp_vertex ** result)<br/>Add a new vertex to the graph.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_graph_delete_vertex](#function-mgp-graph-delete-vertex)**(struct mgp_graph * graph, struct mgp_vertex * vertex)<br/>Delete a vertex from the graph.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_graph_detach_delete_vertex](#function-mgp-graph-detach-delete-vertex)**(struct mgp_graph * graph, struct mgp_vertex * vertex)<br/>Delete a vertex and all of its edges from the graph.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_graph_create_edge](#function-mgp-graph-create-edge)**(struct mgp_graph * graph, struct mgp_vertex * from, struct mgp_vertex * to, struct [mgp_edge_type](#mgp_edge_type) type, struct mgp_memory * memory, struct mgp_edge ** result)<br/>Add a new directed edge between the two vertices with the specified label.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_graph_edge_set_from](#function-mgp-graph-edge-set-from)**(struct mgp_graph * graph, struct mgp_edge * e, struct mgp_vertex * new_from, struct mgp_memory * memory, struct mgp_edge ** result)<br/> Change edge from (start) vertex.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_graph_edge_set_to](#function-mgp-graph-edge-set-to)**(struct mgp_graph * graph, struct mgp_edge * e, struct mgp_vertex * new_to, struct mgp_memory * memory, struct mgp_edge ** result)<br/> Change edge to (end) vertex.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_graph_edge_change_type](#function-mgp-graph-edge-change-type)**(struct mgp_graph * graph, struct mgp_edge * e, struct mgp_edge_type new_type, struct mgp_memory * memory, struct mgp_edge ** result)<br/> Change edge type.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_graph_delete_edge](#function-mgp-graph-delete-edge)**(struct mgp_graph * graph, struct mgp_edge * edge)<br/>Delete an edge from the graph.  |
-| void | **[mgp_vertices_iterator_destroy](#function-mgp-vertices-iterator-destroy)**(struct mgp_vertices_iterator * it)<br/>Free the memory used by a mgp_vertices_iterator.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_graph_iter_vertices](#function-mgp-graph-iter-vertices)**(struct mgp_graph * g, struct mgp_memory * memory, struct mgp_vertices_iterator ** result)<br/>Start iterating over vertices of the given graph.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_vertices_iterator_underlying_graph_is_mutable](#function-mgp-vertices-iterator-underlying-graph-is-mutable)**(struct mgp_vertices_iterator * it, int * result)<br/>Result is non-zero if the vertices returned by this iterator can be modified.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_vertices_iterator_get](#function-mgp-vertices-iterator-get)**(struct mgp_vertices_iterator * it, struct mgp_vertex ** result)<br/>Get the current vertex pointed to by the iterator.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_date_from_string](#function-mgp-date-from-string)**(const char * string, struct mgp_memory * memory, struct mgp_date ** date)<br/>Create a date from a string following the ISO 8601 format.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_date_from_parameters](#function-mgp-date-from-parameters)**(struct [mgp_date_parameters](#mgp_date_parameters) * parameters, struct mgp_memory * memory, struct mgp_date ** date)<br/>Create a date from mgp_date_parameter.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_date_copy](#function-mgp-date-copy)**(struct mgp_date * date, struct mgp_memory * memory, struct mgp_date ** result)<br/>Copy a mgp_date.  |
-| void | **[mgp_date_destroy](#function-mgp-date-destroy)**(struct mgp_date * date)<br/>Free the memory used by a mgp_date.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_date_equal](#function-mgp-date-equal)**(struct mgp_date * first, struct mgp_date * second, int * result)<br/>Result is non-zero if given dates are equal, otherwise 0.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_date_get_year](#function-mgp-date-get-year)**(struct mgp_date * date, int * year)<br/>Get the year property of the date.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_date_get_month](#function-mgp-date-get-month)**(struct mgp_date * date, int * month)<br/>Get the month property of the date.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_date_get_day](#function-mgp-date-get-day)**(struct mgp_date * date, int * day)<br/>Get the day property of the date.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_date_timestamp](#function-mgp-date-timestamp)**(struct mgp_date * date, int64_t * timestamp)<br/>Get the date as microseconds from Unix epoch.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_date_now](#function-mgp-date-now)**(struct mgp_memory * memory, struct mgp_date ** date)<br/>Get the date representing current date.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_date_add_duration](#function-mgp-date-add-duration)**(struct mgp_date * date, struct mgp_duration * dur, struct mgp_memory * memory, struct mgp_date ** result)<br/>Add a duration to the date.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_date_sub_duration](#function-mgp-date-sub-duration)**(struct mgp_date * date, struct mgp_duration * dur, struct mgp_memory * memory, struct mgp_date ** result)<br/>Subtract a duration from the date.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_date_diff](#function-mgp-date-diff)**(struct mgp_date * first, struct mgp_date * second, struct mgp_memory * memory, struct mgp_duration ** result)<br/>Get a duration between two dates.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_local_time_from_string](#function-mgp-local-time-from-string)**(const char * string, struct mgp_memory * memory, struct mgp_local_time ** local_time)<br/>Create a local time from a string following the ISO 8601 format.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_local_time_from_parameters](#function-mgp-local-time-from-parameters)**(struct [mgp_local_time_parameters](#mgp_local_time_parameters) * parameters, struct mgp_memory * memory, struct mgp_local_time ** local_time)<br/>Create a local time from [mgp_local_time_parameters](#mgp_local_time_parameters).  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_local_time_copy](#function-mgp-local-time-copy)**(struct mgp_local_time * local_time, struct mgp_memory * memory, struct mgp_local_time ** result)<br/>Copy a mgp_local_time.  |
-| void | **[mgp_local_time_destroy](#function-mgp-local-time-destroy)**(struct mgp_local_time * local_time)<br/>Free the memory used by a mgp_local_time.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_local_time_equal](#function-mgp-local-time-equal)**(struct mgp_local_time * first, struct mgp_local_time * second, int * result)<br/>Result is non-zero if given local times are equal, otherwise 0.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_local_time_get_hour](#function-mgp-local-time-get-hour)**(struct mgp_local_time * local_time, int * hour)<br/>Get the hour property of the local time.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_local_time_get_minute](#function-mgp-local-time-get-minute)**(struct mgp_local_time * local_time, int * minute)<br/>Get the minute property of the local time.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_local_time_get_second](#function-mgp-local-time-get-second)**(struct mgp_local_time * local_time, int * second)<br/>Get the second property of the local time.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_local_time_get_millisecond](#function-mgp-local-time-get-millisecond)**(struct mgp_local_time * local_time, int * millisecond)<br/>Get the millisecond property of the local time.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_local_time_get_microsecond](#function-mgp-local-time-get-microsecond)**(struct mgp_local_time * local_time, int * microsecond)<br/>Get the microsecond property of the local time.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_local_time_timestamp](#function-mgp-local-time-timestamp)**(struct mgp_local_time * local_time, int64_t * timestamp)<br/>Get the local time as microseconds from midnight.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_local_time_now](#function-mgp-local-time-now)**(struct mgp_memory * memory, struct mgp_local_time ** local_time)<br/>Get the local time representing current time.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_local_time_add_duration](#function-mgp-local-time-add-duration)**(struct mgp_local_time * local_time, struct mgp_duration * dur, struct mgp_memory * memory, struct mgp_local_time ** result)<br/>Add a duration to the local time.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_local_time_sub_duration](#function-mgp-local-time-sub-duration)**(struct mgp_local_time * local_time, struct mgp_duration * dur, struct mgp_memory * memory, struct mgp_local_time ** result)<br/>Subtract a duration from the local time.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_local_time_diff](#function-mgp-local-time-diff)**(struct mgp_local_time * first, struct mgp_local_time * second, struct mgp_memory * memory, struct mgp_duration ** result)<br/>Get a duration between two local times.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_local_date_time_from_string](#function-mgp-local-date-time-from-string)**(const char * string, struct mgp_memory * memory, struct mgp_local_date_time ** local_date_time)<br/>Create a local date-time from a string following the ISO 8601 format.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_local_date_time_from_parameters](#function-mgp-local-date-time-from-parameters)**(struct [mgp_local_date_time_parameters](#mgp_local_date_time_parameters) * parameters, struct mgp_memory * memory, struct mgp_local_date_time ** local_date_time)<br/>Create a local date-time from [mgp_local_date_time_parameters](#mgp_local_date_time_parameters).  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_local_date_time_copy](#function-mgp-local-date-time-copy)**(struct mgp_local_date_time * local_date_time, struct mgp_memory * memory, struct mgp_local_date_time ** result)<br/>Copy a mgp_local_date_time.  |
-| void | **[mgp_local_date_time_destroy](#function-mgp-local-date-time-destroy)**(struct mgp_local_date_time * local_date_time)<br/>Free the memory used by a mgp_local_date_time.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_local_date_time_equal](#function-mgp-local-date-time-equal)**(struct mgp_local_date_time * first, struct mgp_local_date_time * second, int * result)<br/>Result is non-zero if given local date-times are equal, otherwise 0.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_local_date_time_get_year](#function-mgp-local-date-time-get-year)**(struct mgp_local_date_time * local_date_time, int * year)<br/>Get the year property of the local date-time.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_local_date_time_get_month](#function-mgp-local-date-time-get-month)**(struct mgp_local_date_time * local_date_time, int * month)<br/>Get the month property of the local date-time.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_local_date_time_get_day](#function-mgp-local-date-time-get-day)**(struct mgp_local_date_time * local_date_time, int * day)<br/>Get the day property of the local date-time.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_local_date_time_get_hour](#function-mgp-local-date-time-get-hour)**(struct mgp_local_date_time * local_date_time, int * hour)<br/>Get the hour property of the local date-time.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_local_date_time_get_minute](#function-mgp-local-date-time-get-minute)**(struct mgp_local_date_time * local_date_time, int * minute)<br/>Get the minute property of the local date-time.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_local_date_time_get_second](#function-mgp-local-date-time-get-second)**(struct mgp_local_date_time * local_date_time, int * second)<br/>Get the second property of the local date-time.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_local_date_time_get_millisecond](#function-mgp-local-date-time-get-millisecond)**(struct mgp_local_date_time * local_date_time, int * millisecond)<br/>Get the milisecond property of the local date-time.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_local_date_time_get_microsecond](#function-mgp-local-date-time-get-microsecond)**(struct mgp_local_date_time * local_date_time, int * microsecond)<br/>Get the microsecond property of the local date-time.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_local_date_time_timestamp](#function-mgp-local-date-time-timestamp)**(struct mgp_local_date_time * local_date_time, int64_t * timestamp)<br/>Get the local date-time as microseconds from Unix epoch.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_local_date_time_now](#function-mgp-local-date-time-now)**(struct mgp_memory * memory, struct mgp_local_date_time ** local_date_time)<br/>Get the local date-time representing current date and time.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_local_date_time_add_duration](#function-mgp-local-date-time-add-duration)**(struct mgp_local_date_time * local_date_time, struct mgp_duration * dur, struct mgp_memory * memory, struct mgp_local_date_time ** result)<br/>Add a duration to the local date-time.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_local_date_time_sub_duration](#function-mgp-local-date-time-sub-duration)**(struct mgp_local_date_time * local_date_time, struct mgp_duration * dur, struct mgp_memory * memory, struct mgp_local_date_time ** result)<br/>Subtract a duration from the local date-time.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_local_date_time_diff](#function-mgp-local-date-time-diff)**(struct mgp_local_date_time * first, struct mgp_local_date_time * second, struct mgp_memory * memory, struct mgp_duration ** result)<br/>Get a duration between two local date-times.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_duration_from_string](#function-mgp-duration-from-string)**(const char * string, struct mgp_memory * memory, struct mgp_duration ** duration)<br/>Create a duration from a string following the ISO 8601 format.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_duration_from_parameters](#function-mgp-duration-from-parameters)**(struct [mgp_duration_parameters](#mgp_duration_parameters) * parameters, struct mgp_memory * memory, struct mgp_duration ** duration)<br/>Create a duration from [mgp_duration_parameters](#mgp_duration_parameters).  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_duration_from_microseconds](#function-mgp-duration-from-microseconds)**(int64_t microseconds, struct mgp_memory * memory, struct mgp_duration ** duration)<br/>Create a duration from microseconds.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_duration_copy](#function-mgp-duration-copy)**(struct mgp_duration * duration, struct mgp_memory * memory, struct mgp_duration ** result)<br/>Copy a mgp_duration.  |
-| void | **[mgp_duration_destroy](#function-mgp-duration-destroy)**(struct mgp_duration * duration)<br/>Free the memory used by a mgp_duration.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_duration_equal](#function-mgp-duration-equal)**(struct mgp_duration * first, struct mgp_duration * second, int * result)<br/>Result is non-zero if given durations are equal, otherwise 0.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_duration_get_microseconds](#function-mgp-duration-get-microseconds)**(struct mgp_duration * duration, int64_t * microseconds)<br/>Get the duration as microseconds.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_duration_neg](#function-mgp-duration-neg)**(struct mgp_duration * dur, struct mgp_memory * memory, struct mgp_duration ** result)<br/>Apply unary minus operator to the duration.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_duration_add](#function-mgp-duration-add)**(struct mgp_duration * first, struct mgp_duration * second, struct mgp_memory * memory, struct mgp_duration ** result)<br/>Add two durations.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_duration_sub](#function-mgp-duration-sub)**(struct mgp_duration * first, struct mgp_duration * second, struct mgp_memory * memory, struct mgp_duration ** result)<br/>Subtract two durations.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_type_any](#function-mgp-type-any)**(struct mgp_type ** result)<br/>Get the type representing any value that isn't `null`.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_type_bool](#function-mgp-type-bool)**(struct mgp_type ** result)<br/>Get the type representing boolean values.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_type_string](#function-mgp-type-string)**(struct mgp_type ** result)<br/>Get the type representing character string values.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_type_int](#function-mgp-type-int)**(struct mgp_type ** result)<br/>Get the type representing integer values.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_type_float](#function-mgp-type-float)**(struct mgp_type ** result)<br/>Get the type representing floating-point values.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_type_number](#function-mgp-type-number)**(struct mgp_type ** result)<br/>Get the type representing any number value.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_type_map](#function-mgp-type-map)**(struct mgp_type ** result)<br/>Get the type representing map values.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_type_node](#function-mgp-type-node)**(struct mgp_type ** result)<br/>Get the type representing graph node values.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_type_relationship](#function-mgp-type-relationship)**(struct mgp_type ** result)<br/>Get the type representing graph relationship values.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_type_path](#function-mgp-type-path)**(struct mgp_type ** result)<br/>Get the type representing a graph path (walk) from one node to another.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_type_list](#function-mgp-type-list)**(struct mgp_type * element_type, struct mgp_type ** result)<br/>Build a type representing a list of values of given `element_type`.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_type_date](#function-mgp-type-date)**(struct mgp_type ** result)<br/>Get the type representing a date.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_type_local_time](#function-mgp-type-local-time)**(struct mgp_type ** result)<br/>Get the type representing a local time.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_type_local_date_time](#function-mgp-type-local-date-time)**(struct mgp_type ** result)<br/>Get the type representing a local date-time.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_type_duration](#function-mgp-type-duration)**(struct mgp_type ** result)<br/>Get the type representing a duration.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_type_nullable](#function-mgp-type-nullable)**(struct mgp_type * type, struct mgp_type ** result)<br/>Build a type representing either a `null` value or a value of given `type`.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_module_add_read_procedure](#function-mgp-module-add-read-procedure)**(struct mgp_module * module, const char * name, [mgp_proc_cb](#typedef-mgp-proc-cb) cb, struct mgp_proc ** result)<br/>Register a read-only procedure to a module.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_module_add_write_procedure](#function-mgp-module-add-write-procedure)**(struct mgp_module * module, const char * name, [mgp_proc_cb](#typedef-mgp-proc-cb) cb, struct mgp_proc ** result)<br/>Register a writeable procedure to a module.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_module_add_batch_read_procedure](#function-mgp-module-add-read-procedure)**(struct mgp_module * module, const char * name, [mgp_proc_cb](#typedef-mgp-proc-cb) cb, [mgp_proc_initializer](#typedef-mgp-proc-initializer) initializer, [mgp_proc_cleanup](#typedef-mgp-proc-cleanup) cleanup, struct mgp_proc ** result)<br/>Register a read-only procedure to a module.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_module_add_batch_write_procedure](#function-mgp-module-add-write-procedure)**(struct mgp_module * module, const char * name, [mgp_proc_cb](#typedef-mgp-proc-cb) cb, [mgp_proc_initializer](#typedef-mgp-proc-initializer) initializer, [mgp_proc_cleanup](#typedef-mgp-proc-cleanup) cleanup, struct mgp_proc ** result)<br/>Register a writeable procedure to a module.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_proc_add_arg](#function-mgp-proc-add-arg)**(struct mgp_proc * proc, const char * name, struct mgp_type * type)<br/>Add a required argument to a procedure.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_proc_add_opt_arg](#function-mgp-proc-add-opt-arg)**(struct mgp_proc * proc, const char * name, struct mgp_type * type, struct mgp_value * default_value)<br/>Add an optional argument with a default value to a procedure.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_proc_add_result](#function-mgp-proc-add-result)**(struct mgp_proc * proc, const char * name, struct mgp_type * type)<br/>Add a result field to a procedure.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_proc_add_deprecated_result](#function-mgp-proc-add-deprecated-result)**(struct mgp_proc * proc, const char * name, struct mgp_type * type)<br/>Add a result field to a procedure and mark it as deprecated.  |
-| int | **[mgp_must_abort](#function-mgp-must-abort)**(struct mgp_graph * graph)<br/>Return non-zero if the currently executing procedure should abort as soon as possible.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_message_payload](#function-mgp-message-payload)**(struct mgp_message * message, const char ** result)<br/>Payload is not null terminated and not a string but rather a byte array.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_message_payload_size](#function-mgp-message-payload-size)**(struct mgp_message * message, size_t * result)<br/>Get the payload size.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_message_topic_name](#function-mgp-message-topic-name)**(struct mgp_message * message, const char ** result)<br/>Get the name of topic.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_message_key](#function-mgp-message-key)**(struct mgp_message * message, const char ** result)<br/>Get the key of mgp_message as a byte array.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_message_key_size](#function-mgp-message-key-size)**(struct mgp_message * message, size_t * result)<br/>Get the key size of mgp_message.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_message_timestamp](#function-mgp-message-timestamp)**(struct mgp_message * message, int64_t * result)<br/>Get the timestamp of mgp_message as a byte array.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_messages_size](#function-mgp-messages-size)**(struct mgp_messages * message, size_t * result)<br/>Get the number of messages contained in the mgp_messages list Current implementation always returns without errors.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_messages_at](#function-mgp-messages-at)**(struct mgp_messages * message, size_t index, struct mgp_message ** result)<br/>Get the message from a messages list at given index.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_module_add_transformation](#function-mgp-module-add-transformation)**(struct mgp_module * module, const char * name, [mgp_trans_cb](#typedef-mgp-trans-cb) cb)<br/>Register a transformation with a module.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_vertices_iterator_next](#function-mgp-vertices-iterator-next)**(struct mgp_vertices_iterator * it, struct mgp_vertex ** result)<br/>Advance the iterator to the next vertex and return it.  |
-| enum [mgp_error](#variable-mgp-error)| **[mgp_log](#function-mgp-log)**(mgp_log_level log_level, const char *output)<br/>Log a message on a certain level. |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_alloc](#function-mgp-alloc)**(struct mgp_memory * memory, size_t size_in_bytes, void ** result)<br />Allocate a block of memory with given size in bytes.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_aligned_alloc](#function-mgp-aligned-alloc)**(struct mgp_memory * memory, size_t size_in_bytes, size_t alignment, void ** result)<br />Allocate an aligned block of memory with given size in bytes.  |
+| void | **[mgp_free](#function-mgp-free)**(struct mgp_memory * memory, void * ptr)<br />Deallocate an allocation from mgp_alloc or mgp_aligned_alloc.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_global_alloc](#function-mgp-global-alloc)**(size_t size_in_bytes, void ** result)<br />Allocate a global block of memory with given size in bytes.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_global_aligned_alloc](#function-mgp-global-aligned-alloc)**(size_t size_in_bytes, size_t alignment, void ** result)<br />Allocate an aligned global block of memory with given size in bytes.  |
+| void | **[mgp_global_free](#function-mgp-global-free)**(void * p)<br />Deallocate an allocation from mgp_global_alloc or mgp_global_aligned_alloc.  |
+| void | **[mgp_value_destroy](#function-mgp-value-destroy)**(struct mgp_value * val)<br />Free the memory used by the given mgp_value instance.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_value_make_null](#function-mgp-value-make-null)**(struct mgp_memory * memory, struct mgp_value ** result)<br />Construct a value representing `null` in openCypher.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_value_make_bool](#function-mgp-value-make-bool)**(int val, struct mgp_memory * memory, struct mgp_value ** result)<br />Construct a boolean value.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_value_make_int](#function-mgp-value-make-int)**(int64_t val, struct mgp_memory * memory, struct mgp_value ** result)<br />Construct an integer value.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_value_make_double](#function-mgp-value-make-double)**(double val, struct mgp_memory * memory, struct mgp_value ** result)<br />Construct a double floating point value.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_value_make_string](#function-mgp-value-make-string)**(const char * val, struct mgp_memory * memory, struct mgp_value ** result)<br />Construct a character string value from a NULL terminated string.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_value_make_list](#function-mgp-value-make-list)**(struct mgp_list * val, struct mgp_value ** result)<br />Create a mgp_value storing a mgp_list.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_value_make_map](#function-mgp-value-make-map)**(struct mgp_map * val, struct mgp_value ** result)<br />Create a mgp_value storing a mgp_map.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_value_make_vertex](#function-mgp-value-make-vertex)**(struct mgp_vertex * val, struct mgp_value ** result)<br />Create a mgp_value storing a mgp_vertex.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_value_make_edge](#function-mgp-value-make-edge)**(struct mgp_edge * val, struct mgp_value ** result)<br />Create a mgp_value storing a mgp_edge.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_value_make_path](#function-mgp-value-make-path)**(struct mgp_path * val, struct mgp_value ** result)<br />Create a mgp_value storing a mgp_path.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_value_make_date](#function-mgp-value-make-date)**(struct mgp_date * val, struct mgp_value ** result)<br />Create a mgp_value storing a mgp_date.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_value_make_local_time](#function-mgp-value-make-local-time)**(struct mgp_local_time * val, struct mgp_value ** result)<br />Create a mgp_value storing a mgp_local_time.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_value_make_local_date_time](#function-mgp-value-make-local-date-time)**(struct mgp_local_date_time * val, struct mgp_value ** result)<br />Create a mgp_value storing a mgp_local_date_time.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_value_make_duration](#function-mgp-value-make-duration)**(struct mgp_duration * val, struct mgp_value ** result)<br />Create a mgp_value storing a mgp_duration.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_value_get_type](#function-mgp-value-get-type)**(struct mgp_value * val, enum [mgp_value_type](#enum-mgp-value-type) * result)<br />Get the type of the value contained in mgp_value.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_value_is_null](#function-mgp-value-is-null)**(struct mgp_value * val, int * result)<br />Result is non-zero if the given mgp_value represents `null`.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_value_is_bool](#function-mgp-value-is-bool)**(struct mgp_value * val, int * result)<br />Result is non-zero if the given mgp_value stores a boolean.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_value_is_int](#function-mgp-value-is-int)**(struct mgp_value * val, int * result)<br />Result is non-zero if the given mgp_value stores an integer.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_value_is_double](#function-mgp-value-is-double)**(struct mgp_value * val, int * result)<br />Result is non-zero if the given mgp_value stores a double floating-point.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_value_is_string](#function-mgp-value-is-string)**(struct mgp_value * val, int * result)<br />Result is non-zero if the given mgp_value stores a character string.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_value_is_list](#function-mgp-value-is-list)**(struct mgp_value * val, int * result)<br />Result is non-zero if the given mgp_value stores a list of values.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_value_is_map](#function-mgp-value-is-map)**(struct mgp_value * val, int * result)<br />Result is non-zero if the given mgp_value stores a map of values.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_value_is_vertex](#function-mgp-value-is-vertex)**(struct mgp_value * val, int * result)<br />Result is non-zero if the given mgp_value stores a vertex.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_value_is_edge](#function-mgp-value-is-edge)**(struct mgp_value * val, int * result)<br />Result is non-zero if the given mgp_value stores an edge.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_value_is_path](#function-mgp-value-is-path)**(struct mgp_value * val, int * result)<br />Result is non-zero if the given mgp_value stores a path.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_value_is_date](#function-mgp-value-is-date)**(struct mgp_value * val, int * result)<br />Result is non-zero if the given mgp_value stores a date.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_value_is_local_time](#function-mgp-value-is-local-time)**(struct mgp_value * val, int * result)<br />Result is non-zero if the given mgp_value stores a local time.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_value_is_local_date_time](#function-mgp-value-is-local-date-time)**(struct mgp_value * val, int * result)<br />Result is non-zero if the given mgp_value stores a local date-time.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_value_is_duration](#function-mgp-value-is-duration)**(struct mgp_value * val, int * result)<br />Result is non-zero if the given mgp_value stores a duration.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_value_get_bool](#function-mgp-value-get-bool)**(struct mgp_value * val, int * result)<br />Get the contained boolean value.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_value_get_int](#function-mgp-value-get-int)**(struct mgp_value * val, int64_t * result)<br />Get the contained integer.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_value_get_double](#function-mgp-value-get-double)**(struct mgp_value * val, double * result)<br />Get the contained double floating-point.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_value_get_string](#function-mgp-value-get-string)**(struct mgp_value * val, const char ** result)<br />Get the contained character string.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_value_get_list](#function-mgp-value-get-list)**(struct mgp_value * val, struct mgp_list ** result)<br />Get the contained list of values.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_value_get_map](#function-mgp-value-get-map)**(struct mgp_value * val, struct mgp_map ** result)<br />Get the contained map of values.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_value_get_vertex](#function-mgp-value-get-vertex)**(struct mgp_value * val, struct mgp_vertex ** result)<br />Get the contained vertex.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_value_get_edge](#function-mgp-value-get-edge)**(struct mgp_value * val, struct mgp_edge ** result)<br />Get the contained edge.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_value_get_path](#function-mgp-value-get-path)**(struct mgp_value * val, struct mgp_path ** result)<br />Get the contained path.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_value_get_date](#function-mgp-value-get-date)**(struct mgp_value * val, struct mgp_date ** result)<br />Get the contained date.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_value_get_local_time](#function-mgp-value-get-local-time)**(struct mgp_value * val, struct mgp_local_time ** result)<br />Get the contained local time.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_value_get_local_date_time](#function-mgp-value-get-local-date-time)**(struct mgp_value * val, struct mgp_local_date_time ** result)<br />Get the contained local date-time.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_value_get_duration](#function-mgp-value-get-duration)**(struct mgp_value * val, struct mgp_duration ** result)<br />Get the contained duration.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_list_make_empty](#function-mgp-list-make-empty)**(size_t capacity, struct mgp_memory * memory, struct mgp_list ** result)<br />Create an empty list with given capacity.  |
+| void | **[mgp_list_destroy](#function-mgp-list-destroy)**(struct mgp_list * list)<br />Free the memory used by the given mgp_list and contained elements.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_list_contains_deleted](#function-mgp-list-contains-deleted)**(struct mgp_list * list, int * result)<br />Result is non-zero if the given list contains any deleted values, otherwise 0.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_list_append](#function-mgp-list-append)**(struct mgp_list * list, struct mgp_value * val)<br />Append a copy of mgp_value to mgp_list if capacity allows.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_list_append_extend](#function-mgp-list-append-extend)**(struct mgp_list * list, struct mgp_value * val)<br />Append a copy of mgp_value to mgp_list increasing capacity if needed.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_list_size](#function-mgp-list-size)**(struct mgp_list * list, size_t * result)<br />Get the number of elements stored in mgp_list.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_list_capacity](#function-mgp-list-capacity)**(struct mgp_list * list, size_t * result)<br />Get the total number of elements for which there's already allocated memory in mgp_list.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_list_at](#function-mgp-list-at)**(struct mgp_list * list, size_t index, struct mgp_value ** result)<br />Get the element in mgp_list at given position.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_map_make_empty](#function-mgp-map-make-empty)**(struct mgp_memory * memory, struct mgp_map ** result)<br />Create an empty map of character strings to mgp_value instances.  |
+| void | **[mgp_map_destroy](#function-mgp-map-destroy)**(struct mgp_map * map)<br />Free the memory used by the given mgp_map and contained items.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_map_contains_deleted](#function-mgp-map-contains-deleted)**(struct mgp_map * map, int * result)<br />Result is non-zero if the given map contains any deleted values, otherwise 0.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_map_insert](#function-mgp-map-insert)**(struct mgp_map * map, const char * key, struct mgp_value * value)<br />Insert a new mapping from a NULL terminated character string to a value.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_map_update](#function-mgp-map-update)**(struct mgp_map * map, const char * key, struct mgp_value * value)<br />Insert a new mapping from a NULL terminated character string to a value, replacing the old value if it exists.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_map_erase](#function-mgp-map-erase)**(struct mgp_map * map, const char * key)<br />Erase a mapping by key.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_map_size](#function-mgp-map-size)**(struct mgp_map * map, size_t * result)<br />Get the number of items stored in mgp_map.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_map_at](#function-mgp-map-at)**(struct mgp_map * map, const char * key, struct mgp_value ** result)<br />Get the mapped mgp_value to the given character string.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_map_item_key](#function-mgp-map-item-key)**(struct mgp_map_item * item, const char ** result)<br />Get the key of the mapped item.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_map_item_value](#function-mgp-map-item-value)**(struct mgp_map_item * item, struct mgp_value ** result)<br />Get the value of the mapped item.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_map_iter_items](#function-mgp-map-iter-items)**(struct mgp_map * map, struct mgp_memory * memory, struct mgp_map_items_iterator ** result)<br />Start iterating over items contained in the given map.  |
+| void | **[mgp_map_items_iterator_destroy](#function-mgp-map-items-iterator-destroy)**(struct mgp_map_items_iterator * it)<br />Deallocate memory used by mgp_map_items_iterator.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_map_items_iterator_get](#function-mgp-map-items-iterator-get)**(struct mgp_map_items_iterator * it, struct mgp_map_item ** result)<br />Get the current item pointed to by the iterator.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_map_items_iterator_next](#function-mgp-map-items-iterator-next)**(struct mgp_map_items_iterator * it, struct mgp_map_item ** result)<br />Advance the iterator to the next item stored in map and return it.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_path_make_with_start](#function-mgp-path-make-with-start)**(struct mgp_vertex * vertex, struct mgp_memory * memory, struct mgp_path ** result)<br />Create a path with the copy of the given starting vertex.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_path_copy](#function-mgp-path-copy)**(struct mgp_path * path, struct mgp_memory * memory, struct mgp_path ** result)<br />Copy a mgp_path.  |
+| void | **[mgp_path_destroy](#function-mgp-path-destroy)**(struct mgp_path * path)<br />Free the memory used by the given mgp_path and contained vertices and edges.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_path_contains_deleted](#function-mgp-path-contains-deleted)**(struct mgp_path * path, int * result)<br />Result is non-zero if the given path contains any deleted vertices or edges, otherwise 0.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_path_expand](#function-mgp-path-expand)**(struct mgp_path * path, struct mgp_edge * edge)<br />Append an edge continuing from the last vertex on the path.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_path_pop](#function-mgp-path-pop)**(struct mgp_path * path)<br />Remove the last node and the last relationship from the path.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_path_size](#function-mgp-path-size)**(struct mgp_path * path, size_t * result)<br />Get the number of edges in a mgp_path.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_path_vertex_at](#function-mgp-path-vertex-at)**(struct mgp_path * path, size_t index, struct mgp_vertex ** result)<br />Get the vertex from a path at given index.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_path_edge_at](#function-mgp-path-edge-at)**(struct mgp_path * path, size_t index, struct mgp_edge ** result)<br />Get the edge from a path at given index.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_path_equal](#function-mgp-path-equal)**(struct mgp_path * p1, struct mgp_path * p2, int * result)<br />Result is non-zero if given paths are equal, otherwise 0.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_result_set_error_msg](#function-mgp-result-set-error-msg)**(struct mgp_result * res, const char * error_msg)<br />Set the error as the result of the procedure.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_result_new_record](#function-mgp-result-new-record)**(struct mgp_result * res, struct mgp_result_record ** result)<br />Create a new record for results.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_result_record_insert](#function-mgp-result-record-insert)**(struct mgp_result_record * record, const char * field_name, struct mgp_value * val)<br />Assign a value to a field in the given record.  |
+| void | **[mgp_properties_iterator_destroy](#function-mgp-properties-iterator-destroy)**(struct mgp_properties_iterator * it)<br />Free the memory used by a mgp_properties_iterator.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_properties_iterator_get](#function-mgp-properties-iterator-get)**(struct mgp_properties_iterator * it, struct [mgp_property](#mgp_property) ** result)<br />Get the current property pointed to by the iterator.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_properties_iterator_next](#function-mgp-properties-iterator-next)**(struct mgp_properties_iterator * it, struct [mgp_property](#mgp_property) ** result)<br />Advance the iterator to the next property and return it.  |
+| void | **[mgp_edges_iterator_destroy](#function-mgp-edges-iterator-destroy)**(struct mgp_edges_iterator * it)<br />Free the memory used by a mgp_edges_iterator.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_vertex_get_id](#function-mgp-vertex-get-id)**(struct mgp_vertex * v, struct [mgp_vertex_id](#mgp_vertex_id) * result)<br />Get the ID of given vertex.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_vertex_get_in_degree](#function-mgp-vertex-get-in-degree)**(struct mgp_vertex * v, size_t * result)<br /> Get the in degree of the given vertex.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_vertex_get_out_degree](#function-mgp-vertex-get-out-degree)**(struct mgp_vertex * v, size_t * result)<br /> Get the out degree of the given vertex.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_vertex_underlying_graph_is_mutable](#function-mgp-vertex-underlying-graph-is-mutable)**(struct mgp_vertex * v, int * result)<br />Result is non-zero if the vertex can be modified.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_vertex_set_property](#function-mgp-vertex-set-property)**(struct mgp_vertex * v, const char * property_name, struct mgp_value * property_value)<br />Set the value of a property on a vertex.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_vertex_set_properties](#function-mgp-vertex-set-properties)**(struct mgp_vertex *v, struct mgp_map *properties)<br />Set the properties of the given vertex.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_vertex_add_label](#function-mgp-vertex-add-label)**(struct mgp_vertex * v, struct [mgp_label](#mgp_label) label)<br />Add the label to the vertex.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_vertex_remove_label](#function-mgp-vertex-remove-label)**(struct mgp_vertex * v, struct [mgp_label](#mgp_label) label)<br />Remove the label from the vertex.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_vertex_copy](#function-mgp-vertex-copy)**(struct mgp_vertex * v, struct mgp_memory * memory, struct mgp_vertex ** result)<br />Copy a mgp_vertex.  |
+| void | **[mgp_vertex_destroy](#function-mgp-vertex-destroy)**(struct mgp_vertex * v)<br />Free the memory used by a mgp_vertex.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_vertex_equal](#function-mgp-vertex-equal)**(struct mgp_vertex * v1, struct mgp_vertex * v2, int * result)<br />Result is non-zero if given vertices are equal, otherwise 0.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_vertex_is_deleted](#function-mgp-vertex-is-deleted)**(struct mgp_vertex *v, int *result)<br />Result is non-zero if the given vertex is deleted, otherwise 0.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_vertex_labels_count](#function-mgp-vertex-labels-count)**(struct mgp_vertex * v, size_t * result)<br />Get the number of labels a given vertex has.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_vertex_label_at](#function-mgp-vertex-label-at)**(struct mgp_vertex * v, size_t index, struct [mgp_label](#mgp_label) * result)<br />Get [mgp_label](#mgp_label) in mgp_vertex at given index.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_vertex_has_label](#function-mgp-vertex-has-label)**(struct mgp_vertex * v, struct [mgp_label](#mgp_label) label, int * result)<br />Result is non-zero if the given vertex has the given label.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_vertex_has_label_named](#function-mgp-vertex-has-label-named)**(struct mgp_vertex * v, const char * label_name, int * result)<br />Result is non-zero if the given vertex has a label with given name.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_vertex_get_property](#function-mgp-vertex-get-property)**(struct mgp_vertex * v, const char * property_name, struct mgp_memory * memory, struct mgp_value ** result)<br />Get a copy of a vertex property mapped to a given name.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_vertex_iter_properties](#function-mgp-vertex-iter-properties)**(struct mgp_vertex * v, struct mgp_memory * memory, struct mgp_properties_iterator ** result)<br />Start iterating over properties stored in the given vertex.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_vertex_iter_in_edges](#function-mgp-vertex-iter-in-edges)**(struct mgp_vertex * v, struct mgp_memory * memory, struct mgp_edges_iterator ** result)<br />Start iterating over inbound edges of the given vertex.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_vertex_iter_out_edges](#function-mgp-vertex-iter-out-edges)**(struct mgp_vertex * v, struct mgp_memory * memory, struct mgp_edges_iterator ** result)<br />Start iterating over outbound edges of the given vertex.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_edges_iterator_underlying_graph_is_mutable](#function-mgp-edges-iterator-underlying-graph-is-mutable)**(struct mgp_edges_iterator * it, int * result)<br />Result is non-zero if the edges returned by this iterator can be modified.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_edges_iterator_get](#function-mgp-edges-iterator-get)**(struct mgp_edges_iterator * it, struct mgp_edge ** result)<br />Get the current edge pointed to by the iterator.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_edges_iterator_next](#function-mgp-edges-iterator-next)**(struct mgp_edges_iterator * it, struct mgp_edge ** result)<br />Advance the iterator to the next edge and return it.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_edge_get_id](#function-mgp-edge-get-id)**(struct mgp_edge * e, struct [mgp_edge_id](#mgp_edge_id) * result)<br />Get the ID of given edge.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_edge_underlying_graph_is_mutable](#function-mgp-edge-underlying-graph-is-mutable)**(struct mgp_edge * e, int * result)<br />Result is non-zero if the edge can be modified.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_edge_copy](#function-mgp-edge-copy)**(struct mgp_edge * e, struct mgp_memory * memory, struct mgp_edge ** result)<br />Copy a mgp_edge.  |
+| void | **[mgp_edge_destroy](#function-mgp-edge-destroy)**(struct mgp_edge * e)<br />Free the memory used by a mgp_edge.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_edge_is_deleted](#function-mgp-edge-is-deleted)**(struct mgp_edge *e, int *result)<br />Result is non-zero if the given edge is deleted, otherwise 0.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_edge_equal](#function-mgp-edge-equal)**(struct mgp_edge * e1, struct mgp_edge * e2, int * result)<br />Result is non-zero if given edges are equal, otherwise 0.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_edge_get_type](#function-mgp-edge-get-type)**(struct mgp_edge * e, struct [mgp_edge_type](#mgp_edge_type) * result)<br />Get the type of the given edge.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_edge_get_from](#function-mgp-edge-get-from)**(struct mgp_edge * e, struct mgp_vertex ** result)<br />Get the source vertex of the given edge.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_edge_get_to](#function-mgp-edge-get-to)**(struct mgp_edge * e, struct mgp_vertex ** result)<br />Get the destination vertex of the given edge.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_edge_get_property](#function-mgp-edge-get-property)**(struct mgp_edge * e, const char * property_name, struct mgp_memory * memory, struct mgp_value ** result)<br />Get a copy of a edge property mapped to a given name.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_edge_set_property](#function-mgp-edge-set-property)**(struct mgp_edge * e, const char * property_name, struct mgp_value * property_value)<br />Set the value of a property on an edge.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_edge_set_properties](#function-mgp-edge-set-properties)**(struct mgp_edge *e, struct mgp_map *properties)<br />Set the properties of the given edge.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_edge_iter_properties](#function-mgp-edge-iter-properties)**(struct mgp_edge * e, struct mgp_memory * memory, struct mgp_properties_iterator ** result)<br />Start iterating over properties stored in the given edge.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_graph_get_vertex_by_id](#function-mgp-graph-get-vertex-by-id)**(struct mgp_graph * g, struct [mgp_vertex_id](#mgp_vertex_id) id, struct mgp_memory * memory, struct mgp_vertex ** result)<br />Get the vertex corresponding to given ID, or NULL if no such vertex exists.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_graph_is_transactional](#function-mgp-graph-is-transactional)**(struct mgp_graph * graph, int * result)<br />Result is non-zero if the graph is in transactional storage mode.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_graph_is_mutable](#function-mgp-graph-is-mutable)**(struct mgp_graph * graph, int * result)<br />Result is non-zero if the graph can be modified.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_graph_create_vertex](#function-mgp-graph-create-vertex)**(struct mgp_graph * graph, struct mgp_memory * memory, struct mgp_vertex ** result)<br />Add a new vertex to the graph.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_graph_delete_vertex](#function-mgp-graph-delete-vertex)**(struct mgp_graph * graph, struct mgp_vertex * vertex)<br />Delete a vertex from the graph.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_graph_detach_delete_vertex](#function-mgp-graph-detach-delete-vertex)**(struct mgp_graph * graph, struct mgp_vertex * vertex)<br />Delete a vertex and all of its edges from the graph.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_graph_create_edge](#function-mgp-graph-create-edge)**(struct mgp_graph * graph, struct mgp_vertex * from, struct mgp_vertex * to, struct [mgp_edge_type](#mgp_edge_type) type, struct mgp_memory * memory, struct mgp_edge ** result)<br />Add a new directed edge between the two vertices with the specified label.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_graph_edge_set_from](#function-mgp-graph-edge-set-from)**(struct mgp_graph * graph, struct mgp_edge * e, struct mgp_vertex * new_from, struct mgp_memory * memory, struct mgp_edge ** result)<br /> Change edge from (start) vertex.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_graph_edge_set_to](#function-mgp-graph-edge-set-to)**(struct mgp_graph * graph, struct mgp_edge * e, struct mgp_vertex * new_to, struct mgp_memory * memory, struct mgp_edge ** result)<br /> Change edge to (end) vertex.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_graph_edge_change_type](#function-mgp-graph-edge-change-type)**(struct mgp_graph * graph, struct mgp_edge * e, struct mgp_edge_type new_type, struct mgp_memory * memory, struct mgp_edge ** result)<br /> Change edge type.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_graph_delete_edge](#function-mgp-graph-delete-edge)**(struct mgp_graph * graph, struct mgp_edge * edge)<br />Delete an edge from the graph.  |
+| void | **[mgp_vertices_iterator_destroy](#function-mgp-vertices-iterator-destroy)**(struct mgp_vertices_iterator * it)<br />Free the memory used by a mgp_vertices_iterator.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_graph_iter_vertices](#function-mgp-graph-iter-vertices)**(struct mgp_graph * g, struct mgp_memory * memory, struct mgp_vertices_iterator ** result)<br />Start iterating over vertices of the given graph.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_vertices_iterator_underlying_graph_is_mutable](#function-mgp-vertices-iterator-underlying-graph-is-mutable)**(struct mgp_vertices_iterator * it, int * result)<br />Result is non-zero if the vertices returned by this iterator can be modified.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_vertices_iterator_get](#function-mgp-vertices-iterator-get)**(struct mgp_vertices_iterator * it, struct mgp_vertex ** result)<br />Get the current vertex pointed to by the iterator.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_date_from_string](#function-mgp-date-from-string)**(const char * string, struct mgp_memory * memory, struct mgp_date ** date)<br />Create a date from a string following the ISO 8601 format.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_date_from_parameters](#function-mgp-date-from-parameters)**(struct [mgp_date_parameters](#mgp_date_parameters) * parameters, struct mgp_memory * memory, struct mgp_date ** date)<br />Create a date from mgp_date_parameter.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_date_copy](#function-mgp-date-copy)**(struct mgp_date * date, struct mgp_memory * memory, struct mgp_date ** result)<br />Copy a mgp_date.  |
+| void | **[mgp_date_destroy](#function-mgp-date-destroy)**(struct mgp_date * date)<br />Free the memory used by a mgp_date.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_date_equal](#function-mgp-date-equal)**(struct mgp_date * first, struct mgp_date * second, int * result)<br />Result is non-zero if given dates are equal, otherwise 0.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_date_get_year](#function-mgp-date-get-year)**(struct mgp_date * date, int * year)<br />Get the year property of the date.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_date_get_month](#function-mgp-date-get-month)**(struct mgp_date * date, int * month)<br />Get the month property of the date.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_date_get_day](#function-mgp-date-get-day)**(struct mgp_date * date, int * day)<br />Get the day property of the date.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_date_timestamp](#function-mgp-date-timestamp)**(struct mgp_date * date, int64_t * timestamp)<br />Get the date as microseconds from Unix epoch.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_date_now](#function-mgp-date-now)**(struct mgp_memory * memory, struct mgp_date ** date)<br />Get the date representing current date.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_date_add_duration](#function-mgp-date-add-duration)**(struct mgp_date * date, struct mgp_duration * dur, struct mgp_memory * memory, struct mgp_date ** result)<br />Add a duration to the date.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_date_sub_duration](#function-mgp-date-sub-duration)**(struct mgp_date * date, struct mgp_duration * dur, struct mgp_memory * memory, struct mgp_date ** result)<br />Subtract a duration from the date.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_date_diff](#function-mgp-date-diff)**(struct mgp_date * first, struct mgp_date * second, struct mgp_memory * memory, struct mgp_duration ** result)<br />Get a duration between two dates.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_local_time_from_string](#function-mgp-local-time-from-string)**(const char * string, struct mgp_memory * memory, struct mgp_local_time ** local_time)<br />Create a local time from a string following the ISO 8601 format.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_local_time_from_parameters](#function-mgp-local-time-from-parameters)**(struct [mgp_local_time_parameters](#mgp_local_time_parameters) * parameters, struct mgp_memory * memory, struct mgp_local_time ** local_time)<br />Create a local time from [mgp_local_time_parameters](#mgp_local_time_parameters).  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_local_time_copy](#function-mgp-local-time-copy)**(struct mgp_local_time * local_time, struct mgp_memory * memory, struct mgp_local_time ** result)<br />Copy a mgp_local_time.  |
+| void | **[mgp_local_time_destroy](#function-mgp-local-time-destroy)**(struct mgp_local_time * local_time)<br />Free the memory used by a mgp_local_time.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_local_time_equal](#function-mgp-local-time-equal)**(struct mgp_local_time * first, struct mgp_local_time * second, int * result)<br />Result is non-zero if given local times are equal, otherwise 0.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_local_time_get_hour](#function-mgp-local-time-get-hour)**(struct mgp_local_time * local_time, int * hour)<br />Get the hour property of the local time.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_local_time_get_minute](#function-mgp-local-time-get-minute)**(struct mgp_local_time * local_time, int * minute)<br />Get the minute property of the local time.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_local_time_get_second](#function-mgp-local-time-get-second)**(struct mgp_local_time * local_time, int * second)<br />Get the second property of the local time.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_local_time_get_millisecond](#function-mgp-local-time-get-millisecond)**(struct mgp_local_time * local_time, int * millisecond)<br />Get the millisecond property of the local time.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_local_time_get_microsecond](#function-mgp-local-time-get-microsecond)**(struct mgp_local_time * local_time, int * microsecond)<br />Get the microsecond property of the local time.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_local_time_timestamp](#function-mgp-local-time-timestamp)**(struct mgp_local_time * local_time, int64_t * timestamp)<br />Get the local time as microseconds from midnight.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_local_time_now](#function-mgp-local-time-now)**(struct mgp_memory * memory, struct mgp_local_time ** local_time)<br />Get the local time representing current time.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_local_time_add_duration](#function-mgp-local-time-add-duration)**(struct mgp_local_time * local_time, struct mgp_duration * dur, struct mgp_memory * memory, struct mgp_local_time ** result)<br />Add a duration to the local time.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_local_time_sub_duration](#function-mgp-local-time-sub-duration)**(struct mgp_local_time * local_time, struct mgp_duration * dur, struct mgp_memory * memory, struct mgp_local_time ** result)<br />Subtract a duration from the local time.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_local_time_diff](#function-mgp-local-time-diff)**(struct mgp_local_time * first, struct mgp_local_time * second, struct mgp_memory * memory, struct mgp_duration ** result)<br />Get a duration between two local times.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_local_date_time_from_string](#function-mgp-local-date-time-from-string)**(const char * string, struct mgp_memory * memory, struct mgp_local_date_time ** local_date_time)<br />Create a local date-time from a string following the ISO 8601 format.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_local_date_time_from_parameters](#function-mgp-local-date-time-from-parameters)**(struct [mgp_local_date_time_parameters](#mgp_local_date_time_parameters) * parameters, struct mgp_memory * memory, struct mgp_local_date_time ** local_date_time)<br />Create a local date-time from [mgp_local_date_time_parameters](#mgp_local_date_time_parameters).  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_local_date_time_copy](#function-mgp-local-date-time-copy)**(struct mgp_local_date_time * local_date_time, struct mgp_memory * memory, struct mgp_local_date_time ** result)<br />Copy a mgp_local_date_time.  |
+| void | **[mgp_local_date_time_destroy](#function-mgp-local-date-time-destroy)**(struct mgp_local_date_time * local_date_time)<br />Free the memory used by a mgp_local_date_time.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_local_date_time_equal](#function-mgp-local-date-time-equal)**(struct mgp_local_date_time * first, struct mgp_local_date_time * second, int * result)<br />Result is non-zero if given local date-times are equal, otherwise 0.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_local_date_time_get_year](#function-mgp-local-date-time-get-year)**(struct mgp_local_date_time * local_date_time, int * year)<br />Get the year property of the local date-time.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_local_date_time_get_month](#function-mgp-local-date-time-get-month)**(struct mgp_local_date_time * local_date_time, int * month)<br />Get the month property of the local date-time.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_local_date_time_get_day](#function-mgp-local-date-time-get-day)**(struct mgp_local_date_time * local_date_time, int * day)<br />Get the day property of the local date-time.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_local_date_time_get_hour](#function-mgp-local-date-time-get-hour)**(struct mgp_local_date_time * local_date_time, int * hour)<br />Get the hour property of the local date-time.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_local_date_time_get_minute](#function-mgp-local-date-time-get-minute)**(struct mgp_local_date_time * local_date_time, int * minute)<br />Get the minute property of the local date-time.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_local_date_time_get_second](#function-mgp-local-date-time-get-second)**(struct mgp_local_date_time * local_date_time, int * second)<br />Get the second property of the local date-time.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_local_date_time_get_millisecond](#function-mgp-local-date-time-get-millisecond)**(struct mgp_local_date_time * local_date_time, int * millisecond)<br />Get the milisecond property of the local date-time.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_local_date_time_get_microsecond](#function-mgp-local-date-time-get-microsecond)**(struct mgp_local_date_time * local_date_time, int * microsecond)<br />Get the microsecond property of the local date-time.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_local_date_time_timestamp](#function-mgp-local-date-time-timestamp)**(struct mgp_local_date_time * local_date_time, int64_t * timestamp)<br />Get the local date-time as microseconds from Unix epoch.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_local_date_time_now](#function-mgp-local-date-time-now)**(struct mgp_memory * memory, struct mgp_local_date_time ** local_date_time)<br />Get the local date-time representing current date and time.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_local_date_time_add_duration](#function-mgp-local-date-time-add-duration)**(struct mgp_local_date_time * local_date_time, struct mgp_duration * dur, struct mgp_memory * memory, struct mgp_local_date_time ** result)<br />Add a duration to the local date-time.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_local_date_time_sub_duration](#function-mgp-local-date-time-sub-duration)**(struct mgp_local_date_time * local_date_time, struct mgp_duration * dur, struct mgp_memory * memory, struct mgp_local_date_time ** result)<br />Subtract a duration from the local date-time.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_local_date_time_diff](#function-mgp-local-date-time-diff)**(struct mgp_local_date_time * first, struct mgp_local_date_time * second, struct mgp_memory * memory, struct mgp_duration ** result)<br />Get a duration between two local date-times.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_duration_from_string](#function-mgp-duration-from-string)**(const char * string, struct mgp_memory * memory, struct mgp_duration ** duration)<br />Create a duration from a string following the ISO 8601 format.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_duration_from_parameters](#function-mgp-duration-from-parameters)**(struct [mgp_duration_parameters](#mgp_duration_parameters) * parameters, struct mgp_memory * memory, struct mgp_duration ** duration)<br />Create a duration from [mgp_duration_parameters](#mgp_duration_parameters).  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_duration_from_microseconds](#function-mgp-duration-from-microseconds)**(int64_t microseconds, struct mgp_memory * memory, struct mgp_duration ** duration)<br />Create a duration from microseconds.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_duration_copy](#function-mgp-duration-copy)**(struct mgp_duration * duration, struct mgp_memory * memory, struct mgp_duration ** result)<br />Copy a mgp_duration.  |
+| void | **[mgp_duration_destroy](#function-mgp-duration-destroy)**(struct mgp_duration * duration)<br />Free the memory used by a mgp_duration.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_duration_equal](#function-mgp-duration-equal)**(struct mgp_duration * first, struct mgp_duration * second, int * result)<br />Result is non-zero if given durations are equal, otherwise 0.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_duration_get_microseconds](#function-mgp-duration-get-microseconds)**(struct mgp_duration * duration, int64_t * microseconds)<br />Get the duration as microseconds.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_duration_neg](#function-mgp-duration-neg)**(struct mgp_duration * dur, struct mgp_memory * memory, struct mgp_duration ** result)<br />Apply unary minus operator to the duration.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_duration_add](#function-mgp-duration-add)**(struct mgp_duration * first, struct mgp_duration * second, struct mgp_memory * memory, struct mgp_duration ** result)<br />Add two durations.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_duration_sub](#function-mgp-duration-sub)**(struct mgp_duration * first, struct mgp_duration * second, struct mgp_memory * memory, struct mgp_duration ** result)<br />Subtract two durations.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_type_any](#function-mgp-type-any)**(struct mgp_type ** result)<br />Get the type representing any value that isn't `null`.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_type_bool](#function-mgp-type-bool)**(struct mgp_type ** result)<br />Get the type representing boolean values.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_type_string](#function-mgp-type-string)**(struct mgp_type ** result)<br />Get the type representing character string values.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_type_int](#function-mgp-type-int)**(struct mgp_type ** result)<br />Get the type representing integer values.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_type_float](#function-mgp-type-float)**(struct mgp_type ** result)<br />Get the type representing floating-point values.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_type_number](#function-mgp-type-number)**(struct mgp_type ** result)<br />Get the type representing any number value.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_type_map](#function-mgp-type-map)**(struct mgp_type ** result)<br />Get the type representing map values.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_type_node](#function-mgp-type-node)**(struct mgp_type ** result)<br />Get the type representing graph node values.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_type_relationship](#function-mgp-type-relationship)**(struct mgp_type ** result)<br />Get the type representing graph relationship values.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_type_path](#function-mgp-type-path)**(struct mgp_type ** result)<br />Get the type representing a graph path (walk) from one node to another.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_type_list](#function-mgp-type-list)**(struct mgp_type * element_type, struct mgp_type ** result)<br />Build a type representing a list of values of given `element_type`.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_type_date](#function-mgp-type-date)**(struct mgp_type ** result)<br />Get the type representing a date.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_type_local_time](#function-mgp-type-local-time)**(struct mgp_type ** result)<br />Get the type representing a local time.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_type_local_date_time](#function-mgp-type-local-date-time)**(struct mgp_type ** result)<br />Get the type representing a local date-time.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_type_duration](#function-mgp-type-duration)**(struct mgp_type ** result)<br />Get the type representing a duration.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_type_nullable](#function-mgp-type-nullable)**(struct mgp_type * type, struct mgp_type ** result)<br />Build a type representing either a `null` value or a value of given `type`.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_module_add_read_procedure](#function-mgp-module-add-read-procedure)**(struct mgp_module * module, const char * name, [mgp_proc_cb](#typedef-mgp-proc-cb) cb, struct mgp_proc ** result)<br />Register a read-only procedure to a module.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_module_add_write_procedure](#function-mgp-module-add-write-procedure)**(struct mgp_module * module, const char * name, [mgp_proc_cb](#typedef-mgp-proc-cb) cb, struct mgp_proc ** result)<br />Register a writeable procedure to a module.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_module_add_batch_read_procedure](#function-mgp-module-add-read-procedure)**(struct mgp_module * module, const char * name, [mgp_proc_cb](#typedef-mgp-proc-cb) cb, [mgp_proc_initializer](#typedef-mgp-proc-initializer) initializer, [mgp_proc_cleanup](#typedef-mgp-proc-cleanup) cleanup, struct mgp_proc ** result)<br />Register a read-only procedure to a module.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_module_add_batch_write_procedure](#function-mgp-module-add-write-procedure)**(struct mgp_module * module, const char * name, [mgp_proc_cb](#typedef-mgp-proc-cb) cb, [mgp_proc_initializer](#typedef-mgp-proc-initializer) initializer, [mgp_proc_cleanup](#typedef-mgp-proc-cleanup) cleanup, struct mgp_proc ** result)<br />Register a writeable procedure to a module.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_proc_add_arg](#function-mgp-proc-add-arg)**(struct mgp_proc * proc, const char * name, struct mgp_type * type)<br />Add a required argument to a procedure.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_proc_add_opt_arg](#function-mgp-proc-add-opt-arg)**(struct mgp_proc * proc, const char * name, struct mgp_type * type, struct mgp_value * default_value)<br />Add an optional argument with a default value to a procedure.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_proc_add_result](#function-mgp-proc-add-result)**(struct mgp_proc * proc, const char * name, struct mgp_type * type)<br />Add a result field to a procedure.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_proc_add_deprecated_result](#function-mgp-proc-add-deprecated-result)**(struct mgp_proc * proc, const char * name, struct mgp_type * type)<br />Add a result field to a procedure and mark it as deprecated.  |
+| int | **[mgp_must_abort](#function-mgp-must-abort)**(struct mgp_graph * graph)<br />Return non-zero if the currently executing procedure should abort as soon as possible.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_message_payload](#function-mgp-message-payload)**(struct mgp_message * message, const char ** result)<br />Payload is not null terminated and not a string but rather a byte array.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_message_payload_size](#function-mgp-message-payload-size)**(struct mgp_message * message, size_t * result)<br />Get the payload size.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_message_topic_name](#function-mgp-message-topic-name)**(struct mgp_message * message, const char ** result)<br />Get the name of topic.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_message_key](#function-mgp-message-key)**(struct mgp_message * message, const char ** result)<br />Get the key of mgp_message as a byte array.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_message_key_size](#function-mgp-message-key-size)**(struct mgp_message * message, size_t * result)<br />Get the key size of mgp_message.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_message_timestamp](#function-mgp-message-timestamp)**(struct mgp_message * message, int64_t * result)<br />Get the timestamp of mgp_message as a byte array.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_messages_size](#function-mgp-messages-size)**(struct mgp_messages * message, size_t * result)<br />Get the number of messages contained in the mgp_messages list Current implementation always returns without errors.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_messages_at](#function-mgp-messages-at)**(struct mgp_messages * message, size_t index, struct mgp_message ** result)<br />Get the message from a messages list at given index.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_module_add_transformation](#function-mgp-module-add-transformation)**(struct mgp_module * module, const char * name, [mgp_trans_cb](#typedef-mgp-trans-cb) cb)<br />Register a transformation with a module.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_vertices_iterator_next](#function-mgp-vertices-iterator-next)**(struct mgp_vertices_iterator * it, struct mgp_vertex ** result)<br />Advance the iterator to the next vertex and return it.  |
+| enum [mgp_error](#variable-mgp-error)| **[mgp_log](#function-mgp-log)**(mgp_log_level log_level, const char *output)<br />Log a message on a certain level. |
 
 ## Attributes
 
 |                | Name           |
 | -------------- | -------------- |
-| enum MGP_NODISCARD | **[mgp_error](#variable-mgp-error)** <br/>All functions return an error code that can be used to figure out whether the API call was successful or not.  |
+| enum MGP_NODISCARD | **[mgp_error](#variable-mgp-error)** <br />All functions return an error code that can be used to figure out whether the API call was successful or not.  |
 | | **[MGP_ERROR_NO_ERROR](#variable-mgp-error-no-error)**  |
 | | **[MGP_ERROR_UNKNOWN_ERROR](#variable-mgp-error-unknown-error)**  |
 | | **[MGP_ERROR_UNABLE_TO_ALLOCATE](#variable-mgp-error-unable-to-allocate)**  |
@@ -314,7 +320,7 @@ Label of a vertex.
 
 | Type           | Name           |
 | -------------- | -------------- |
-| const char * | **[name](#variable-name)** <br/>Name of the label as a NULL terminated character string.  |
+| const char * | **[name](#variable-name)** <br />Name of the label as a NULL terminated character string.  |
 
 #### variable name [#variable-name]
 ```cpp
@@ -331,7 +337,7 @@ Type of an edge.
 
 | Type           | Name           |
 | -------------- | -------------- |
-| const char * | **[name](#variable-name)** <br/>Name of the type as a NULL terminated character string.  |
+| const char * | **[name](#variable-name)** <br />Name of the type as a NULL terminated character string.  |
 
 #### variable name [#variable-name]
 ```cpp
@@ -348,8 +354,8 @@ Reference to a named property value.
 
 | Type           | Name           |
 | -------------- | -------------- |
-| const char * | **[name](#variable-name)** <br/>Name (key) of a property as a NULL terminated string.  |
-| struct mgp_value * | **[value](#variable-value)** <br/>Value of the referenced property.  |
+| const char * | **[name](#variable-name)** <br />Name (key) of a property as a NULL terminated string.  |
+| struct mgp_value * | **[value](#variable-value)** <br />Value of the referenced property.  |
 
 #### variable name [#variable-name]
 ```cpp
@@ -1232,6 +1238,18 @@ void mgp_list_destroy(
 
 Free the memory used by the given mgp_list and contained elements.
 
+
+### mgp_list_contains_deleted [#function-mgp-list-contains-deleted]
+```cpp
+enum mgp_error mgp_list_contains_deleted(
+    struct mgp_list * list,
+    int * result
+)
+```
+
+Result is non-zero if the given list contains any deleted values (`mgp_vertex`, `mgp_edge`, or container types holding them), otherwise 0.
+
+
 ### mgp_list_append [#function-mgp-list-append]
 ```cpp
 enum mgp_error mgp_list_append(
@@ -1319,6 +1337,18 @@ void mgp_map_destroy(
 ```
 
 Free the memory used by the given mgp_map and contained items.
+
+
+### mgp_map_contains_deleted [#function-mgp-map-contains-deleted]
+```cpp
+enum mgp_error mgp_map_contains_deleted(
+    struct mgp_map * map,
+    int * result
+)
+```
+
+Result is non-zero if the given map contains any deleted values (`mgp_vertex`, `mgp_edge`, or container types holding them), otherwise 0.
+
 
 ### mgp_map_insert [#function-mgp-map-insert]
 ```cpp
@@ -1490,6 +1520,18 @@ void mgp_path_destroy(
 ```
 
 Free the memory used by the given mgp_path and contained vertices and edges.
+
+
+### mgp_path_contains_deleted [#function-mgp-path-contains-deleted]
+```cpp
+enum mgp_error mgp_path_contains_deleted(
+    struct mgp_path * path,
+    int * result
+)
+```
+
+Result is non-zero if the given path contains any deleted values (`mgp_vertex` or `mgp_edge`), otherwise 0.
+
 
 ### mgp_path_expand [#function-mgp-path-expand]
 ```cpp
@@ -1769,6 +1811,17 @@ void mgp_vertex_destroy(
 
 Free the memory used by a mgp_vertex.
 
+### mgp_vertex_is_deleted [#function-mgp-vertex-is-deleted]
+```cpp
+enum mgp_error mgp_vertex_is_deleted(
+    struct mgp_vertex * v,
+    int * result
+)
+```
+
+Result is non-zero if the given vertex is deleted, otherwise 0.
+
+
 ### mgp_vertex_equal [#function-mgp-vertex-equal]
 ```cpp
 enum mgp_error mgp_vertex_equal(
@@ -1977,6 +2030,17 @@ void mgp_edge_destroy(
 
 Free the memory used by a mgp_edge.
 
+### mgp_edge_is_deleted [#function-mgp-edge-is-deleted]
+```cpp
+enum mgp_error mgp_edge_is_deleted(
+    struct mgp_edge * e,
+    int * result
+)
+```
+
+Result is non-zero if the given edge is deleted, otherwise 0.
+
+
 ### mgp_edge_equal [#function-mgp-edge-equal]
 ```cpp
 enum mgp_error mgp_edge_equal(
@@ -2077,7 +2141,7 @@ enum mgp_error mgp_edge_iter_properties(
 
 Start iterating over properties stored in the given edge.
 
-The properties of the edge are copied when the iterator is created, therefore later changes won't affect them. Resulting mgp_properties_iterator needs to be deallocated with mgp_properties_iterator_destroy. Return MGP_ERROR_UNABLE_TO_ALLOCATE if unable to allocate a mgp_properties_iterator. Return MGP_ERROR_DELETED_OBJECT if `e` has been deleted.
+The properties of the edge are copied when the iterator is created, therefore later changes won’t affect them. Resulting mgp_properties_iterator needs to be deallocated with mgp_properties_iterator_destroy. Return MGP_ERROR_UNABLE_TO_ALLOCATE if unable to allocate a mgp_properties_iterator. Return MGP_ERROR_DELETED_OBJECT if `e` has been deleted.
 
 
 ### mgp_graph_get_vertex_by_id [#function-mgp-graph-get-vertex-by-id]
@@ -2093,6 +2157,21 @@ enum mgp_error mgp_graph_get_vertex_by_id(
 Get the vertex corresponding to given ID, or NULL if no such vertex exists. When the first parameter to a procedure is a projected graph, the vertex must also exist in the projected graph.
 
 Resulting vertex must be freed using mgp_vertex_destroy. Return MGP_ERROR_UNABLE_TO_ALLOCATE if unable to allocate the vertex.
+
+
+### mgp_graph_is_transactional [#function-mgp-graph-is-transactional]
+```cpp
+enum mgp_error mgp_graph_is_transactional(
+    struct mgp_graph * graph,
+    int * result
+)
+```
+
+Result is non-zero if the graph is in a transactional storage mode.
+
+If the graph is not in a transactional mode (i.e. in [analytical mode](/fundamentals/storage-memory-usage#in-memory-analytical-storage-mode)), then vertices and edges may be missing due to changes from parallel transactions.
+
+The current implementation always returns without errors.
 
 
 ### mgp_graph_is_mutable [#function-mgp-graph-is-mutable]
@@ -3680,6 +3759,8 @@ enum mgp_error mgp_list_make_empty(size_t capacity, struct mgp_memory *memory, s
 
 void mgp_list_destroy(struct mgp_list *list);
 
+enum mgp_error mgp_list_contains_deleted(struct mgp_list *list, int *result);
+
 enum mgp_error mgp_list_append(struct mgp_list *list, struct mgp_value *val);
 
 enum mgp_error mgp_list_append_extend(struct mgp_list *list, struct mgp_value *val);
@@ -3693,6 +3774,8 @@ enum mgp_error mgp_list_at(struct mgp_list *list, size_t index, struct mgp_value
 enum mgp_error mgp_map_make_empty(struct mgp_memory *memory, struct mgp_map **result);
 
 void mgp_map_destroy(struct mgp_map *map);
+
+enum mgp_error mgp_map_contains_deleted(struct mgp_map *map, int *result);
 
 enum mgp_error mgp_map_insert(struct mgp_map *map, const char *key, struct mgp_value *value);
 
@@ -3726,6 +3809,8 @@ enum mgp_error mgp_path_make_with_start(struct mgp_vertex *vertex, struct mgp_me
 enum mgp_error mgp_path_copy(struct mgp_path *path, struct mgp_memory *memory, struct mgp_path **result);
 
 void mgp_path_destroy(struct mgp_path *path);
+
+enum mgp_error mgp_path_contains_deleted(struct mgp_path *path, int *result);
 
 enum mgp_error mgp_path_expand(struct mgp_path *path, struct mgp_edge *edge);
 
@@ -3802,6 +3887,8 @@ enum mgp_error mgp_vertex_copy(struct mgp_vertex *v, struct mgp_memory *memory, 
 
 void mgp_vertex_destroy(struct mgp_vertex *v);
 
+enum mgp_error mgp_vertex_is_deleted(struct mgp_vertex *v, int *result);
+
 enum mgp_error mgp_vertex_equal(struct mgp_vertex *v1, struct mgp_vertex *v2, int *result);
 
 enum mgp_error mgp_vertex_labels_count(struct mgp_vertex *v, size_t *result);
@@ -3842,6 +3929,8 @@ enum mgp_error mgp_edge_copy(struct mgp_edge *e, struct mgp_memory *memory, stru
 
 void mgp_edge_destroy(struct mgp_edge *e);
 
+enum mgp_error mgp_edge_is_deleted(struct mgp_edge *e, int *result);
+
 enum mgp_error mgp_edge_equal(struct mgp_edge *e1, struct mgp_edge *e2, int *result);
 
 enum mgp_error mgp_edge_get_type(struct mgp_edge *e, struct mgp_edge_type *result);
@@ -3864,6 +3953,8 @@ struct mgp_graph;
 
 enum mgp_error mgp_graph_get_vertex_by_id(struct mgp_graph *g, struct mgp_vertex_id id, struct mgp_memory *memory,
                                           struct mgp_vertex **result);
+
+enum mgp_error mgp_graph_is_transactional(struct mgp_graph *graph, int *result);
 
 enum mgp_error mgp_graph_is_mutable(struct mgp_graph *graph, int *result);
 

--- a/pages/custom-query-modules/cpp/cpp-api.md
+++ b/pages/custom-query-modules/cpp/cpp-api.md
@@ -16,6 +16,7 @@ To see how to implement query modules in C++, take a look at
 If you install any C++ modules after running Memgraph, you’ll need to [load
 them into Memgraph](/custom-query-modules/manage-query-modules#loading-query-modules) or restart
 Memgraph in order to use them.
+
 ## Functions and procedures
 
 With this API it’s possible to extend your Cypher queries with **functions** and **procedures** with
@@ -131,26 +132,31 @@ and (if optional) default value.
 #### Constructors
 
 Creates a non-optional parameter with the given `name` and `type`.
+
 ```cpp
 Parameter(std::string_view name, Type type)
 ```
 
 Creates an optional Boolean parameter with the given `name` and `default_value`.
+
 ```cpp
 Parameter(std::string_view name, Type type, bool default_value)
 ```
 
 Creates an optional integer parameter with the given `name` and `default_value`.
+
 ```cpp
 Parameter(std::string_view name, Type type, int default_value)
 ```
 
 Creates an optional floating-point parameter with the given `name` and `default_value`.
+
 ```cpp
 Parameter(std::string_view name, Type type, double default_value)
 ```
 
 Creates an optional string parameter with the given `name` and `default_value`.
+
 ```cpp
 Parameter(std::string_view name, Type type, std::string_view default_value)
 Parameter(std::string_view name, Type type, const char *default_value)
@@ -158,12 +164,14 @@ Parameter(std::string_view name, Type type, const char *default_value)
 
 Creates a non-optional list parameter with the given `name` and `item_type`.
 The `list_type` parameter is organized as follows: `{Type::List, Type::[ITEM_TYPE]}`.
+
 ```cpp
 Parameter(std::string_view name, std::pair<Type, Type> list_type)
 ```
 
 Creates an optional list parameter with the given `name`, `item_type`, and `default_value`.
 The `list_type` parameter is organized as follows: `{Type::List, Type::[ITEM_TYPE]}`.
+
 ```cpp
 Parameter(std::string_view name, std::pair<Type, Type> list_type, Value default_value)
 ```
@@ -185,12 +193,14 @@ Represents a procedure/function return value. Values are defined by their name a
 #### Constructors
 
 Creates a return value with the given `name` and `type`.
+
 ```cpp
 Return(std::string_view name, Type type)
 ```
 
 Creates a return value with the given `name` and `list_type`.
 The `list_type` parameter is organized as follows: `{Type::List, Type::[ITEM_TYPE]}`.
+
 ```cpp
 Return(std::string_view name, std::pair<Type, Type> list_type)
 ```
@@ -205,7 +215,7 @@ Return(std::string_view name, std::pair<Type, Type> list_type)
 
 ### RecordFactory
 
-Factory class for [`Record`](#Record).
+Factory class for [`Record`](#record).
 
 #### Constructors
 
@@ -219,7 +229,6 @@ explicit RecordFactory(mgp_result *result)
 | ----------------- | ----------------------------- |
 | `NewRecord`       | Adds a new result record.     |
 | `SetErrorMessage` | Sets the given error message. |
-
 
 ##### NewRecord
 
@@ -317,6 +326,7 @@ Inserts a value of given type under field `field_name`.
 ```cpp
   void Insert(const char *field_name, const Duration value)
 ```
+
 ```cpp
   void Insert(const char *field_name, const Value &value)
 ```
@@ -435,6 +445,7 @@ explicit Graph(mgp_graph *graph)
 | `ContainsNode`         | Returns whether the graph contains the given node (accepts node or its ID).                   |
 | `ContainsRelationship` | Returns whether the graph contains the given relationship (accepts relationship or its ID).   |
 | `IsMutable`            | Returns whether the graph is mutable.                                                         |
+| `IsTransactional`      | Returns whether the graph is in a transactional storage mode.                                 |
 | `CreateNode`           | Creates a node and adds it to the graph.                                                      |
 | `DeleteNode`           | Deletes a node from the graph.                                                                |
 | `DetachDeleteNode`     | Deletes a node and all its incident edges from the graph.                                     |
@@ -514,6 +525,14 @@ Returns whether the graph is mutable.
 
 ```cpp
 bool IsMutable() const
+```
+
+##### IsTransactional
+
+Returns whether the graph is in a transactional storage mode.
+
+```cpp
+bool IsTransactional() const
 ```
 
 ##### CreateNode
@@ -633,12 +652,14 @@ Represents a node (vertex) of the Memgraph graph.
 #### Constructors
 
 Creates a Node from the copy of the given `mgp_vertex`.
+
 ```cpp
 explicit Node(mgp_vertex *ptr)
 explicit Node(const mgp_vertex *const_ptr)
 ```
 
 Copy and move constructors:
+
 ```cpp
 Node(const Node &other) noexcept
 Node(Node &&other) noexcept
@@ -648,6 +669,7 @@ Node(Node &&other) noexcept
 
 | Name               | Description                                                         |
 |--------------------|---------------------------------------------------------------------|
+| `IsDeleted`        | Returns whether the node has been deleted.                          |
 | `Id`               | Returns the node’s ID.                                              |
 | `Labels`           | Returns an iterable & indexable structure of the node’s labels.     |
 | `HasLabel`         | Returns whether the node has the given `label`.                     |
@@ -663,6 +685,14 @@ Node(Node &&other) noexcept
 | `InDegree`         | Get the in degree of the node.                                      |
 | `OutDegree`        | Get the out degree of the node.                                     |
 | `ToString`         | Returns the node's string representation.                           |
+
+##### IsDeleted
+
+Returns whether the node has been deleted.
+
+```cpp
+bool IsDeleted() const
+```
 
 ##### Id
 
@@ -806,12 +836,14 @@ Represents a relationship (edge) of the Memgraph graph.
 #### Constructors
 
 Creates a Relationship from the copy of the given `mgp_edge`.
+
 ```cpp
 explicit Relationship(mgp_edge *ptr)
 explicit Relationship(const mgp_edge *const_ptr)
 ```
 
 Copy and move constructors:
+
 ```cpp
 Relationship(const Relationship &other) noexcept
 Relationship(Relationship &&other) noexcept
@@ -821,6 +853,7 @@ Relationship(Relationship &&other) noexcept
 
 | Name               | Description                                                                 |
 | ------------------ | --------------------------------------------------------------------------- |
+| `IsDeleted`        | Returns whether the relationship has been deleted.                          |
 | `Id`               | Returns the relationship’s ID.                                              |
 | `Type`             | Returns the relationship’s type.                                            |
 | `Properties`       | Returns an iterable & indexable structure of the relationship’s properties. |
@@ -831,6 +864,14 @@ Relationship(Relationship &&other) noexcept
 | `From`             | Returns the relationship’s source node.                                     |
 | `To`               | Returns the relationship’s destination node.                                |
 | `ToString`         | Returns the relationship’s string representation.                           |
+
+##### IsDeleted
+
+Returns whether the relationship has been deleted.
+
+```cpp
+bool IsDeleted() const
+```
 
 ##### Id
 
@@ -855,6 +896,7 @@ Returns an iterable & indexable structure of the relationship’s properties.
 ```cpp
 std::unordered_map<std::string, mgp::Value> Properties() const
 ```
+
 ##### GetProperty
 
 Gets value of the relationship's property.
@@ -928,6 +970,7 @@ const Value operator[](std::string_view property_name) const
 ```
 
 Object is hashable using
+
 ```cpp
 std::hash<mgp::Relationship>
 ```
@@ -1006,7 +1049,6 @@ int64_t AsInt() const
 | --------------------------------------------- | -------------------- |
 | `operator==`<br/>`operator!=`<br/>`operator<` | comparison operators |
 
-
 ### Labels
 
 Represents a view of node labels.
@@ -1018,6 +1060,7 @@ explicit Labels(mgp_vertex *node_ptr)
 ```
 
 Copy and move constructors:
+
 ```cpp
 Labels(const Labels &other) noexcept
 Labels(Labels &&other) noexcept
@@ -1044,7 +1087,6 @@ Returns the number of the labels, i.e. the size of their list.
 size_t Size() const
 ```
 
-
 #### Operators
 
 | Name         | Description                                   |
@@ -1066,6 +1108,7 @@ Represents a date with a year, month, and day.
 #### Constructors
 
 Creates a Date object from the copy of the given `mgp_date`.
+
 ```cpp
 explicit Date(mgp_date *ptr)
 explicit Date(const mgp_date *const_ptr)
@@ -1073,16 +1116,19 @@ explicit Date(const mgp_date *const_ptr)
 
 Creates a Date object from the given string representing a date in the ISO 8601 format
 (`YYYY-MM-DD`, `YYYYMMDD`, or `YYYY-MM`).
+
 ```cpp
 explicit Date(std::string_view string)
 ```
 
 Creates a Date object with the given `year`, `month`, and `day` properties.
+
 ```cpp
 Date(int year, int month, int day)
 ```
 
 Copy and move constructors:
+
 ```cpp
 Date(const Date &other) noexcept
 Date(Date &&other) noexcept
@@ -1143,11 +1189,9 @@ int64_t Timestamp() const
 
 Returns the date's string representation, which has this format: "`year`-`month`-`day`".
 
-
 ```cpp
 const std::string ToString() const
 ```
-
 
 #### Operators
 
@@ -1161,6 +1205,7 @@ const std::string ToString() const
 ```cpp
 Date operator-(const Duration &dur) const
 ```
+
 ```cpp
 Duration operator-(const Date &other) const
 ```
@@ -1174,6 +1219,7 @@ const Value operator[](std::string_view property_name) const
 ```
 
 Object is hashable using
+
 ```cpp
 std::hash<mgp::Date>
 ```
@@ -1185,6 +1231,7 @@ Represents a time within the day without timezone information.
 #### Constructors
 
 Creates a LocalTime object from the copy of the given `mgp_local_time`.
+
 ```cpp
 explicit LocalTime(mgp_local_time *ptr)
 explicit LocalTime(const mgp_local_time *const_ptr)
@@ -1192,16 +1239,19 @@ explicit LocalTime(const mgp_local_time *const_ptr)
 
 Creates a LocalTime object from the given string representing a date in the ISO 8601 format
 (`[T]hh:mm:ss`, `[T]hh:mm`, `[T]hhmmss`, `[T]hhmm`, or `[T]hh`).
+
 ```cpp
 explicit LocalTime(std::string_view string)
 ```
 
 Creates a LocalTime object with the given `hour`, `minute`, `second`, `millisecond`, and `microsecond` properties.
+
 ```cpp
 LocalTime(int hour, int minute, int second, int millisecond, int microsecond)
 ```
 
 Copy and move constructors:
+
 ```cpp
 LocalTime(const LocalTime &other) noexcept
 LocalTime(LocalTime &&other) noexcept
@@ -1275,15 +1325,14 @@ Returns the object’s timestamp (microseconds since Unix epoch).
 ```cpp
 int64_t Timestamp() const
 ```
+
 ##### ToString
 
 Returns the object's string representation, which has this format: "`hour`:`minute`:`second`,`microsecond milisecond`".
 
-
 ```cpp
 const std::string ToString() const
 ```
-
 
 #### Operators
 
@@ -1297,11 +1346,13 @@ const std::string ToString() const
 ```cpp
 LocalTime operator-(const Duration &dur) const
 ```
+
 ```cpp
 Duration operator-(const LocalDateTime &other) const
 ```
 
 Object is hashable using
+
 ```cpp
 std::hash<mgp::LocalTime>
 ```
@@ -1313,6 +1364,7 @@ Temporal type representing a date and a local time.
 #### Constructors
 
 Creates a LocalDateTime object from the copy of the given `mgp_local_date_time`.
+
 ```cpp
 explicit LocalDateTime(mgp_local_date_time *ptr)
 explicit LocalDateTime(const mgp_local_date_time *const_ptr)
@@ -1320,17 +1372,20 @@ explicit LocalDateTime(const mgp_local_date_time *const_ptr)
 
 Creates a LocalDateTime object from the given string representing a date in the ISO 8601 format
 (`YYYY-MM-DDThh:mm:ss`, `YYYY-MM-DDThh:mm`, `YYYYMMDDThhmmss`, `YYYYMMDDThhmm`, or `YYYYMMDDThh`).
+
 ```cpp
 explicit LocalDateTime(std::string_view string)
 ```
 
 Creates a LocalDateTime object with the given `year`, `month`, `day`, `hour`, `minute`, `second`, `millisecond`,
 and `microsecond` properties.
+
 ```cpp
 LocalDateTime(int year, int month, int day, int hour, int minute, int second, int millisecond, int microsecond)
 ```
 
 Copy and move constructors:
+
 ```cpp
 LocalDateTime(const LocalDateTime &other) noexcept
 LocalDateTime(LocalDateTime &&other) noexcept
@@ -1436,11 +1491,9 @@ int64_t Timestamp() const
 
 Returns the object's string representation, which has this format: "`year`-`month`-`day`T`hour`:`minute`:`second`,`microsecond milisecond`".
 
-
 ```cpp
 const std::string ToString() const
 ```
-
 
 #### Operators
 
@@ -1454,11 +1507,13 @@ const std::string ToString() const
 ```cpp
 LocalDateTime operator-(const Duration &dur) const
 ```
+
 ```cpp
 Duration operator-(const LocalDateTime &other) const
 ```
 
 Object is hashable using
+
 ```cpp
 std::hash<mgp::LocalDateTime>
 ```
@@ -1470,6 +1525,7 @@ Represents a period of time in Memgraph.
 #### Constructors
 
 Creates a Duration object from the copy of the given `mgp_duration`.
+
 ```cpp
 explicit Duration(mgp_duration *ptr)
 explicit Duration(const mgp_duration *const_ptr)
@@ -1478,21 +1534,25 @@ explicit Duration(const mgp_duration *const_ptr)
 Creates a Duration object from the given string in the following format: `P[nD]T[nH][nM][nS]`, where (1)
 `n` stands for a number, (2) capital letters are used as a separator, (3) each field in `[]` is optional,
 and (4) only the last field may be a non-integer.
+
 ```cpp
 explicit Duration(std::string_view string)
 ```
 
 Creates a Duration object from the given number of microseconds.
+
 ```cpp
 explicit Duration(int64_t microseconds)
 ```
 
 Creates a Duration object with the given `day`, `hour`, `minute`, `second`, `millisecond`, and `microsecond` properties.
+
 ```cpp
 Duration(double day, double hour, double minute, double second, double millisecond, double microsecond)
 ```
 
 Copy and move constructors:
+
 ```cpp
 Duration(const Duration &other) noexcept
 Duration(Duration &&other) noexcept
@@ -1512,10 +1572,10 @@ Returns the duration as microseconds.
 ```cpp
 int64_t Microseconds() const
 ```
+
 ##### ToString
 
 Returns the duration's string representation, which has this format: "`microseconds` ms".
-
 
 ```cpp
 const std::string ToString() const
@@ -1533,11 +1593,13 @@ const std::string ToString() const
 ```cpp
 Duration operator-(const Duration &other) const
 ```
+
 ```cpp
 Duration operator-() const
 ```
 
 Object is hashable using
+
 ```cpp
 std::hash<mgp::Duration>
 ```
@@ -1550,17 +1612,20 @@ and end points of a path necessarily being nodes.
 #### Constructors
 
 Creates a Path from the copy of the given `mgp_path`.
+
 ```cpp
 explicit Path(mgp_path *ptr)
 explicit Path(const mgp_path *const_ptr)
 ```
 
 Creates a Path starting with the given `start_node`.
+
 ```cpp
 explicit Path(const Node &start_node)
 ```
 
 Copy and move constructors:
+
 ```cpp
 Path(const Path &other) noexcept
 Path(Path &&other) noexcept
@@ -1570,12 +1635,21 @@ Path(Path &&other) noexcept
 
 | Name                | Description                                                                                           |
 | ------------------- | ----------------------------------------------------------------------------------------------------- |
+| `ContainsDeleted`   | Returns whether the path contains any deleted nodes or relationships.                                 |
 | `Length`            | Returns the path length (number of relationships).                                                    |
 | `GetNodeAt`         | Returns the node at the given `index`.  The `index` must be less than or equal to length of the path. |
 | `GetRelationshipAt` | Returns the relationship at the given `index`. The `index` must be less than length of the path.      |
 | `Expand`            | Adds a relationship continuing from the last node on the path.                                        |
 | `Pop`               | Removes the last node and the last relationship from the path.                                        |
 | `ToString`          | Returns the path's string representation.                                                             |
+
+##### ContainsDeleted
+
+Returns whether the path contains any deleted nodes or relationships.
+
+```cpp
+bool ContainsDeleted() const
+```
 
 ##### Length
 
@@ -1621,11 +1695,9 @@ void Pop()
 
 Returns the path's string representation, which has nearly the same format as `Relationship.ToString()`, the difference being that `Path.ToString()` can have multiple nodes and relationships in its string representation, for example: "`(node)-(relationship)->(node)-(relationship)->(node)`...".
 
-
 ```cpp
 const std::string ToString() const
 ```
-
 
 #### Operators
 
@@ -1634,6 +1706,7 @@ const std::string ToString() const
 | `operator==`<br/>`operator!=` | comparison operators |
 
 Object is hashable using
+
 ```cpp
 std::hash<mgp::Path>
 ```
@@ -1645,33 +1718,39 @@ A list containing any number of values of any supported type.
 #### Constructors
 
 Creates a List from the copy of the given `mgp_list`.
+
 ```cpp
 explicit List(mgp_list *ptr)
 explicit List(const mgp_list *const_ptr)
 ```
 
 Creates an empty List.
+
 ```cpp
 explicit List()
 ```
 
 Creates a List with the given `capacity`.
+
 ```cpp
 explicit List(size_t capacity)
 ```
 
 Creates a List from the given vector.
+
 ```cpp
 explicit List(const std::vector<Value> &values)
 explicit List(std::vector<Value> &&values)
 ```
 
 Creates a List from the given initializer_list.
+
 ```cpp
 explicit List(const std::initializer_list<Value> list)
 ```
 
 Copy and move constructors:
+
 ```cpp
 List(const List &other) noexcept
 List(List &&other) noexcept
@@ -1687,12 +1766,21 @@ List(List &&other) noexcept
 
 | Name                                      | Description                                           |
 | ----------------------------------------- | ----------------------------------------------------- |
+| `ContainsDeleted`                         | Returns whether the list contains any deleted values (`Node`, `Relationship`, or containers holding them). |
 | `Size`                                    | Returns the size of the list.                         |
 | `Empty`                                   | Returns whether the list is empty.                    |
 | `Append`                                  | Appends the given `value` to the list.                |
 | `AppendExtend`                            | Extends the list and appends the given `value` to it. |
 | `begin`<br/>`end`<br/>`cbegin`<br/>`cend` | Returns the beginning/end of the `List` iterator.     |
 | `ToString`                                | Returns the list's string representation.             |
+
+##### ContainsDeleted
+
+Returns whether the path contains any deleted values (`Node`, `Relationship`, or containers holding them).
+
+```cpp
+bool ContainsDeleted() const
+```
 
 ##### Size
 
@@ -1748,7 +1836,6 @@ Returns the list's string representation, which has this format: "[`element.ToSt
 const std::string ToString() const
 ```
 
-
 #### Operators
 
 | Name                          | Description                             |
@@ -1765,6 +1852,7 @@ const Value operator[](size_t index) const
 ```
 
 Object is hashable using
+
 ```cpp
 std::hash<mgp::List>
 ```
@@ -1772,33 +1860,38 @@ std::hash<mgp::List>
 ### Map
 
 A map of key-value pairs where keys are strings, and values can be of any supported type.
-The pairs are represented as [MapItems](#MapItem).
+The pairs are represented as [MapItems](#mapitem).
 
 #### Constructors
 
 Creates a Map from the copy of the given `mgp_map`.
+
 ```cpp
 explicit Map(mgp_map *ptr)
 explicit Map(const mgp_map *const_ptr)
 ```
 
 Creates an empty Map.
+
 ```cpp
 explicit Map()
 ```
 
 Creates a Map from the given STL map.
+
 ```cpp
 explicit Map(const std::map<std::string_view, Value> &items)
 explicit Map(std::map<std::string_view, Value> &&items)
 ```
 
 Creates a Map from the given initializer_list (map items correspond to initializer list pairs).
+
 ```cpp
 Map(const std::initializer_list<std::pair<std::string_view, Value>> items)
 ```
 
 Copy and move constructors:
+
 ```cpp
 Map(const Map &other) noexcept
 Map(Map &&other) noexcept
@@ -1814,6 +1907,7 @@ Map(Map &&other) noexcept
 
 | Name                                      | Description                                        |
 | ----------------------------------------- | -------------------------------------------------- |
+| `ContainsDeleted`                         | Returns whether the map contains any deleted values (`Node`, `Relationship`, or containers holding them). |
 | `Size`                                    | Returns the size of the map.                       |
 | `Empty`                                   | Returns whether the map is empty.                  |
 | `At`                                      | Returns the value at the given `key`.              |
@@ -1823,6 +1917,14 @@ Map(Map &&other) noexcept
 | `begin`<br/>`end`<br/>`cbegin`<br/>`cend` | Returns the beginning/end of the `Map` iterator.   |
 | `ToString`                                | Returns the map's string representation.           |
 | `KeyExists`                               | Checks if the key exists in a map.                 |
+
+##### ContainsDeleted
+
+Returns whether the path contains any deleted values (`Node`, `Relationship`, or containers holding them).
+
+```cpp
+bool ContainsDeleted() const
+```
 
 ##### Size
 
@@ -1855,6 +1957,7 @@ Inserts the given `key`-`value` pair into the map. The `value` is copied.
 ```cpp
 void Insert(std::string_view key, const Value &value)
 ```
+
 Inserts the given `key`-`value` pair into the map. Takes ownership of `value` by moving it.
 The behavior of accessing `value` after performing this operation is undefined.
 
@@ -1870,6 +1973,7 @@ The `value` is copied.
 ```cpp
 void Update(std::string_view key, const Value &value)
 ```
+
 Updates the `key`-`value` pair in the map. If the key doesn't exist, the value gets inserted.
 The `value` is copied. Takes the ownership of `value` by moving it.
 The behavior of accessing `value` after performing this operation is undefined.
@@ -1885,6 +1989,7 @@ Erases the element associated with the key from the map, if it doesn't exist not
 ```cpp
 void Erase(std::string_view key);
 ```
+
 ##### ToString
 
 Returns the map's string representation, which has this format: "{`key1` : `value1.ToString()`, `key2`: `value2.ToString()`...}".
@@ -1892,6 +1997,7 @@ Returns the map's string representation, which has this format: "{`key1` : `valu
 ```cpp
 const std::string ToString() const
 ```
+
 ##### KeyExists
 
 Returns `true` if key is present in the map, otherwise `false`.
@@ -1916,6 +2022,7 @@ const Value operator[](std::string_view key) const
 ```
 
 Object is hashable using
+
 ```cpp
 std::hash<mgp::Map>
 ```
@@ -1938,6 +2045,7 @@ Auxiliary data structure representing key-value pairs where keys are strings, an
 | `operator==`<br/>`operator!=`<br/>`operator<` | comparison operators |
 
 Object is hashable using
+
 ```cpp
 std::hash<mgp::MapItem>
 ```
@@ -1950,16 +2058,19 @@ The data types are described [in the reference guide](/fundamentals/data-types).
 #### Constructors
 
 Creates a Value from the copy of the given `mgp_value`.
+
 ```cpp
 explicit Value(mgp_value *ptr)
 ```
 
 Creates a null Value.
+
 ```cpp
 explicit Value()
 ```
 
 Basic type constructors:
+
 ```cpp
 explicit Value(const bool value)
 explicit Value(const int64_t value)
@@ -1969,6 +2080,7 @@ explicit Value(const std::string_view value)
 ```
 
 Container type constructors:
+
 ```cpp
 explicit Value(const List &value)
 explicit Value(List &&value)
@@ -1977,6 +2089,7 @@ explicit Value(Map &&value)
 ```
 
 Graph element type constructors:
+
 ```cpp
 explicit Value(const Node &value)
 explicit Value(Node &&value)
@@ -1987,6 +2100,7 @@ explicit Value(Path &&value)
 ```
 
 Temporal type constructors:
+
 ```cpp
 explicit Value(const Date &value)
 explicit Value(Date &&value)
@@ -1999,6 +2113,7 @@ explicit Value(Duration &&value)
 ```
 
 Copy and move constructors:
+
 ```cpp
 Value(const Value &other) noexcept
 Value(Value &&other) noexcept
@@ -2200,8 +2315,8 @@ const std::string ToString() const
 | ----------------------------- | -------------------- |
 | `operator==`<br/>`operator!=` <br/> `operator<` | comparison operators |
 
-
 Object is hashable using
+
 ```cpp
 std::hash<mgp::Value>
 ```

--- a/pages/custom-query-modules/python/python-api.mdx
+++ b/pages/custom-query-modules/python/python-api.mdx
@@ -52,7 +52,7 @@ produce either a complete `Record` or `None`. To mark a field as deprecated, use
 returning an iterable of them. Registering generator functions is currently not
 supported.
 
-In the analytical storage mode, graph elements may be deleted by parallel
+In the [in-memory analytical storage mode](/fundamentals/storage-memory-usage#in-memory-analytical-storage-mode), graph elements may be deleted by parallel
 transactions. If the return record contains any deleted values, that record is
 automatically skipped.
 

--- a/pages/custom-query-modules/python/python-api.mdx
+++ b/pages/custom-query-modules/python/python-api.mdx
@@ -176,7 +176,7 @@ passed in the Cypher query. Only the funcion arguments need to be annotated with
 types. The return type doesn't need to be specified, but it has to be supported
 by `mgp.Any`. Registering generator functions is currently not supported.
 
-In the analytical storage mode, graph elements may be deleted by parallel
+In the [in-memory analytical storage mode](/fundamentals/storage-memory-usage#in-memory-analytical-storage-mode), graph elements may be deleted by parallel
 transactions. If the return value is deleted, a null value is returned instead.
 
 **Example usage**

--- a/pages/custom-query-modules/python/python-api.mdx
+++ b/pages/custom-query-modules/python/python-api.mdx
@@ -106,7 +106,7 @@ produce either a complete `Record` or `None`. To mark a field as deprecated, use
 returning an iterable of them. Registering generator functions is currently not
 supported.
 
-In the analytical storage mode, graph elements may be deleted by parallel
+In the [in-memory analytical storage mode](/fundamentals/storage-memory-usage#in-memory-analytical-storage-mode), graph elements may be deleted by parallel
 transactions. If the return record contains any deleted values, that record is
 automatically skipped.
 

--- a/pages/custom-query-modules/python/python-api.mdx
+++ b/pages/custom-query-modules/python/python-api.mdx
@@ -12,30 +12,30 @@ public Python API provided by Memgraph. In essence, this is a wrapper around the
 **[C API](/custom-query-modules/c/c-api)**. This source file can be found in the Memgraph
 installation directory, under `/usr/lib/memgraph/python_support`.
 
-<Callout>
+    <Callout>
 
-For an example of how to implement query modules in Python, take a look at [the
+    For an example of how to implement query modules in Python, take a look at [the
 example we
 provided](/custom-query-modules/python/python-example).
 
-</Callout>
+    </Callout>
 
-<Callout>
+    <Callout>
 
-If you install any Python modules after running Memgraph, you'll have to [load
+    If you install any Python modules after running Memgraph, you'll have to [load
 them into Memgraph](/custom-query-modules/manage-query-modules#loading-query-modules) or restart
 Memgraph in order to use them.
 
 You can also develop query modules in Python from Memgraph Lab (v2.0 and newer). Just
 navigate to **Query Modules** and click on **New Module** to start.
 
-</Callout>
+    </Callout>
 
-<Callout type="info">
-If you need an additional Python library not included with Memgraph, check out
+    <Callout type="info">
+    If you need an additional Python library not included with Memgraph, check out
 [the guide on how to install
 it](/custom-query-modules/manage-query-modules).
-</Callout>
+    </Callout>
 
 
 ## mgp.read_proc(func: Callable[…, mgp.Record])
@@ -51,6 +51,10 @@ produce either a complete `Record` or `None`. To mark a field as deprecated, use
 `Record(field_name=Deprecated(type), …)`. Multiple records can be produced by
 returning an iterable of them. Registering generator functions is currently not
 supported.
+
+In the analytical storage mode, graph elements may be deleted by parallel
+transactions. If the return record contains any deleted values, that record is
+automatically skipped.
 
 **Example usage**
 
@@ -82,11 +86,11 @@ CALL example.procedure(1) YIELD args, result;
 
 Naturally, you may pass in different arguments or yield less fields.
 
-<Callout>
-Install the `mgp` Python module so your editor can use typing annotations
+    <Callout>
+    Install the `mgp` Python module so your editor can use typing annotations
 properly and suggest methods and classes it contains. You can install the module
 by running `pip install mgp`.
-</Callout>
+    </Callout>
 
 ## mgp.write_proc(func: Callable[…, mgp.Record])
 
@@ -101,6 +105,10 @@ produce either a complete `Record` or `None`. To mark a field as deprecated, use
 `Record(field_name=Deprecated(type), …)`. Multiple records can be produced by
 returning an iterable of them. Registering generator functions is currently not
 supported.
+
+In the analytical storage mode, graph elements may be deleted by parallel
+transactions. If the return record contains any deleted values, that record is
+automatically skipped.
 
 **Example usage**
 
@@ -167,6 +175,9 @@ functions. The registered func needs to be a callable which optionally takes
 passed in the Cypher query. Only the funcion arguments need to be annotated with
 types. The return type doesn't need to be specified, but it has to be supported
 by `mgp.Any`. Registering generator functions is currently not supported.
+
+In the analytical storage mode, graph elements may be deleted by parallel
+transactions. If the return value is deleted, a null value is returned instead.
 
 **Example usage**
 

--- a/pages/fundamentals/storage-memory-usage.mdx
+++ b/pages/fundamentals/storage-memory-usage.mdx
@@ -163,9 +163,11 @@ built-in behavior is as follows:
 * [procedures](/advanced-algorithms/run-algorithms#run-procedures-from-mage-library): skip all records that contain any deleted value
 * [functions](/querying/functions): return a null value
 Users developing custom query procedures and functions intended to work in the
-analytical storage mode should use API methods to check if the graph elements
-(nodes and relationships) are deleted, and if containers (maps, lists and paths)
-that may hold graph elements don’t contain any deleted values.
+analytical storage mode should use API methods to check if Memgraph is running
+in a transactional (ACID-compliant) storage mode. If not, the query module APIs
+let you check whether graph elements (nodes and relationships) are deleted, and
+whether containers (maps, lists and paths) that may hold graph elements don’t
+contain any deleted values.
 
 Memgraph uses [snapshots](/configuration/data-durability-and-backup#snapshots)
 and [write-ahead

--- a/pages/fundamentals/storage-memory-usage.mdx
+++ b/pages/fundamentals/storage-memory-usage.mdx
@@ -154,6 +154,19 @@ can see the changes it is doing](/fundamentals/transactions#isolation-levels).
 This means that the transactions can be committed in random orders, and the
 updates to the data, in the end, might not be correct.
 
+The absence of ACID guarantees also implies that changes by parallel
+transactions may affect the correctness of query procedures that read from the
+graph. The most critical case is that of the procedure returning a graph
+element (node or relationship), or a container type holding those.
+If the returned graph element has been deleted by a parallel transaction, the
+built-in behavior is as follows:
+* [procedures](/advanced-algorithms/run-algorithms#run-procedures-from-mage-library): skip all records that contain any deleted value
+* [functions](/querying/functions): return a null value
+Users developing custom query procedures and functions intended to work in the
+analytical storage mode should use API methods to check if the graph elements
+(nodes and relationships) are deleted, and if containers (maps, lists and paths)
+that may hold graph elements don’t contain any deleted values.
+
 Memgraph uses [snapshots](/configuration/data-durability-and-backup#snapshots)
 and [write-ahead
 logs](/configuration/data-durability-and-backup#write-ahead-logging) to ensure
@@ -350,7 +363,7 @@ For [files containing Cypher queries (.cypherql)](/data-migration/cypherl),
 create all nodes, then activate the `EDGE IMPORT MODE` and create relationships.
 Indexes can be created before or after activating the `EDGE IMPORT MODE`. It's
 best to [**create a label-property index**](/fundamentals/indexes) on node
-properties used to match nodes that will be connected with a relationhsip. 
+properties used to match nodes that will be connected with a relationship. 
 
 Here as an exampe of a CYPHERL file:
 

--- a/pages/fundamentals/storage-memory-usage.mdx
+++ b/pages/fundamentals/storage-memory-usage.mdx
@@ -162,7 +162,7 @@ If the returned graph element has been deleted by a parallel transaction, the
 built-in behavior is as follows:
 * [procedures](/advanced-algorithms/run-algorithms#run-procedures-from-mage-library): skip all records that contain any deleted value
 * [functions](/querying/functions): return a null value
-Users developing custom query procedures and functions intended to work in the
+Users developing [custom query procedures and functions](/custom-query-modules) intended to work in the
 analytical storage mode should use API methods to check if Memgraph is running
 in a transactional (ACID-compliant) storage mode. If not, the query module APIs
 let you check whether graph elements (nodes and relationships) are deleted, and


### PR DESCRIPTION
### Description

This PR documents the behavior of query modules in the analytical storage mode and adds the query module API methods which are intended for that case.

### Pull request type

Please check what kind of PR this is:

- [x] Fix or improvement of an existing page

### Related PRs and issues

PR this doc page is related to: https://github.com/memgraph/memgraph/pull/1395, https://github.com/memgraph/mage/pull/400


### Checklist:

- [x] Check all content with Grammarly
- [x] Perform a self-review of my code
- [x] Make corresponding changes to the rest of the documentation (consult with the DX team)
- [x] The build passes locally
- [x] My changes generate no new warnings or errors
- [x] Add a corresponding label
- [x] If release-related, add a product and version label
- [x] If release-related, add release note on product PR
