### PR TITLE
[memgraph-v2-13 < 365] Add accumulated path and weight description

### DIFF
--- a/pages/advanced-algorithms/built-in-graph-algorithms.mdx
+++ b/pages/advanced-algorithms/built-in-graph-algorithms.mdx
@@ -454,8 +454,7 @@ RETURN path, total_weight;
 Additionally, the filter can use the current path of traversal and the current weight of the path. In that case, the
 filter is defined as a lambda function over `r`, `n`, `p`, and `w`, which denotes the relationship expanded over, node expanded to, already collected path and current weight of the path in the all shortest path.
 
-In the following example, expansion is allowed over relationships with an `eu_border`
-property equal to `false`, to nodes with a `drinks_USD` property less than `20`, relationship type not equal to `CloseTo` and weight less than `1000`:
+In the following example, expansion is allowed over relationships with an `eu_border` property equal to `false`, to nodes with a `drinks_USD` property less than `20`, relationship type not equal to `CloseTo` and weight less than `1000`:
 
 ```cypher
 MATCH path=(n {id: 0})-[*ALLSHORTEST (r, n | n.total_USD) total_weight (r, n, p, w | r.eu_border = false AND n.drinks_USD < 20 AND type(last(relationships(p))) != 'CloseTo' AND w < 1000)]->(m {id: 46})

--- a/pages/advanced-algorithms/built-in-graph-algorithms.mdx
+++ b/pages/advanced-algorithms/built-in-graph-algorithms.mdx
@@ -451,9 +451,8 @@ MATCH path=(n {id: 0})-[*ALLSHORTEST (r, n | n.total_USD) total_weight (r, n | r
 RETURN path, total_weight;
 ```
 
-Additionally, the filter can use current path of traversal and current weight of path. To use them the
-filter is defined as a lambda function over `r`, `n`, `p` and `w`, which denotes the
-relationship expanded over, node expanded to, already collected path and current weight of the path in the all shortest path.
+Additionally, the filter can use the current path of traversal and the current weight of the path. In that case, the
+filter is defined as a lambda function over `r`, `n`, `p`, and `w`, which denotes the relationship expanded over, node expanded to, already collected path and current weight of the path in the all shortest path.
 
 In the following example, expansion is allowed over relationships with an `eu_border`
 property equal to `false`, to nodes with a `drinks_USD` property less than `20`, relationship type not equal to `CloseTo` and weight less than `1000`:

--- a/pages/advanced-algorithms/built-in-graph-algorithms.mdx
+++ b/pages/advanced-algorithms/built-in-graph-algorithms.mdx
@@ -240,7 +240,7 @@ RETURN path;
 
 Additionally, the filter can use current path of traversal. To use it the
 filter is defined as a lambda function over `r`, `n` and `p`, which denotes the
-relationship expanded over, node expanded to and already collected path in the breadth-first search.
+relationship expanded over, the node expanded to and the already collected path in the breadth-first search.
 
 In the following example, expansion is allowed over relationships with an `eu_border`
 property equal to `false`, to nodes with a `drinks_USD` property less than `15` and relationship type not equal to `CloseTo`:

