### PR TITLE
[memgraph-2.15.2 < T651] Fix text search usage example

### DIFF
--- a/pages/configuration/text-search.mdx
+++ b/pages/configuration/text-search.mdx
@@ -168,10 +168,10 @@ aggregation queries contain property names, attach the `data.` prefix to them.
 The following query counts all nodes in the `complianceDocuments` index:
 
 ```cypher
-CALL text_search.regex_search(
+CALL text_search.aggregate(
     "complianceDocuments",
     "data.title:Rules2024",
-    '"count": {"value_count": {"field": "metadata.gid"}}'
+    '{"count": {"value_count": {"field": "metadata.gid"}}}'
 )
 YIELD aggregation
 RETURN aggregation;


### PR DESCRIPTION
### Description

This PR fixes the function call for `text_search.aggregate` so that readers may have a functional example.

### Pull request type

- [x] Fix or improvement of an existing page

### Related PRs and issues

~PR this doc page is related to~: N/A (fix typo)

~Closes~: N/A (fix typo)


### Checklist:

- [x] Check all content with Grammarly
- [x] Perform a self-review of my code
- [x] Make corresponding changes to the rest of the documentation (consult with the DX team)
- [x] The build passes locally
- [x] My changes generate no new warnings or errors
- [x] Add a corresponding label
- [x] If release-related, add a product and version label
- [x] ~If release-related, add release note on product PR~ N/A
