### PR TITLE
Add `SHOW METRICS INFO` query

### DIFF
--- a/pages/database-management/monitoring.mdx
+++ b/pages/database-management/monitoring.mdx
@@ -263,14 +263,21 @@ local Memgraph build will result in a response similar to the one below.
 {
     "General": {
         "average_degree": 0.0,
-        "disk_usage": 1417846,
+        "disk_usage": 238141,
         "edge_count": 0,
-        "memory_usage": 36937728,
+        "memory_usage": 46329856,
+        "peak_memory_usage": 46329856,
+        "unreleased_delta_objects": 0,
         "vertex_count": 0
     },
     "Index": {
         "ActiveLabelIndices": 0,
-        "ActiveLabelPropertyIndices": 0
+        "ActiveLabelPropertyIndices": 0,
+        "ActiveTextIndices": 0
+    },
+    "Memory": {
+        "PeakMemoryRes": 46329856,
+        "UnreleasedDeltaObjects": 0
     },
     "Operator": {
         "AccumulateOperator": 0,
@@ -290,6 +297,8 @@ local Memgraph build will result in a response similar to the one below.
         "ExpandVariableOperator": 0,
         "FilterOperator": 0,
         "ForeachOperator": 0,
+        "HashJoinOperator": 0,
+        "IndexedJoinOperator": 0,
         "LimitOperator": 0,
         "MergeOperator": 0,
         "OnceOperator": 0,
@@ -298,6 +307,9 @@ local Memgraph build will result in a response similar to the one below.
         "ProduceOperator": 0,
         "RemoveLabelsOperator": 0,
         "RemovePropertyOperator": 0,
+        "RollUpApplyOperator": 0,
+        "ScanAllByEdgeIdOperator": 0,
+        "ScanAllByEdgeTypeOperator": 0,
         "ScanAllByIdOperator": 0,
         "ScanAllByLabelOperator": 0,
         "ScanAllByLabelPropertyOperator": 0,
@@ -322,20 +334,20 @@ local Memgraph build will result in a response similar to the one below.
         "WriteQuery": 0
     },
     "Session": {
-        "ActiveBoltSessions": 0,
+        "ActiveBoltSessions": 1,
         "ActiveSSLSessions": 0,
-        "ActiveSessions": 0,
-        "ActiveTCPSessions": 0,
+        "ActiveSessions": 1,
+        "ActiveTCPSessions": 1,
         "ActiveWebSocketSessions": 0,
-        "BoltMessages": 0
+        "BoltMessages": 3
     },
     "Snapshot": {
-        "SnapshotCreationLatency_us_50p": 4860,
-        "SnapshotCreationLatency_us_90p": 4860,
-        "SnapshotCreationLatency_us_99p": 4860,
-        "SnapshotRecoveryLatency_us_50p": 628,
-        "SnapshotRecoveryLatency_us_90p": 628,
-        "SnapshotRecoveryLatency_us_99p": 628
+        "SnapshotCreationLatency_us_50p": 0,
+        "SnapshotCreationLatency_us_90p": 0,
+        "SnapshotCreationLatency_us_99p": 0,
+        "SnapshotRecoveryLatency_us_50p": 0,
+        "SnapshotRecoveryLatency_us_90p": 0,
+        "SnapshotRecoveryLatency_us_99p": 0
     },
     "Stream": {
         "MessagesConsumed": 0,
@@ -343,9 +355,12 @@ local Memgraph build will result in a response similar to the one below.
     },
     "Transaction": {
         "ActiveTransactions": 0,
-        "CommitedTransactions": 0,
-        "FailedQuery": 0,
-        "RollbackedTransactions": 0
+        "CommitedTransactions": 1,
+        "FailedPrepare": 1,
+        "FailedPull": 0,
+        "FailedQuery": 1,
+        "RollbackedTransactions": 0,
+        "SuccessfulQuery": 1
     },
     "Trigger": {
         "TriggersCreated": 0,

--- a/pages/database-management/server-stats.md
+++ b/pages/database-management/server-stats.md
@@ -45,6 +45,106 @@ The result will contain the following fields:
 | next_session_isolation_level | The current `next` isolation level.                                                                                                                                                           |
 | storage_mode                 | The current storage mode.<br/>For more info, check out [storage modes](/fundamentals/storage-memory-usage#storage-modes).                                                                 |
 
+## Metrics information
+
+Running this query will show the system metrics. Same metrics can be provided from the HTTP endpoint at default
+port 9091. This is a query that only works with the Memgraph Enterprise License. For the information about the metrics,
+please see the [information about monitoring via HTTP server](/database-management/monitoring#monitoring-via-http-server-enterprise).
+
+```cypher
+SHOW METRICS INFO;
+```
+
+```console copy=false
++---------------------------------------+---------------+-------------+----------+
+| name                                  | type          | metric type | value    |
++---------------------------------------+---------------+-------------+----------+
+| "AverageDegree"                       | "General"     | "Gauge"     | 0        |
+| "EdgeCount"                           | "General"     | "Gauge"     | 0        |
+| "VertexCount"                         | "General"     | "Gauge"     | 0        |
+| "ActiveLabelIndices"                  | "Index"       | "Counter"   | 0        |
+| "ActiveLabelPropertyIndices"          | "Index"       | "Counter"   | 0        |
+| "ActiveTextIndices"                   | "Index"       | "Counter"   | 0        |
+| "UnreleasedDeltaObjects"              | "Memory"      | "Counter"   | 0        |
+| "DiskUsage"                           | "Memory"      | "Gauge"     | 231838   |
+| "MemoryRes"                           | "Memory"      | "Gauge"     | 45805568 |
+| "PeakMemoryRes"                       | "Memory"      | "Gauge"     | 45805568 |
+| "AccumulateOperator"                  | "Operator"    | "Counter"   | 0        |
+| "AggregateOperator"                   | "Operator"    | "Counter"   | 0        |
+| "ApplyOperator"                       | "Operator"    | "Counter"   | 0        |
+| "CallProcedureOperator"               | "Operator"    | "Counter"   | 0        |
+| "CartesianOperator"                   | "Operator"    | "Counter"   | 0        |
+| "ConstructNamedPathOperator"          | "Operator"    | "Counter"   | 0        |
+| "CreateExpandOperator"                | "Operator"    | "Counter"   | 0        |
+| "CreateNodeOperator"                  | "Operator"    | "Counter"   | 0        |
+| "DeleteOperator"                      | "Operator"    | "Counter"   | 0        |
+| "DistinctOperator"                    | "Operator"    | "Counter"   | 0        |
+| "EdgeUniquenessFilterOperator"        | "Operator"    | "Counter"   | 0        |
+| "EmptyResultOperator"                 | "Operator"    | "Counter"   | 0        |
+| "EvaluatePatternFilterOperator"       | "Operator"    | "Counter"   | 0        |
+| "ExpandOperator"                      | "Operator"    | "Counter"   | 0        |
+| "ExpandVariableOperator"              | "Operator"    | "Counter"   | 0        |
+| "FilterOperator"                      | "Operator"    | "Counter"   | 0        |
+| "ForeachOperator"                     | "Operator"    | "Counter"   | 0        |
+| "HashJoinOperator"                    | "Operator"    | "Counter"   | 0        |
+| "IndexedJoinOperator"                 | "Operator"    | "Counter"   | 0        |
+| "LimitOperator"                       | "Operator"    | "Counter"   | 0        |
+| "MergeOperator"                       | "Operator"    | "Counter"   | 0        |
+| "OnceOperator"                        | "Operator"    | "Counter"   | 0        |
+| "OptionalOperator"                    | "Operator"    | "Counter"   | 0        |
+| "OrderByOperator"                     | "Operator"    | "Counter"   | 0        |
+| "ProduceOperator"                     | "Operator"    | "Counter"   | 0        |
+| "RemoveLabelsOperator"                | "Operator"    | "Counter"   | 0        |
+| "RemovePropertyOperator"              | "Operator"    | "Counter"   | 0        |
+| "RollUpApplyOperator"                 | "Operator"    | "Counter"   | 0        |
+| "ScanAllByEdgeIdOperator"             | "Operator"    | "Counter"   | 0        |
+| "ScanAllByEdgeTypeOperator"           | "Operator"    | "Counter"   | 0        |
+| "ScanAllByIdOperator"                 | "Operator"    | "Counter"   | 0        |
+| "ScanAllByLabelOperator"              | "Operator"    | "Counter"   | 0        |
+| "ScanAllByLabelPropertyOperator"      | "Operator"    | "Counter"   | 0        |
+| "ScanAllByLabelPropertyRangeOperator" | "Operator"    | "Counter"   | 0        |
+| "ScanAllByLabelPropertyValueOperator" | "Operator"    | "Counter"   | 0        |
+| "ScanAllOperator"                     | "Operator"    | "Counter"   | 0        |
+| "SetLabelsOperator"                   | "Operator"    | "Counter"   | 0        |
+| "SetPropertiesOperator"               | "Operator"    | "Counter"   | 0        |
+| "SetPropertyOperator"                 | "Operator"    | "Counter"   | 0        |
+| "SkipOperator"                        | "Operator"    | "Counter"   | 0        |
+| "UnionOperator"                       | "Operator"    | "Counter"   | 0        |
+| "UnwindOperator"                      | "Operator"    | "Counter"   | 0        |
+| "QueryExecutionLatency_us_50p"        | "Query"       | "Histogram" | 0        |
+| "QueryExecutionLatency_us_90p"        | "Query"       | "Histogram" | 0        |
+| "QueryExecutionLatency_us_99p"        | "Query"       | "Histogram" | 0        |
+| "ReadQuery"                           | "QueryType"   | "Counter"   | 0        |
+| "ReadWriteQuery"                      | "QueryType"   | "Counter"   | 0        |
+| "WriteQuery"                          | "QueryType"   | "Counter"   | 0        |
+| "ActiveBoltSessions"                  | "Session"     | "Counter"   | 1        |
+| "ActiveSSLSessions"                   | "Session"     | "Counter"   | 0        |
+| "ActiveSessions"                      | "Session"     | "Counter"   | 1        |
+| "ActiveTCPSessions"                   | "Session"     | "Counter"   | 1        |
+| "ActiveWebSocketSessions"             | "Session"     | "Counter"   | 0        |
+| "BoltMessages"                        | "Session"     | "Counter"   | 3        |
+| "SnapshotCreationLatency_us_50p"      | "Snapshot"    | "Histogram" | 0        |
+| "SnapshotCreationLatency_us_90p"      | "Snapshot"    | "Histogram" | 0        |
+| "SnapshotCreationLatency_us_99p"      | "Snapshot"    | "Histogram" | 0        |
+| "SnapshotRecoveryLatency_us_50p"      | "Snapshot"    | "Histogram" | 0        |
+| "SnapshotRecoveryLatency_us_90p"      | "Snapshot"    | "Histogram" | 0        |
+| "SnapshotRecoveryLatency_us_99p"      | "Snapshot"    | "Histogram" | 0        |
+| "MessagesConsumed"                    | "Stream"      | "Counter"   | 0        |
+| "StreamsCreated"                      | "Stream"      | "Counter"   | 0        |
+| "ActiveTransactions"                  | "Transaction" | "Counter"   | 1        |
+| "CommitedTransactions"                | "Transaction" | "Counter"   | 0        |
+| "FailedPrepare"                       | "Transaction" | "Counter"   | 1        |
+| "FailedPull"                          | "Transaction" | "Counter"   | 0        |
+| "FailedQuery"                         | "Transaction" | "Counter"   | 1        |
+| "RollbackedTransactions"              | "Transaction" | "Counter"   | 0        |
+| "SuccessfulQuery"                     | "Transaction" | "Counter"   | 0        |
+| "TriggersCreated"                     | "Trigger"     | "Counter"   | 0        |
+| "TriggersExecuted"                    | "Trigger"     | "Counter"   | 0        |
++---------------------------------------+---------------+-------------+----------+
+```
+
+
+
 ## Build information
 
 Running the following query will return certain information about the build type of


### PR DESCRIPTION
### Description

New query has been added `SHOW METRICS INFO`, which expose the same metrics like from the HTTP endpoint, over a query

### Pull request type

Please check what kind of PR this is:

- [X] Fix or improvement of an existing page
- [ ] New documentation page, release related

### Related PRs and issues

PR this doc page is related to: 
https://github.com/memgraph/memgraph/pull/2052

Closes:
X

### Checklist:

- [X] Check all content with Grammarly
- [X] Perform a self-review of my code
- [X] Make corresponding changes to the rest of the documentation (consult with the DX team)
- [X] The build passes locally
- [X] My changes generate no new warnings or errors
- [X] Add a corresponding label
- [X] If release-related, add a product and version label
- [X] If release-related, add release note on product PR