--- a/pages/advanced-algorithms/built-in-graph-algorithms.mdx
+++ b/pages/advanced-algorithms/built-in-graph-algorithms.mdx
@@ -131,9 +131,9 @@ MATCH path=(n {id: 0})-[* (r, n | r.eu_border = false AND n.drinks_USD < 15)]->(
 RETURN path;
 ```
 
-Additionally, the filter can use current path of traversal. To use it the
-filter is defined as a lambda function over `r`, `n` and `p`, which denotes the
-relationship expanded over, node expanded to and already collected path in the depth-first search.
+Additionally, the filter can use the current path of traversal. The
+filter is defined as a lambda function over `r`, `n`, and `p`, which denotes the
+relationship expanded over, the node expanded to and the path already collected in the depth-first search.
 
 In the following example, expansion is allowed over relationships with an `eu_border`
 property equal to `false`, to nodes with a `drinks_USD` property less than `15` and relationship type not equal to `CloseTo`:

--- a/pages/advanced-algorithms/built-in-graph-algorithms.mdx
+++ b/pages/advanced-algorithms/built-in-graph-algorithms.mdx
@@ -422,6 +422,7 @@ RETURN nodes(path), total_weight;
 ```
 
 When the weight is taken from the node property and relationship property, the `coalesce()` function must be used with the relationship property. It's required because when Memgraph calculates the weight for the first node, there is no relationship in the calculation.
+
 For example:
 ```cypher
 MATCH path=(n {id: 0})-[relationships:CloseTo *ALLSHORTEST (r, n | n.total_USD + coalesce(r.weight, 0)) total_weight]-(m {id: 9})

--- a/pages/advanced-algorithms/built-in-graph-algorithms.mdx
+++ b/pages/advanced-algorithms/built-in-graph-algorithms.mdx
@@ -308,7 +308,7 @@ MATCH path=(n {id: 0})-[relationships:CloseTo *WSHORTEST (r, n | n.total_USD) to
 RETURN nodes(path), total_weight;
 ```
 
-Remember that in the case when weight is taken from the node property and edge property, `coalesce` function must be used with edge property. It's required because when Memgraph calculates weight for the first node, there is no edge in calculation.
+If the weight is taken from the node property and relationship property, the `coalesce()` function must be used with the relationship property, because when Memgraph calculates the weight of the first node, there is no relationship in the calculation.
 For example,
 ```cypher
 MATCH path=(n {id: 0})-[relationships:CloseTo *WSHORTEST (r, n | n.total_USD + coalesce(r.weight, 0)) total_weight]-(m {id: 9})

--- a/pages/advanced-algorithms/built-in-graph-algorithms.mdx
+++ b/pages/advanced-algorithms/built-in-graph-algorithms.mdx
@@ -421,8 +421,8 @@ MATCH path=(n {id: 0})-[relationships:CloseTo *ALLSHORTEST (r, n | 1) total_weig
 RETURN nodes(path), total_weight;
 ```
 
-Remember that in the case when weight is taken from the node property and edge property, `coalesce` function must be used with edge property. It's required because when Memgraph calculates weight for the first node, there is no edge in calculation.
-For example,
+When the weight is taken from the node property and relationship property, the `coalesce()` function must be used with the relationship property. It's required because when Memgraph calculates the weight for the first node, there is no relationship in the calculation.
+For example:
 ```cypher
 MATCH path=(n {id: 0})-[relationships:CloseTo *ALLSHORTEST (r, n | n.total_USD + coalesce(r.weight, 0)) total_weight]-(m {id: 9})
 RETURN nodes(path), total_weight;

--- a/pages/advanced-algorithms/built-in-graph-algorithms.mdx
+++ b/pages/advanced-algorithms/built-in-graph-algorithms.mdx
@@ -361,9 +361,9 @@ MATCH path=(n {id: 0})-[*WSHORTEST (r, n | n.total_USD) total_weight (r, n | r.e
 RETURN path,total_weight;
 ```
 
-Additionally, the filter can use current path of traversal and current weight of path. To use them the
-filter is defined as a lambda function over `r`, `n`, `p` and `w`, which denotes the
-relationship expanded over, node expanded to, already collected path and current weight of the path in the weighted shortest path.
+Additionally, the filter can use the current path of traversal and the current weight of the path. The
+filter is then defined as a lambda function over `r`, `n`, `p`, and `w`, which denotes the
+relationship expanded over, the node expanded to, the already collected path and the current weight of the path in the weighted shortest path.
 
 In the following example, expansion is allowed over relationships with an `eu_border`
 property equal to `false`, to nodes with a `drinks_USD` property less than `15`, relationship type not equal to `CloseTo` and weight less than `1000`:

--- a/pages/advanced-algorithms/built-in-graph-algorithms.mdx
+++ b/pages/advanced-algorithms/built-in-graph-algorithms.mdx
@@ -1,6 +1,6 @@
 ---
 title: Built-in graph algorithms
-description: Enhance your graph analysis tasks with Memgraph's comprehensive set of built-in graph algorithms. Our documentation and detailed instructions have got your back. 
+description: Enhance your graph analysis tasks with Memgraph's comprehensive set of built-in graph algorithms. Our documentation and detailed instructions have got your back.
 ---
 
 import { Callout } from 'nextra/components'
@@ -20,7 +20,7 @@ algorithms are built into Memgraph and don't require any additional libraries:
 Below you can find examples of how to use these algorithms, and you can try them out
 in the [Playground
 sandbox](https://playground.memgraph.com/sandbox/europe-backpacking) using the
-Europe backpacking dataset, or adjust them to the dataset of your choice. 
+Europe backpacking dataset, or adjust them to the dataset of your choice.
 
 <Callout>
 
@@ -29,7 +29,7 @@ are all a part of [MAGE](/advanced-algorithms/install-mage) - Memgraph Advanced
 Graph Extensions, an open-source repository that contains graph algorithms and
 modules written in the form of query modules that can be used to tackle the most
 interesting and challenging graph analytics problems. Check the [full list of
-algorithms](/advanced-algorithms/available-algorithms). 
+algorithms](/advanced-algorithms/available-algorithms).
 
 </Callout>
 
@@ -50,7 +50,7 @@ Below are several examples of how to use the DFS in Memgraph.
 The following query will show all the paths from node `n` to node `m`:
 
 ```cypher
-MATCH path=(n {id: 0})-[*]->(m {id: 8}) 
+MATCH path=(n {id: 0})-[*]->(m {id: 8})
 RETURN path;
 ```
 
@@ -58,14 +58,14 @@ To get the list of all relationships, add a variable in the square brackets and
 return it as a result:
 
 ```cypher
-MATCH (n {id: 0})-[relationships *]->(m {id: 8}) 
+MATCH (n {id: 0})-[relationships *]->(m {id: 8})
 RETURN relationships;
 ```
 
 To get the list of path nodes, use the `nodes()` function:
 
 ```cypher
-MATCH path=(n {id: 0})-[*]->(m {id: 8}) 
+MATCH path=(n {id: 0})-[*]->(m {id: 8})
 RETURN path,nodes(path);
 ```
 
@@ -79,23 +79,23 @@ In the following example, the algorithm will traverse only across `CloseTo` type
 of relationships:
 
 ```cypher
-MATCH path=(n {id: 0})-[relationships:CloseTo *]->(m {id: 8}) 
+MATCH path=(n {id: 0})-[relationships:CloseTo *]->(m {id: 8})
 RETURN path,relationships;
 ```
 
 You can also list multiple relationship types and allow your algorithm to traverse across any of them.
 
 In the following example, the algorithm will traverse across any of the `CloseTo`, `Borders` or the `Inside` type
-of relationship: 
+of relationship:
 
 ```cypher
-MATCH path=(n {id: 0})-[relationships:CloseTo | :Borders | :Inside *]->(m {id: 8}) 
+MATCH path=(n {id: 0})-[relationships:CloseTo | :Borders | :Inside *]->(m {id: 8})
 RETURN path,relationships;
 ```
 
 Be careful when using algorithms, especially DFS, without defining a direction.
 Depending on the size of the dataset, the execution of the query can cause a
-timeout. 
+timeout.
 
 ### Constraining the path's length
 
@@ -104,7 +104,7 @@ following query will return all the results when the path is equal to or shorter
 than 5 hops:
 
 ```cypher
-MATCH path=(n {id: 0})-[relationships * ..5]->(m {id: 8}) 
+MATCH path=(n {id: 0})-[relationships * ..5]->(m {id: 8})
 RETURN path,relationships;
 ```
 
@@ -112,7 +112,7 @@ This query will return all the paths that are equal to or longer than 3, and
 equal to or shorter than 5 hops:
 
 ```cypher
-MATCH path=(n {id: 0})-[relationships * 3..5]->(m {id: 8}) 
+MATCH path=(n {id: 0})-[relationships * 3..5]->(m {id: 8})
 RETURN path,relationships;
 ```
 
@@ -121,13 +121,25 @@ RETURN path,relationships;
 Depth-first expansion allows an arbitrary expression filter that determines if
 an expansion is allowed over a certain relationship to a certain node. The
 filter is defined as a lambda function over `r` and `n`, which denotes the
-relationship expanded over and node expanded to in the depth-first search. 
+relationship expanded over and node expanded to in the depth-first search.
 
 In the following example, expansion is allowed over relationships with an `eu_border`
 property equal to `false` and to nodes with a `drinks_USD` property less than `15`:
 
 ```cypher
-MATCH path=(n {id: 0})-[* (r, n | r.eu_border = false AND n.drinks_USD < 15)]->(m {id: 8}) 
+MATCH path=(n {id: 0})-[* (r, n | r.eu_border = false AND n.drinks_USD < 15)]->(m {id: 8})
+RETURN path;
+```
+
+Additionally, the filter can use current path of traversal. To use it the
+filter is defined as a lambda function over `r`, `n` and `p`, which denotes the
+relationship expanded over, node expanded to and already collected path in the depth-first search.
+
+In the following example, expansion is allowed over relationships with an `eu_border`
+property equal to `false`, to nodes with a `drinks_USD` property less than `15` and relationship type not equal to `CloseTo`:
+
+```cypher
+MATCH path=(n {id: 0})-[* (r, n, p | r.eu_border = false AND n.drinks_USD < 15 AND type(last(relationships(p))) != 'CloseTo')]->(m {id: 8})
 RETURN path;
 ```
 
@@ -138,7 +150,7 @@ visited nodes is decided based on nodes' breadth (distance from the source
 node). This means that when a certain node is visited, it can be safely assumed
 that all nodes that are fewer relationships away from the source node have
 already been visited, resulting in the shortest path from the source node to the
