### PR TITLE
[manin < 688-update-lab-installation-manual] Update Lab installation manual 

### DIFF
--- a/pages/configuration/multi-tenancy.md
+++ b/pages/configuration/multi-tenancy.md
@@ -50,14 +50,16 @@ Users interact with multi-tenant features through specialized Cypher queries:
 
 1. `CREATE DATABASE name`: Creates a new database.
 2. `DROP DATABASE name`: Deletes a specified database.
-3. `SHOW DATABASE`: Shows the current used database. It will return `NULL` if there is not one.
+3. `SHOW DATABASE`: Shows the current used database. It will return `NULL` if
+   there is not one.
 4. `SHOW DATABASES`: Shows only the existing set of multitenant databases.
 5. `USE DATABASE name`: Switches focus to a specific database (disabled during
    transactions).
 6. `GRANT DATABASE name TO user`: Grants a user access to a specified database.
 7. `DENY DATABASE name FROM user`: Denies a user's access to a specified
-8. `REVOKE DATABASE name FROM user`: Removes database from user's authentication 
-   context
+   database.
+8. `REVOKE DATABASE name FROM user`: Removes database from user's authentication
+   context.
 9. `SET MAIN DATABASE name FOR user`: Sets a user's default (landing) database.
 10. `SHOW DATABASE PRIVILEGES FOR user`: Lists a user's database access rights.
 

--- a/pages/data-visualization/install-and-connect.mdx
+++ b/pages/data-visualization/install-and-connect.mdx
@@ -72,7 +72,7 @@ These are the default settings:
 
 {<h3>Connect</h3>}
 
-Click on connect, and you should be presented with the following dashboard:
+Click on Connect, and you should be presented with the following dashboard:
 
 ![lab-dashboard](/pages/data-visualization/install-and-connect/lab-dashboard.png)
 

--- a/pages/data-visualization/install-and-connect.mdx
+++ b/pages/data-visualization/install-and-connect.mdx
@@ -8,9 +8,9 @@ import { Steps } from 'nextra/components'
 
 # Install Memgraph Lab and connect to a database
 
