### PR TITLE
[main < ] Add missing docs for replication

### DIFF
--- a/pages/configuration/replication.mdx
+++ b/pages/configuration/replication.mdx
@@ -12,10 +12,13 @@ import { Callout } from 'nextra/components'
 Memgraph 2.9 introduced a new configuration flag
 `--replication-restore-state-on-startup` which is `false` by default.
 
-If you want instances to remember their role and configuration in a replication
-cluster upon restart, the `--replication-restore-state-on-startup` needs to be
+Instances need to remember their role and configuration details in a replication
+cluster upon restart, and the `--replication-restore-state-on-startup` needs to be
 set to `true` when first initializing the instances and remain `true` throughout
-the instances' lifetime.
+the instances' lifetime for replication to work properly. If the flag is set to `false`,
+MAIN can't communicate with instance, because each REPLICA has a UUID of MAIN which can communicate
+with it, and it is set up only on instance registration. In case the flag is set to `false`,
+the way to go forward is to first unregister the instance on MAIN and register it again.
 
 When reinstating a cluster it is advised to first initialize the MAIN
 instance, then the REPLICA instances.
@@ -94,6 +97,14 @@ enough information to synchronize the data on a REPLICA. Memgraph stores only
 If the REPLICA is so far behind the MAIN instance that the synchronization using
 WAL files and deltas within it is impossible, Memgraph will use snapshots to
 synchronize the REPLICA to the state of the MAIN instance.
+
+From version 2.15, a REPLICA instance has integrated support to only listen to one MAIN.
+This part is introduced to support the high availability but reflects also on the replication.
+The mechanism that is used is a unique identifier that which MAIN instance sends to all REPLICAs
+when REPLICA is first registered on a MAIN. A REPLICA stores the UUID of the MAIN instance it listens to.
+The MAIN's UUID is also stored on a disk, in case of restart of an instance to continue listening to the correct 
+MAIN instance. When REPLICA restarts, `--replication-restore-state-on-startup` must be set to 
+`true` to continue getting updates from the MAIN.
 
 ## Running multiple instances
 

--- a/pages/configuration/replication.mdx
+++ b/pages/configuration/replication.mdx
@@ -10,17 +10,17 @@ import { Callout } from 'nextra/components'
 <Callout type="warning">
 
 Memgraph 2.9 introduced a new configuration flag
-`--replication-restore-state-on-startup` which is `false` by default.
+`--replication-restore-state-on-startup`, which is `false` by default.
 
 Instances need to remember their role and configuration details in a replication
 cluster upon restart, and the `--replication-restore-state-on-startup` needs to be
 set to `true` when first initializing the instances and remain `true` throughout
-the instances' lifetime for replication to work properly. If the flag is set to `false`,
+the instances' lifetime for replication to work correctly. If the flag is set to `false`,
 MAIN can't communicate with instance, because each REPLICA has a UUID of MAIN which can communicate
 with it, and it is set up only on instance registration. In case the flag is set to `false`,
-the way to go forward is to first unregister the instance on MAIN and register it again.
+the way to go forward is first to unregister the instance on MAIN and register it again.
 
-When reinstating a cluster it is advised to first initialize the MAIN
+When reinstating a cluster, it is advised first to initialize the MAIN
 instance, then the REPLICA instances.
 
 </Callout>
@@ -98,8 +98,8 @@ If the REPLICA is so far behind the MAIN instance that the synchronization using
 WAL files and deltas within it is impossible, Memgraph will use snapshots to
 synchronize the REPLICA to the state of the MAIN instance.
 
-From version 2.15, a REPLICA instance has integrated support to only listen to one MAIN.
-This part is introduced to support the high availability but reflects also on the replication.
+From Memgraph version 2.15, a REPLICA instance has integrated support to only listen to one MAIN.
+This part is introduced to support the high availability but also reflects on the replication.
 The mechanism that is used is a unique identifier that which MAIN instance sends to all REPLICAs
 when REPLICA is first registered on a MAIN. A REPLICA stores the UUID of the MAIN instance it listens to.
 The MAIN's UUID is also stored on a disk, in case of restart of an instance to continue listening to the correct 


### PR DESCRIPTION
### Description

PR adds docs for REPLICA listening to one MAIN, and --restore-replication-state-on-startup which needs to be set to true

### Pull request type

Please check what kind of PR this is:

- [x] Fix or improvement of an existing page
- [ ] New documentation page, release related

### Related PRs and issues

PR this doc page is related to: 
- [x] https://github.com/memgraph/documentation/pull/476#discussion_r1504535280
- [x] https://github.com/memgraph/memgraph/pull/1674

Closes:
(paste the link to the issue it closes)


### Checklist:

- [x] Check all content with Grammarly
- [x] Perform a self-review of my code
- [x] Make corresponding changes to the rest of the documentation (consult with the DX team)
- [x] The build passes locally
- [x] My changes generate no new warnings or errors
- [x] Add a corresponding label
- [ ] If release-related, add a product and version label
- [ ] If release-related, add release note on product PR