-newly visited node. 
+newly visited node.
 
 BFS in Memgraph has been implemented based on the relationship expansion syntax.
 There are a few benefits of the breadth-first expansion approach, instead of
@@ -158,7 +170,7 @@ The following query will show the shortest path between nodes `n` and `m` as a
 graph result.
 
 ```cypher
-MATCH path=(n {id: 0})-[*BFS]->(m {id: 8}) 
+MATCH path=(n {id: 0})-[*BFS]->(m {id: 8})
 RETURN path;
 ```
 
@@ -166,7 +178,7 @@ To get the list of relationships, add a variable before the `*BFS` and return
 it as a result:
 
 ```cypher
-MATCH (n {id: 0})-[relationships *BFS]->(m {id: 8}) 
+MATCH (n {id: 0})-[relationships *BFS]->(m {id: 8})
 RETURN relationships;
 ```
 
@@ -175,7 +187,7 @@ results as a list, or use the `UNWIND` clause to return individual node
 properties:
 
 ```cypher
-MATCH path=(n {id: 0})-[*BFS]->(m {id: 8}) 
+MATCH path=(n {id: 0})-[*BFS]->(m {id: 8})
 RETURN nodes(path);
 ```
 
@@ -189,7 +201,7 @@ In the following example, the algorithm will traverse only across `CloseTo` type
 of relationships regardless of the direction:
 
 ```cypher
-MATCH (n {id: 0})-[relationships:CloseTo *BFS]-(m {id: 8}) 
+MATCH (n {id: 0})-[relationships:CloseTo *BFS]-(m {id: 8})
 RETURN relationships;
 ```
 
