### PR TITLE
[memgraph-2-17 < T782] Fix the Cypher examples for ZonedDateTime

### DIFF
--- a/pages/fundamentals/data-types.mdx
+++ b/pages/fundamentals/data-types.mdx
@@ -546,7 +546,7 @@ calling the `datetime()` function.
 
 The `datetime()` function takes strings that follow the ISO 8601 standard. An
 ISO 8601-compliant string that stands for a zoned datetime value has two parts:
-`<DateTime><timezone>`. The first part is defined the same way as with
+`<DateTime><timezone>`. The first part is defined the same way as
 [LocalDateTime](#localdatetime), and the second part follows one of the given
 timezone formats:
 * `Z`
@@ -563,8 +563,8 @@ where `ZoneName` is a timezone name from the
 Examples:
 
 ```cypher
-CREATE (:Flight {AIR123: datetime("2024-04-21T14:15:00-08:00[America/Los_Angeles]")});
-CREATE (:Flight {AIR123: datetime("2021-04-21Z")});
+CREATE (:Flight {AIR123: datetime("2024-04-21T14:15:00-07:00[America/Los_Angeles]")});
+CREATE (:Flight {AIR123: datetime("2021-04-21T14:15:00Z")});
 ```
 
 **Maps**
@@ -591,7 +591,7 @@ that reflects the current date and time in UTC.
 Example:
 
 ```cypher
-CREATE (:Flights {AIR123: datetime()});
+CREATE (:Flight {AIR123: datetime()});
 ```
 
 You can access the individual fields of ZonedDateTime through its properties:


### PR DESCRIPTION
### Description

This PR corrects the Cypher examples for `ZonedDateTime` so that they construct valid values.

### Pull request type

- [x] Fix or improvement of an existing page

### Related PRs and issues

PR this doc page is related to: #1866 (corrects the docs written for it)


### Checklist:

- [x] Check all content with Grammarly
- [x] Perform a self-review of my code
- [x] Make corresponding changes to the rest of the documentation (consult with the DX team)
- [x] The build passes locally
- [x] My changes generate no new warnings or errors
- [x] Add a corresponding label
- [x] If release-related, add a product and version label
- [x] ~If release-related, add release note on product PR~ N/A (correction)
