### PR TITLE
Update docker-compose file examples

### DIFF
--- a/pages/getting-started/install-memgraph/docker-compose.mdx
+++ b/pages/getting-started/install-memgraph/docker-compose.mdx
@@ -62,10 +62,10 @@ from Memgraph inside Memgraph Lab. We specified three useful volumes:
 
 The exact location of the local directories depends on your specific setup.
 
-[Configuration settings](/configuration/configuration-settings) can be changed by
-setting the value of the `MEMGRAPH` environment variable. In the above example,
-you can see how to set `--log-level` to `TRACE`. Since Memgraph Platform is not
-a single service, the process manager
+[Configuration settings](/configuration/configuration-settings) can be changed
+by setting the value of the `MEMGRAPH` environment variable. In the above
+example, you can see how to set `--log-level` to `TRACE`. Since Memgraph
+Platform is not a single service, the process manager
 [`supervisord`](https://docs.docker.com/config/containers/multi-service_container/)
 is used as the main running process in the `entrypoint`. The MAGE library is
 included in this image, so you can use the available graph algorithms.
@@ -89,7 +89,7 @@ services:
     ports:
       - "7687:7687"
       - "7444:7444"
-    entrypoint: ["/usr/lib/memgraph/memgraph", "--log-level=TRACE"]
+    command: ["--log-level=TRACE"]
 volumes:
   mg_lib:
   mg_log:
@@ -106,16 +106,19 @@ Memgraph Lab application. We specified three useful volumes:
 
 The exact location of the local directories depends on your specific setup.
 
-[Configuration settings](/configuration/configuration-settings) can be changed by
-adding the `entrypoint`. You first need to add `/usr/lib/memgraph/memgraph` and
-then the configuration setting you'd like to change. In the above example, you
-can see how to set `--log-level` to `TRACE`. Since the MAGE library is included
-in this image, you can use the available graph algorithms.
+We recommend using the `command` option to customize [Memgraph's runtime
+flags](/configuration/configuration-settings) instead of setting them through
+`entrypoint`. This approach enhances your flexibility and aligns with Docker
+best practices, allowing you to easily adjust your container's behavior without
+altering its foundational settings.
+
+In the above example,
+you can see how to set `--log-level` to `TRACE`. Since the MAGE library is
+included in this image, you can use the available graph algorithms.
 
 ## Docker Compose for Memgraph image
 
-The **Memgraph** image contains the database that holds your
-data.
+The **Memgraph** image contains the database that holds your data.
 
 ```yaml
 version: "3"
@@ -129,7 +132,7 @@ services:
       - mg_lib:/var/lib/memgraph
       - mg_log:/var/log/memgraph
       - mg_etc:/etc/memgraph
-    entrypoint: ["/usr/lib/memgraph/memgraph", "--log-level=TRACE"]
+    command: ["--log-level=TRACE"]
 volumes:
   mg_lib:
   mg_log:
@@ -146,11 +149,14 @@ Memgraph Lab application. We specified three useful volumes:
 
 The exact location of the local directories depends on your specific setup.
 
-[Configuration settings](/configuration/configuration-settings) can be changed by
-adding the `entrypoint`. You first need to add `/usr/lib/memgraph/memgraph` and
-then the configuration setting you'd like to change. In the above example, you
-can see how to set `--log-level` to `TRACE`. Since this image doesn't have the
-MAGE library included, you won't be able to use graph algorithms.
+We recommend using the `command` option to customize [Memgraph's runtime
+flags](/configuration/configuration-settings) instead of setting them through
+`entrypoint`. This approach enhances your flexibility and aligns with Docker
+best practices, allowing you to easily adjust your container's behavior without
+altering its foundational settings.
+
+In the above example, you can see how to set `--log-level` to `TRACE`. Since this image doesn't have
+the MAGE library included, you won't be able to use graph algorithms.
 
 > Want to see applications built with Memgraph and Docker Compose? Check out
 > [Memgraph's Github](https://github.com/memgraph) repositories.


### PR DESCRIPTION
### Description

I've updated docker-compose file examples. For the `memgraph `and `memgraph-mage` Docker Compose configurations, now use `command` for setting runtime flags.

### Pull request type

Please check what kind of PR this is:

- [ ] Fix or improvement of an existing page

### Related PRs and issues

PR this doc page is related to: 
(especially necessary if the PR is related to a release)

Closes:
https://github.com/memgraph/documentation/issues/459

### Checklist:

- [x] Check all content with Grammarly
- [x] Perform a self-review of my code
- [x] Make corresponding changes to the rest of the documentation (consult with the DX team)
- [x] The build passes locally
- [x] My changes generate no new warnings or errors
- [x] Add a corresponding label
- [ ] If release-related, add a product and version label
- [ ] If release-related, add release note on product PR
