### PR TITLE
Add monitoring at runtime docs

### DIFF
--- a/pages/database-management/monitoring.mdx
+++ b/pages/database-management/monitoring.mdx
@@ -112,7 +112,8 @@ transactions, query latencies, snapshot recovery latencies, triggers, bolt
 messages, indexes, streams, and many more using an HTTP server.
 
 To start the metrics HTTP server, [enter a valid Memgraph Enterprise license
-key](/database-management/enabling-memgraph-enterprise) and restart the database. 
+key](/database-management/enabling-memgraph-enterprise) and you will be able 
+to retrieve data from the HTTP server. 
 
 ### Configure the HTTP endpoint
 


### PR DESCRIPTION
### Description

By providing Memgraph Enterprise license, Memgraph is now able to retrieve metrics data from the HTTP endpoint at runtime. Previously, one needed to restart the database in order to get access to the metrics server, which is suboptimal because in the case of large datasets, it can be a long time to restore the dataset.

### Pull request type

Please check what kind of PR this is:

- [X] Fix or improvement of an existing page
- [ ] New documentation page, release related

### Related PRs and issues

PR this doc page is related to: 
https://github.com/memgraph/memgraph/pull/2067

Closes:
X

### Checklist:

- [X] Check all content with Grammarly
- [X] Perform a self-review of my code
- [X] Make corresponding changes to the rest of the documentation (consult with the DX team)
- [X] The build passes locally
- [X] My changes generate no new warnings or errors
- [X] Add a corresponding label
- [X] If release-related, add a product and version label
- [X] If release-related, add release note on product PR