@@ -199,7 +211,7 @@ The constraints on the path length are defined after the *BFS. The following
 query will return a result only if the path is equal to or shorter than 5 hops:
 
 ```cypher
-MATCH (n {id: 0})-[relationships:CloseTo *BFS ..5]->(m {id: 8}) 
+MATCH (n {id: 0})-[relationships:CloseTo *BFS ..5]->(m {id: 8})
 RETURN relationships;
 ```
 
@@ -207,7 +219,7 @@ The result will be returned only if the path is equal to or longer than 3, and
 equal to or shorter than 5 hops:
 
 ```cypher
-MATCH (n {id: 0})-[relationships:CloseTo *BFS 3..5]-(m {id: 15}) 
+MATCH (n {id: 0})-[relationships:CloseTo *BFS 3..5]-(m {id: 15})
 RETURN relationships;
 ```
 
@@ -216,13 +228,25 @@ RETURN relationships;
 Breadth-first expansion allows an arbitrary expression filter that determines if
 an expansion is allowed over a certain relationship to a certain node. The
 filter is defined as a lambda function over `r` and `n`, which denotes the
-relationship expanded over and node expanded to in the breadth-first search. 
+relationship expanded over and node expanded to in the breadth-first search.
 
 In the following example, expansion is allowed over relationships with an `eu_border`
 property equal to `false` and to nodes with a `drinks_USD` property less than `15`:
 
 ```cypher
-MATCH path=(n {id: 0})-[*BFS (r, n | r.eu_border = false AND n.drinks_USD < 15)]-(m {id: 8}) 
+MATCH path=(n {id: 0})-[*BFS (r, n | r.eu_border = false AND n.drinks_USD < 15)]-(m {id: 8})
+RETURN path;
+```
+
+Additionally, the filter can use current path of traversal. To use it the
+filter is defined as a lambda function over `r`, `n` and `p`, which denotes the
+relationship expanded over, node expanded to and already collected path in the breadth-first search.
+
+In the following example, expansion is allowed over relationships with an `eu_border`
+property equal to `false`, to nodes with a `drinks_USD` property less than `15` and relationship type not equal to `CloseTo`:
+
+```cypher
+MATCH path=(n {id: 0})-[*BFS (r, n, p | r.eu_border = false AND n.drinks_USD < 15 AND type(last(relationships(p))) != 'CloseTo')]->(m {id: 8})
 RETURN path;
 ```
 
