### PR TITLE
Add uniqueness constraint example

### DIFF
--- a/pages/fundamentals/constraints.mdx
+++ b/pages/fundamentals/constraints.mdx
@@ -100,7 +100,7 @@ SHOW CONSTRAINT INFO;
 
 Trying to modify the database in a way that violates the constraint will yield
 an error `Unable to commit due to unique constraint violation on
-:Employee(email)`.
+:Label(property)`.
 
 Constraints are dropped using the `DROP` clause:
 
@@ -111,10 +111,11 @@ DROP CONSTRAINT ON (n:label) ASSERT n.property IS UNIQUE;
 ### Example
 
 If the database is used to hold basic employee information, each employee should
-have a unique id. You can enforce this by running the following query:
+have a unique id and email. You can enforce this by running the following query:
 
 ```cypher
 CREATE CONSTRAINT ON (n:Employee) ASSERT n.id IS UNIQUE;
+CREATE CONSTRAINT ON (n:Employee) ASSERT n.email IS UNIQUE;
 ```
 
 The `SHOW CONSTRAINT INFO;` should return the following result:
@@ -124,6 +125,7 @@ The `SHOW CONSTRAINT INFO;` should return the following result:
 | constraint type | label           | properties      |
 +-----------------+-----------------+-----------------+
 | unique          | Employee        | id              |
+| unique          | Employee        | email           |
 +-----------------+-----------------+-----------------+
 ```
 
@@ -131,7 +133,7 @@ To specify multiple properties when creating uniqueness
 constraints, list them one after the other:
 
 ```cypher
-CREATE CONSTRAINT ON (n:Employee) ASSERT n.email, n.phone IS UNIQUE;
+CREATE CONSTRAINT ON (n:Employee) ASSERT n.name, n.address IS UNIQUE;
 ```
 
 At this point, `SHOW CONSTRAINT INFO;` yields the following result:
@@ -141,15 +143,20 @@ At this point, `SHOW CONSTRAINT INFO;` yields the following result:
 | constraint type | label           | properties      |
 +-----------------+-----------------+-----------------+
 | unique          | Employee        | id              |
-| unique          | Employee        | email, phone    |
+| unique          | Employee        | email           |
+| unique          | Employee        | name, address   |
 +-----------------+-----------------+-----------------+
 ```
+
+This means that two employees could have the same name **or** the same address,
+but they can not have the same name **and** the same address. 
 
 To drop the created constraints use the following queries:
 
 ```cypher
 DROP CONSTRAINT ON (n:Employee) ASSERT n.id IS UNIQUE;
-DROP CONSTRAINT ON (n:Employee) ASSERT n.email, n.phone IS UNIQUE;
+DROP CONSTRAINT ON (n:Employee) ASSERT n.email IS UNIQUE;
+DROP CONSTRAINT ON (n:Employee) ASSERT n.name, n.address IS UNIQUE;
 ```
 
 Now, `SHOW CONSTRAINT INFO;` returns an empty set.


### PR DESCRIPTION
The uniqueness constraint section was missing an example distinguishing creating multiple properties' uniqueness constraint and listing them separately.

