### PR TITLE
Typo fix, added space after link

### DIFF
--- a/pages/custom-query-modules/cpp/cpp-example.mdx
+++ b/pages/custom-query-modules/cpp/cpp-example.mdx
@@ -49,7 +49,7 @@ In order to install the required dependencies and tooling, you need to run the f
 In this guide, we will use `cmake` and `clang` to compile the query module. By default, Memgraph uses `clang` as a compiler, so it is recommended that it be used as well. The currently used version of `clang` is `17.0.2`, but this is subject to change and can be inspected in the [latest version of toolchain](https://github.com/memgraph/memgraph/blob/master/environment/toolchain/) file.
 
 Vim and Git are optional. It is recommended to use Git for version control and create a backup since if you delete your container, you will lose the file developed inside the container. 
-Of course, if you do not want to use the Vim for your day-to-day development, you can use any other text editor or IDE that you feel most comfortable with. The recommended way would be to connect to the container and use your favorite IDE. For example Visual Studio Code has [Developing inside the container](https://code.visualstudio.com/docs/devcontainers/containers)feature. 
+Of course, if you do not want to use the Vim for your day-to-day development, you can use any other text editor or IDE that you feel most comfortable with. The recommended way would be to connect to the container and use your favorite IDE. For example Visual Studio Code has [Developing inside the container](https://code.visualstudio.com/docs/devcontainers/containers) feature. 
 
 The same goes for `cmake`, you can use any other build system you want or call the compiler directly.
 


### PR DESCRIPTION
### Description

Added a space after the link that was not present on the cpp-example page. 

### Pull request type

Please check what kind of PR this is:

- [x] Fix or improvement of an existing page
- [ ] New documentation page, release related

### Related PRs and issues

PR this doc page is related to: 
(especially necessary if the PR is related to a release)

Closes:
(paste the link to the issue it closes)
Have not opened an issue on this. 


### Checklist:

- [x] Check all content with Grammarly
- [x] Perform a self-review of my code
- [ ] Make corresponding changes to the rest of the documentation (consult with the DX team)
- [ ] The build passes locally
- [x] My changes generate no new warnings or errors
- [ ] Add a corresponding label
- [ ] If release-related, add a product and version label
- [ ] If release-related, add release note on product PR