@@ -277,15 +301,19 @@ UNWIND (nodes(path)) AS node
 RETURN node.id;
 ```
 
-To get the total weight, add a variable at the end of the expansion expression: 
+To get the total weight, add a variable at the end of the expansion expression:
 
 ```cypher
 MATCH path=(n {id: 0})-[relationships:CloseTo *WSHORTEST (r, n | n.total_USD) total_weight]-(m {id: 9})
 RETURN nodes(path), total_weight;
 ```
 
-Remember that in the case when weight is taken from the node property, the value
-of the last node is not taken into the total weight. 
+Remember that in the case when weight is taken from the node property and edge property, `coalesce` function must be used with edge property. It's required because when Memgraph calculates weight for the first node, there is no edge in calculation.
+For example,
+```cypher
+MATCH path=(n {id: 0})-[relationships:CloseTo *WSHORTEST (r, n | n.total_USD + coalesce(r.weight, 0)) total_weight]-(m {id: 9})
+RETURN nodes(path), total_weight;
+```
 
 ### Filtering by relationships type and direction
 
@@ -311,7 +339,7 @@ that the term "length" in this context denotes the number of traversed
 relationships and not the sum of their weights.
 
 The following example will find the shortest path with a maximum length of 4
-relationships between nodes `n` and `m`. 
+relationships between nodes `n` and `m`.
 
 ```cypher
 MATCH path=(n {id: 0})-[:CloseTo *WSHORTEST 4 (r, n | n.total_USD) total_weight]-(m {id: 46})
@@ -323,7 +351,7 @@ RETURN path,total_weight;
 Weighted shortest path expansion allows an arbitrary expression filter that
 determines if an expansion is allowed over a certain relationship to a certain
 node. The filter is defined as a lambda function over `r` and `n`, which denotes
-the relationship expanded over and node expanded to in finding the weighted shortest path. 
+the relationship expanded over and node expanded to in finding the weighted shortest path.
 
 In the following example, expansion is allowed over relationships with an `eu_border`
 property equal to `false` and to nodes with a `drinks_USD` property less than `15`:
@@ -331,6 +359,18 @@ property equal to `false` and to nodes with a `drinks_USD` property less than `1
 ```cypher
 MATCH path=(n {id: 0})-[*WSHORTEST (r, n | n.total_USD) total_weight (r, n | r.eu_border = false AND n.drinks_USD < 15)]-(m {id: 46})
 RETURN path,total_weight;
+```
+
+Additionally, the filter can use current path of traversal and current weight of path. To use them the
+filter is defined as a lambda function over `r`, `n`, `p` and `w`, which denotes the
+relationship expanded over, node expanded to, already collected path and current weight of the path in the weighted shortest path.
+
+In the following example, expansion is allowed over relationships with an `eu_border`
+property equal to `false`, to nodes with a `drinks_USD` property less than `15`, relationship type not equal to `CloseTo` and weight less than `1000`:
+
+```cypher
+MATCH path=(n {id: 0})-[*WSHORTEST (r, n | n.total_USD) total_weight (r, n, p, w | r.eu_border = false AND n.drinks_USD < 15 AND type(last(relationships(p))) != 'CloseTo' AND w < 1000)]->(m {id: 46})
+RETURN path, total_weight;
 ```
 
 ## All shortest paths
@@ -343,7 +383,7 @@ fetches them all.
 Weighted shortest path implementation returns only one resulting path from one
 node to the other. Commonly, multiple shortest paths are flowing through different
 routes. Syntax of obtaining all shortest paths is similar to the weighted shortest path
-and boils down to calling `[*ALLSHORTEST (r, n | r.weight)]` where `r` and `n` define 
+and boils down to calling `[*ALLSHORTEST (r, n | r.weight)]` where `r` and `n` define
 the current expansion relationship and node respectively.
 
 ### Getting various results
@@ -357,7 +397,7 @@ MATCH path=(n {id: 0})-[:CloseTo *ALLSHORTEST (r, n | 1)]-(m {id: 15})
 RETURN path;
 ```
 
