### PR TITLE
Update installation documentation for Memgraph with Docker

### DIFF
--- a/pages/getting-started/install-memgraph/docker.mdx
+++ b/pages/getting-started/install-memgraph/docker.mdx
@@ -303,6 +303,50 @@ application](/data-visualization/user-manual), available for download from
 To start using Memgraph in your application, use one of the [client
 libraries](/client-libraries) and follow their getting started guide.
 
+#### Load and run Memgraph Docker image from Memgraph download hub
+
+If you've downloaded the Memgraph Docker image directly from the [Memgraph
+download hub](https://memgraph.com/download), you'll receive a file named
+similar to `memgraph-2.13.0-docker.tar.gz` (the exact file name varies based on
+the version you've downloaded).
+
+To load this image into Docker, do the following:
+
+<Steps>
+
+{<h3>Uncompress the downloaded file</h3>}
+
+The downloaded `.tar.gz` file needs to be uncompressed so that you get file
+named `memgraph-2.13.0-docker.tar`. Do not unpack the `.tar` archive. This
+process varies depending on your operating system:
+
+- **Windows**: Use a tool like 7-Zip to extract the contents of the `.tar.gz` file
+- **macOS/Linux**: Use the terminal with the following command:
+
+    ```terminal
+    gunzip memgraph-2.13.0-docker.tar.gz
+    ```
+
+{<h3>Load the image into Docker</h3>}
+
+Once you've uncompressed the file, use the `docker load` command to load the
+image into Docker:
+
+```terminal
+docker load -i memgraph-2.13.0-docker.tar
+```
+
+{<h3>Run the Memgraph image</h3>}
+
+After loading the image, you can run it using the `docker run` command. Here’s
+an example command to start the Memgraph Docker container:
+
+```terminal
+docker run -p 7687:7687 -p 7444:7444 --name memgraph memgraph/memgraph
+```
+</Steps>
+
+
 ## Configuration options
 
 To learn about all the configuration options, check out the [configuration


### PR DESCRIPTION
This PR updates the installation documentation for Memgraph with Docker. The main focus is to provide detailed instructions for users who download the Docker image directly from the Memgraph Download Hub.

Key Updates:
- Added New Section: Introduced a new section titled "Load and Run Memgraph Docker Image from Download Hub." This section offers step-by-step instructions for users who download the Memgraph Docker image as a .tar.gz file from the official download hub, detailing the process of uncompressing, loading, and running the image in Docker.

Clarified Uncompressing vs. Unpacking: 
- Emphasized the distinction between uncompressing the .tar.gz file to a .tar file and not unpacking the .tar file itself, which is a crucial step for correct installation.