### PR TITLE
Add section about configuring user authentication in Docker Compose

### DIFF
--- a/pages/configuration/configuration-settings.mdx
+++ b/pages/configuration/configuration-settings.mdx
@@ -198,8 +198,8 @@ This section contains the list of all other releant flags used within Memgraph.
 
 | Variable          | Description                                                                                                                                                                                                               | Type       |
 |-------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------|
-| MEMGRAPH_USER     | Username                                                                                                                                                                                                                  | `[string]` |
-| MEMGRAPH_PASSWORD | User password                                                                                                                                                                                                             | `[string]` |
+| MEMGRAPH_USER     | Specifies the username to connect to Memgraph. If the user does not already exist, Memgraph will create a new user with this username.                                                                                    | `[string]` |
+| MEMGRAPH_PASSWORD | Specifies the password for the user. If the user is being created (does not already exist), this password will be assigned. Otherwise, it is used to authenticate the connection to Memgraph.                             | `[string]` |
 | MEMGRAPH_PASSFILE | Path to file that contains username and password for creating user. Data in file should be in format `username:password` if your username or password contains  `:` just add `\` before for example `us\:ername:password` | `[string]` |
 
 ## Additional configuration inclusion

--- a/pages/configuration/configuration-settings.mdx
+++ b/pages/configuration/configuration-settings.mdx
@@ -198,9 +198,9 @@ This section contains the list of all other releant flags used within Memgraph.
 
 | Variable          | Description                                                                                                                                                                                                               | Type       |
 |-------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------|
-| MEMGRAPH_USER     | Specifies the username to connect to Memgraph. If the user does not already exist, Memgraph will create a new user with this username.                                                                                    | `[string]` |
-| MEMGRAPH_PASSWORD | Specifies the password for the user. If the user is being created (does not already exist), this password will be assigned. Otherwise, it is used to authenticate the connection to Memgraph.                             | `[string]` |
-| MEMGRAPH_PASSFILE | Path to file that contains username and password for creating user. Data in file should be in format `username:password` if your username or password contains  `:` just add `\` before for example `us\:ername:password` | `[string]` |
+| MEMGRAPH_USER     | Specifies the username for connecting to Memgraph. If the user does not exist, a new one is created with this username. Manual entry of credentials is always necessary when accessing Memgraph using Memgraph Lab. | `[string]` |
+| MEMGRAPH_PASSWORD | Specifies the password for the user. If creating a new user, this password is assigned. For existing users, this setting does not change the password. Manual entry of credentials is always necessary when accessing Memgraph using Memgraph Lab. | `[string]` |
+| MEMGRAPH_PASSFILE | Path to file that contains username and password for creating a user. Data in file should be in format `username:password` if your username or password contains  `:` just add `\` before for example `us\:ername:password` | `[string]`
 
 ## Additional configuration inclusion
 

--- a/pages/getting-started/install-memgraph/docker-compose.mdx
+++ b/pages/getting-started/install-memgraph/docker-compose.mdx
@@ -173,6 +173,25 @@ When setting up Memgraph with Docker Compose, you can use environment variables
  `MEMGRAPH_USER` and
 `MEMGRAPH_PASSWORD` to create a new user if that username doesn't already exist.
 
+<Callout>
+
+When working with `MEMGRAPH_USER` and `MEMGRAPH_PASSWORD` environmental
+variables, keep the following things in mind:
+- **New User Creation:** When `MEMGRAPH_USER` and `MEMGRAPH_PASSWORD` are set
+  and the specified user does not exist, Memgraph creates this new user.
+  However, these credentials must be manually entered each time when accessing
+  Memgraph through Memgraph Lab.
+- **Existing Users:** If the username already exists and an incorrect password
+  is provided via `MEMGRAPH_PASSWORD`, no changes will occur. The existing
+  password remains unchanged, and you must use the original credentials to
+  access Memgraph Lab.
+- **Docker Compose Restarts:** If Memgraph is restarted via Docker Compose
+  without these environment variables being set, previously created users remain
+  unaffected. You must manually enter the user credentials every time you access
+  Memgraph Lab.
+
+</Callout>
+
 Below is an example of how to configure these environment variables in your
 `docker-compose.yml` file:
 

--- a/pages/getting-started/install-memgraph/docker-compose.mdx
+++ b/pages/getting-started/install-memgraph/docker-compose.mdx
@@ -167,6 +167,65 @@ the MAGE library included, you won't be able to use graph algorithms.
 > Want to see applications built with Memgraph and Docker Compose? Check out
 > [Memgraph's Github](https://github.com/memgraph) repositories.
 
+## Configuring user authentication in Docker Compose
+
+When setting up Memgraph with Docker Compose, you can use environment variables
+to manage user authentication. You can use `MEMGRAPH_USER` and
+`MEMGRAPH_PASSWORD` to either create a new user or connect with existing
+credentials.
+
+Below is an example of how to configure these environment variables in your
+`docker-compose.yml` file:
+
+```yaml
+version: "3"
+
+services:
+  memgraph:
+    image: memgraph/memgraph-mage:latest
+    container_name: memgraph-mage
+    ports:
+      - "7687:7687"
+      - "7444:7444"
+    command: ["--log-level=TRACE"]
+    environment:
+      - MEMGRAPH_USER=testuser123
+      - MEMGRAPH_PASSWORD=t123
+
+  lab:
+    image: memgraph/lab:latest
+    container_name: memgraph-lab
+    ports:
+      - "3000:3000"
+    depends_on:
+      - memgraph
+    environment:
+      - QUICK_CONNECT_MG_HOST=memgraph
+      - QUICK_CONNECT_MG_PORT=7687
+```
+
+<Callout type="warning">
+
+When specifying environment variables in Docker Compose, avoid spaces around the
+equals sign (`=`). Including spaces can cause the variables to be misinterpreted
+or ignored by Docker, leading to unexpected behavior.
+
+Correct format:
+```
+environment:
+  - MEMGRAPH_USER=testuser123
+  - MEMGRAPH_PASSWORD=t123
+```
+
+Incorrect format (will not work):
+```
+environment:
+  - MEMGRAPH_USER = testuser123
+  - MEMGRAPH_PASSWORD = t123
+```
+
+</Callout>
+
 ## Issues when running Memgraph and Lab within the same Docker compose
 
 When running both Memgraph and Lab services within the same Docker Compose file,

--- a/pages/getting-started/install-memgraph/docker-compose.mdx
+++ b/pages/getting-started/install-memgraph/docker-compose.mdx
@@ -170,9 +170,8 @@ the MAGE library included, you won't be able to use graph algorithms.
 ## Configuring user authentication in Docker Compose
 
 When setting up Memgraph with Docker Compose, you can use environment variables
-to manage user authentication. You can use `MEMGRAPH_USER` and
-`MEMGRAPH_PASSWORD` to either create a new user or connect with existing
-credentials.
+ `MEMGRAPH_USER` and
+`MEMGRAPH_PASSWORD` to create a new user if that username doesn't already exist.
 
 Below is an example of how to configure these environment variables in your
 `docker-compose.yml` file:


### PR DESCRIPTION
### Description

- Added section about configuring user authentication in Docker Compose
- Added info on usage of  `MEMGRAPH_USER` and `MEMGRAPH_PASSWORD` env vars

### Pull request type

Please check what kind of PR this is:

- [ ] Fix or improvement of an existing page

### Related PRs and issues

PR this doc page is related to: 
(especially necessary if the PR is related to a release)

Closes:
- https://github.com/memgraph/documentation/issues/640
- https://github.com/memgraph/documentation/issues/332


### Checklist:

- [ ] Check all content with Grammarly
- [ ] Perform a self-review of my code
- [ ] Make corresponding changes to the rest of the documentation (consult with the DX team)
- [ ] The build passes locally
- [ ] My changes generate no new warnings or errors
- [ ] Add a corresponding label
- [ ] If release-related, add a product and version label
- [ ] If release-related, add release note on product PR