-The query returns multiple results, all with 4 hops meaning that there are 
+The query returns multiple results, all with 4 hops meaning that there are
 multiple paths flowing from the source node to the destination node.
 
 The following is a weighted query based on the weight property on each visited relationship:
@@ -372,12 +412,19 @@ To obtain all relationship on all shortest paths, use the `relationships` functi
 ```cypher
 MATCH path=(n {id: 0})-[relationships:CloseTo *ALLSHORTEST (r, n | n.total_USD)]-(m {id: 51})
 UNWIND (relationships(path)) AS edge
-RETURN DISTINCT edge; 
+RETURN DISTINCT edge;
 ```
 
-To get the total weight, add a variable at the end of the expansion expression: 
+To get the total weight, add a variable at the end of the expansion expression:
 ```cypher
 MATCH path=(n {id: 0})-[relationships:CloseTo *ALLSHORTEST (r, n | 1) total_weight]-(m {id: 9})
+RETURN nodes(path), total_weight;
+```
+
+Remember that in the case when weight is taken from the node property and edge property, `coalesce` function must be used with edge property. It's required because when Memgraph calculates weight for the first node, there is no edge in calculation.
+For example,
+```cypher
+MATCH path=(n {id: 0})-[relationships:CloseTo *ALLSHORTEST (r, n | n.total_USD + coalesce(r.weight, 0)) total_weight]-(m {id: 9})
 RETURN nodes(path), total_weight;
 ```
 
@@ -401,5 +448,17 @@ property equal to `false` and to nodes with a `drinks_USD` property less than `2
 
 ```cypher
 MATCH path=(n {id: 0})-[*ALLSHORTEST (r, n | n.total_USD) total_weight (r, n | r.eu_border = false AND n.drinks_USD < 20)]-(m {id: 46})
+RETURN path, total_weight;
+```
+
+Additionally, the filter can use current path of traversal and current weight of path. To use them the
+filter is defined as a lambda function over `r`, `n`, `p` and `w`, which denotes the
+relationship expanded over, node expanded to, already collected path and current weight of the path in the all shortest path.
+
+In the following example, expansion is allowed over relationships with an `eu_border`
+property equal to `false`, to nodes with a `drinks_USD` property less than `20`, relationship type not equal to `CloseTo` and weight less than `1000`:
+
+```cypher
+MATCH path=(n {id: 0})-[*ALLSHORTEST (r, n | n.total_USD) total_weight (r, n, p, w | r.eu_border = false AND n.drinks_USD < 20 AND type(last(relationships(p))) != 'CloseTo' AND w < 1000)]->(m {id: 46})
 RETURN path, total_weight;
 ```


### PR DESCRIPTION
### Description

Add information about accumulated path and weight in filter lambda in built-in algorithms (DFS, BFS, WSHORTEST, ALLSHORTEST).
Fix info about weight calculation in case of node property usage and mixed of node and edge properties usage in weight lambda.

### Pull request type

Please check what kind of PR this is:

- [x] Fix or improvement of an existing page
- [ ] New documentation page, release related

### Related PRs and issues

PR this doc page is related to: 
https://github.com/memgraph/memgraph/pull/1434

Closes:
https://github.com/memgraph/memgraph/issues/1289


### Checklist:

- [ ] Check all content with Grammarly
- [ ] Perform a self-review of my code
- [ ] Make corresponding changes to the rest of the documentation (consult with the DX team)
- [ ] The build passes locally
- [ ] My changes generate no new warnings or errors
- [ ] Add a corresponding label
- [ ] If release-related, add a product and version label
- [ ] If release-related, add release note on product PR
