### PR TITLE
Update starting Memgraph with Docker

### DIFF
--- a/pages/data-migration/migrate-from-neo4j.mdx
+++ b/pages/data-migration/migrate-from-neo4j.mdx
@@ -150,11 +150,24 @@ directory into the Docker container where Memgraph can access it.
 
 This can be done by copying the file into your running instance. 
 
-1. Run Memgraph with
+1. Run Memgraph 
 
-    ```
-    docker run -p 7687:7687 -p 7444:7444 -p 3000:3000 memgraph/memgraph-platform
-    ```
+    The easiest way to run Memgraph is by running installation scripts that use a
+    pre-prepared `docker-compose.yml` file by executing one of the following
+    commands, depending on your operating system: 
+
+    **For Linux and macOS:**
+      ```
+      curl https://install.memgraph.com | sh
+      ```
+
+    **For Windows:**
+      ```
+      iwr https://windows.memgraph.com | iex
+      ```
+
+    For more installation options, visit the [Getting started
+    guide](https://memgraph.com/docs/getting-started#other-installation-options).
 
 2. To copy the file inside the container, open a new terminal to find out the
     `CONTAINER ID` with `docker ps`, then run:


### PR DESCRIPTION
### Description

Updating the [Migrate from Neo4j](http://localhost:3001/docs/data-migration/migrate-from-neo4j#1-starting-memgraph-with-docker) section of the docs with the new easiest way of starting Memgraph with Docker

### Pull request type

Please check what kind of PR this is:

- [x] Fix or improvement of an existing page
- [ ] New documentation page, release related