-We recommend you use the `memgraph/memgraph-platform` Docker image to install
-**Memgraph Platform** and get the complete streaming graph application platform
-that includes:
+We recommend you use the [Memgraph
+Platform](getting-started/first-steps-with-memgraph#install-memgraph-platform)
+and get the complete streaming graph application platform that includes:
 
 - **Memgraph** - the database that holds your data
 - **Memgraph Lab** - visual user interface for running queries and visualizing
@@ -20,18 +20,6 @@ that includes:
 
 After running the image, mgconsole will open in the terminal while Memgraph Lab
 is available on `http://localhost:3000`. 
-
-There is also a smaller
-[`memgraph/memgraph-platform`](https://hub.docker.com/r/memgraph/memgraph-platform/tags?page=1)
-Docker image that doesn't include MAGE - the graph algorithms and modules
-library. The tag includes only `mamgraph` and `lab` keywords, for example:
-`2.7.1-memgraph2.7.0-lab2.6.0`.
-
-You can run only the Memgraph Lab web application from the Memgraph Platform image using the following command:
-
-```
-docker run -p 3000:3000 memgraph/memgraph-platform -c /etc/supervisor/supervisord-lab-only.conf
-```
 
 If you want to install Memgraph Lab as a desktop application, check out the
 [installation instructions](#install-memgraph-lab-desktop-application) for
@@ -142,5 +130,5 @@ Use the following environment variables to configure Memgraph Lab:
 Example: 
 
 ```bash
-docker run -p 7687:7687 -p 7444:7444 -p 3000:3000 -v memgraph/memgraph-platform -e APP_CYPHER_QUERY_MAX_LEN=10000 memgraph/memgraph-platform
+docker run -d -p 3000:3000 --name lab -e APP_STREAM_NAME_MAX_LEN=700 memgraph/lab
 ```

--- a/pages/data-visualization/install-and-connect.mdx
+++ b/pages/data-visualization/install-and-connect.mdx
@@ -130,5 +130,5 @@ Use the following environment variables to configure Memgraph Lab:
 Example: 
 
 ```bash
-docker run -d -p 3000:3000 --name lab -e APP_STREAM_NAME_MAX_LEN=700 memgraph/lab
+docker run -d -p 3000:3000 --name lab -e APP_CYPHER_QUERY_MAX_LEN=10000 memgraph/lab
 ```

--- a/pages/data-visualization/install-and-connect.mdx
+++ b/pages/data-visualization/install-and-connect.mdx
@@ -118,7 +118,13 @@ You should get the following result:
 
 ## Environment variables
 
-Use the following environment variables to configure Memgraph Lab:
+<Callout>
+
+The desktop application version of Memgraph Lab does not support receiving environment variables.
+
+</Callout>
+
+Configure Memgraph Lab using the following environment variables when running it through Docker, including Docker Compose:
 
 | Variable                        | Description                                   | Type       | Default  |
 |---------------------------------|-----------------------------------------------|------------|----------|

--- a/pages/data-visualization/install-and-connect.mdx
+++ b/pages/data-visualization/install-and-connect.mdx
@@ -32,12 +32,22 @@ you can access the Lab web application at [https://lab.memgraph.com/](https://la
 
 {<h3>Download and install Memgraph</h3>} 
 
-Memgraph Lab needs a [running Memgraph database instance](/getting-started).
+Memgraph Lab requires a [running Memgraph database instance](/getting-started).
 
-If you installed Memgraph using Docker, and you want to be able to connect to
-it with Memgraph Lab desktop application, be sure that ports 7687, used for
-the instance connection (`-p 7687:7687`), and 7444, used for logs (`-p
-7444:7444`) were exposed in the `docker run ...` command.
+If you installed Memgraph using Docker and wish to connect to it with the
+Memgraph Lab desktop application, ensure that ports 7687, used for instance
+connections (`-p 7687:7687`), and 7444, used for logs (`-p 7444:7444`), are
+exposed in the `docker run ...` command.
+
+<Callout type="info">
+
+Connecting Memgraph Lab to Memgraph may vary depending on the deployment method
+or operating system. The handling of the `QUICK_CONNECT_MG_HOST` environment
+variable [varies by operating
+system](/getting-started/install-memgraph/docker#issues-when-connecting-to-memgraph-lab-to-memgraph).
+
+</Callout>
+
 
 {<h3>Download Memgraph Lab</h3>}
 

--- a/pages/data-visualization/install-and-connect.mdx
+++ b/pages/data-visualization/install-and-connect.mdx
@@ -52,7 +52,7 @@ system](/getting-started/install-memgraph/docker#issues-when-connecting-to-memgr
 {<h3>Download Memgraph Lab</h3>}
 
 Visit the [Download Hub](https://memgraph.com/download/#individual) and
-download Memgraph Lab desktop application.
+download the Memgraph Lab desktop application.
 
 {<h3>Install Memgraph Lab</h3>}
 

--- a/pages/data-visualization/install-and-connect.mdx
+++ b/pages/data-visualization/install-and-connect.mdx
@@ -120,15 +120,37 @@ You should get the following result:
 
 Use the following environment variables to configure Memgraph Lab:
 
-| Variable        | Description    | Type           | Default |
-| -------------- | -------------- | -------------- | -------- |
-| APP_CYPHER_QUERY_MAX_LEN        | Max length of a Cypher query     | [`integer`]     | 5000 |
-| APP_MODULE_NAME_MAX_LEN    | Max length of the query module name       | [`integer`]     | 1000 |
-| APP_MODULE_CONTENT_MAX_LEN    | Max length of a query module content | [`integer`]     | 50000 |
-| APP_STREAM_NAME_MAX_LEN | Max length of the stream name | [`integer`] | 500 |
+| Variable                        | Description                                   | Type       | Default  |
+|---------------------------------|-----------------------------------------------|------------|----------|
+| `QUERY_MAX_LEN`                 | Max length of a Cypher query                  | `integer`  | `5000`   |
+| `MODULE_NAME_MAX_LEN`           | Max length of the query module name           | `integer`  | `1000`   |
+| `MODULE_CONTENT_MAX_LEN`        | Max length of a query module content          | `integer`  | `50000`  |
+| `STREAM_NAME_MAX_LEN`           | Max length of the stream name                 | `integer`  | `500`    |
+| `QUERY_VALIDATION_IS_ENABLED`   | State of query validation                     | `boolean`  | `false`  |
+| `STREAM_VALIDATION_IS_ENABLED`  | State of stream validation                    | `boolean`  | `false`  |
+| `NODE_LABEL_MAX_LEN`            | Max length of the node label                  | `integer`  | `1000`   |
+| `NODE_LABEL_VALIDATION_IS_ENABLED` | State of node label validation             | `boolean`  | `false`  |
+| `NODE_PROPERTY_MAX_LEN`         | Max length of the node property               | `integer`  | `1000`   |
+| `NODE_PROPERTY_VALIDATION_IS_ENABLED` | State of node property validation       | `boolean`  | `false`  |
+| `MODULE_VALIDATION_IS_ENABLED`  | State of module validation                    | `boolean`  | `false`  |
+| `QUICK_CONNECT_IS_DISABLED`     | State of quick connect feature                | `boolean`  | `false`  |
+| `QUICK_CONNECT_MG_HOST`         | Host address for quick connect                | `string`   | `127.0.0.1` |
+| `QUICK_CONNECT_MG_PORT`         | Port for quick connect                        | `integer`  | `7687`   |
+| `REQUEST_BODY_LIMIT_MB`         | Limit for request body size in MB             | `integer`  | `20`     |
 
-Example: 
+When running Memgraph Lab using Docker, configure the environment variables to
+adjust settings. Use the Docker `run` command as follows to set these variables:
 
 ```bash
-docker run -d -p 3000:3000 --name lab -e APP_CYPHER_QUERY_MAX_LEN=10000 memgraph/lab
+docker run -d -p 3000:3000 --name lab -e QUERY_MAX_LEN=10000 -e MODULE_NAME_MAX_LEN=2500 memgraph/lab
+```
+
+For Docker Compose, define the same environment variables within the
+`environment` section of your service configuration in the `docker-compose.yml`
+file:
+
+```yaml
+environment:
+  - QUERY_MAX_LEN=10000
+  - MODULE_NAME_MAX_LEN=2500
 ```


### PR DESCRIPTION
### Description

- Update the Lab manual so that it doesn't refer to the obsolete Memgrpah Platform docker image

### Pull request type

Please check what kind of PR this is:

- [x] Fix or improvement of an existing page

### Related PRs and issues

PR this doc page is related to: 
(especially necessary if the PR is related to a release)

Closes:
https://github.com/memgraph/documentation/issues/688

### Checklist:

- [ ] Check all content with Grammarly
- [ ] Perform a self-review of my code
- [ ] Make corresponding changes to the rest of the documentation (consult with the DX team)
- [ ] The build passes locally
- [ ] My changes generate no new warnings or errors
- [ ] Add a corresponding label
- [ ] If release-related, add a product and version label
- [ ] If release-related, add release note on product PR
