### PR TITLE
[memgraph-2.16 < ] Forbid merge with null properties

### DIFF
--- a/pages/querying/clauses/merge.mdx
+++ b/pages/querying/clauses/merge.mdx
@@ -32,7 +32,9 @@ more details.
     3.2. [Merging with ON MATCH SET](#32-merging-with-on-match-set)<br />
     3.3. [Merging with ON CREATE SET and ON MATCH SET](#33-merging-with-on-create-set-and-on-match-set)<br />
     3.4. [Merging with SET](#34-merging-with-set)<br />
-    3.5. [Combination of clauses](#35-combination-of-clauses)
+    3.5. [Combination of clauses](#35-combination-of-clauses) <br />
+4. [Errors related to invalid MERGE usage](#4-errors-related-to-invalid-merge-usage) <br />
+    4.1. [Merging a null property](#41-merging-a-null-property)
 
 ## Data Set
 
@@ -306,3 +308,23 @@ CREATE (c2)<-[:LIVING_IN {date_of_start: 2014}]-(p)-[:LIVING_IN {date_of_start: 
 
 MATCH (n)-[r]->(m) RETURN n,r,m;
 ```
+
+## 4. Errors related to invalid `MERGE` usage
+
+### 4.1. Merging a null property
+
+Issuing a query like the following:
+
+```cypher
+MERGE (n:Node {id:null})
+```
+will result in the following error
+
+```
+Can't have null literal properties inside merge (n.id)!
+```
+
+Due to Memgraph having the same behaviour for null types, which also corresponds to not having the property at all,
+we do not support this behaviour.
+This applies for both node and edge properties. The check is evaluated at runtime.
+To mitigate this issue, try modifying the query using `ON CREATE SET`, `ON MATCH SET`, or just `SET` after the `MERGE` clause.

--- a/pages/querying/clauses/merge.mdx
+++ b/pages/querying/clauses/merge.mdx
@@ -324,7 +324,7 @@ will result in the following error
 Can't have null literal properties inside merge (n.id)!
 ```
 
-Due to Memgraph having the same behaviour for null types, which also corresponds to not having the property at all,
-we do not support this behaviour.
-This applies for both node and edge properties. The check is evaluated at runtime.
+Due to Memgraph having the same behavior for null types, which also corresponds to not having the property at all,
+we do not support this behavior.
+This applies to both node and edge properties. The check is evaluated at runtime.
 To mitigate this issue, try modifying the query using `ON CREATE SET`, `ON MATCH SET`, or just `SET` after the `MERGE` clause.


### PR DESCRIPTION
### Description

Docs have been updated to the extended behaviour of not being to able to merge null properties inside nodes and edges.

### Pull request type

Please check what kind of PR this is:

- [X] Fix or improvement of an existing page
- [ ] New documentation page, release related

### Related PRs and issues

PR this doc page is related to: 
https://github.com/memgraph/memgraph/actions/runs/8420804275/job/23056265259

### Checklist:

- [X] Check all content with Grammarly
- [X] Perform a self-review of my code
- [X] Make corresponding changes to the rest of the documentation (consult with the DX team)
- [X] The build passes locally
- [X] My changes generate no new warnings or errors
- [X] Add a corresponding label
- [X] If release-related, add a product and version label
- [X] If release-related, add release note on product PR
