### PR TITLE
Add info on edge-type indices and the schema.assert procedure

### DIFF
--- a/pages/querying/schema.mdx
+++ b/pages/querying/schema.mdx
@@ -193,7 +193,7 @@ Results:
 
 #### Delete all node indexes 
 
-The `assert()` procedure can be used to delete all indexes and constraints. By
+The `assert()` procedure can be used to delete all indexes and constraints, except for edge-type indices. By
 providing empty `indices_map`, `unique_constraints` and `existence_constraints` as
 well as `drop_existing` set to `true`, ensure that there are no indexes or
 constraints in the database. Here is the query for deleting all indexes and constraints:

--- a/pages/querying/schema.mdx
+++ b/pages/querying/schema.mdx
@@ -193,7 +193,7 @@ Results:
 
 #### Delete all node indexes 
 
-The `assert()` procedure can be used to delete all indexes and constraints, except for edge-type indices. By
+The `assert()` procedure can be used to delete all indexes and constraints, **except for edge-type indices**. By
 providing empty `indices_map`, `unique_constraints` and `existence_constraints` as
 well as `drop_existing` set to `true`, ensure that there are no indexes or
 constraints in the database. Here is the query for deleting all indexes and constraints:


### PR DESCRIPTION
Add info that `schema.assert` procedure can be used to delete all indexes and constraints, except for edge-type indices

Close: https://github.com/memgraph/documentation/issues/673