### PR TITLE
Add docker compose example for running HA

### DIFF
--- a/pages/clustering/high-availability.mdx
+++ b/pages/clustering/high-availability.mdx
@@ -450,7 +450,7 @@ We support deploying Memgraph HA instances as part of the Kubernetes cluster. Yo
 
 The following example shows you how to setup Memgraph cluster using docker compose. The cluster will use host's network.
 
-License file `license.cypher` should be in the format:
+License file `license.cypherl` should be in the format:
 
 ```
 
@@ -459,7 +459,7 @@ SET DATABASE SETTING 'enterprise.license' TO '<YOUR_ENTERPRISE_LICENSE>';
 
 ```
 
-You can directly use initialization file `HA_init.cypher`:
+You can directly use initialization file `HA_init.cypherl`:
 
 ```
 
@@ -481,51 +481,51 @@ services:
     image: "memgraph/memgraph-mage"
     container_name: coord1
     volumes:
-      - ./license.cypher:/tmp/init/license.cypher:ro
-      - ./HA_register.cypher:/tmp/init/HA_init.cypher:ro
+      - ./license.cypherl:/tmp/init/license.cypherl:ro
+      - ./HA_register.cypherl:/tmp/init/HA_init.cypherl:ro
     environment:
-      - MEMGRAPH_HA_CLUSTER_INIT_QUERIES=/tmp/init/HA_register.cypher
-    command: ["--bolt-port=7690", "--init-file=/tmp/init/license.cypher", "--log-level=TRACE", "--data-directory=/tmp/mg_data_coord1", "--log-file=/tmp/coord1.log", "--coordinator-id=1", "--coordinator-port=10111", "--experimental-enabled=high-availability"]
+      - MEMGRAPH_HA_CLUSTER_INIT_QUERIES=/tmp/init/HA_register.cypherl
+    command: ["--bolt-port=7690", "--init-file=/tmp/init/license.cypherl", "--log-level=TRACE", "--data-directory=/tmp/mg_data_coord1", "--log-file=/tmp/coord1.log", "--coordinator-id=1", "--coordinator-port=10111", "--experimental-enabled=high-availability"]
     network_mode: host
 
   coord2:
     image: "memgraph/memgraph-mage"
     container_name: coord2
     volumes:
-      - ./license.cypher:/tmp/init/license.cypher:ro
-    command: ["--bolt-port=7691", "--init-file=/tmp/init/license.cypher", "--log-level=TRACE", "--data-directory=/tmp/mg_data_coord2", "--log-file=/tmp/coord2.log", "--coordinator-id=2", "--coordinator-port=10112", "--experimental-enabled=high-availability"]
+      - ./license.cypherl:/tmp/init/license.cypherl:ro
+    command: ["--bolt-port=7691", "--init-file=/tmp/init/license.cypherl", "--log-level=TRACE", "--data-directory=/tmp/mg_data_coord2", "--log-file=/tmp/coord2.log", "--coordinator-id=2", "--coordinator-port=10112", "--experimental-enabled=high-availability"]
     network_mode: host
 
   coord3:
     image: "memgraph/memgraph-mage"
     container_name: coord3
     volumes:
-      - ./license.cypher:/tmp/init/license.cypher:ro
-    command: ["--bolt-port=7692", "--init-file=/tmp/init/license.cypher", "--log-level=TRACE", "--data-directory=/tmp/mg_data_coord3", "--log-file=/tmp/coord3.log", "--coordinator-id=3", "--coordinator-port=10113", "--experimental-enabled=high-availability"]
+      - ./license.cypherl:/tmp/init/license.cypherl:ro
+    command: ["--bolt-port=7692", "--init-file=/tmp/init/license.cypherl", "--log-level=TRACE", "--data-directory=/tmp/mg_data_coord3", "--log-file=/tmp/coord3.log", "--coordinator-id=3", "--coordinator-port=10113", "--experimental-enabled=high-availability"]
     network_mode: host
     
   instance1:
     image: "memgraph/memgraph-mage"
     container_name: instance1
     volumes:
-      - ./license.cypher:/tmp/init/license.cypher:ro
-    command: ["--bolt-port=7687", "--init-file=/tmp/init/license.cypher","--data-recovery-on-startup=true", "--log-level=TRACE", "--data-directory=/tmp/mg_data_instance1", "--log-file=/tmp/instance1.log", "--management-port=10011", "--experimental-enabled=high-availability"]
+      - ./license.cypherl:/tmp/init/license.cypherl:ro
+    command: ["--bolt-port=7687", "--init-file=/tmp/init/license.cypherl","--data-recovery-on-startup=true", "--log-level=TRACE", "--data-directory=/tmp/mg_data_instance1", "--log-file=/tmp/instance1.log", "--management-port=10011", "--experimental-enabled=high-availability"]
     network_mode: host
     
   instance2:
     image: "memgraph/memgraph-mage"
     container_name: instance2
     volumes:
-      - ./license.cypher:/tmp/init/license.cypher:ro
-    command: ["--bolt-port=7688", "--init-file=/tmp/init/license.cypher","--data-recovery-on-startup=true", "--log-level=TRACE", "--data-directory=/tmp/mg_data_instance2", "--log-file=/tmp/instance2.log", "--management-port=10012", "--experimental-enabled=high-availability"]
+      - ./license.cypherl:/tmp/init/license.cypherl:ro
+    command: ["--bolt-port=7688", "--init-file=/tmp/init/license.cypherl","--data-recovery-on-startup=true", "--log-level=TRACE", "--data-directory=/tmp/mg_data_instance2", "--log-file=/tmp/instance2.log", "--management-port=10012", "--experimental-enabled=high-availability"]
     network_mode: host
     
   instance3:
     image: "memgraph/memgraph-mage"
     container_name: instance3
     volumes:
-      - ./license.cypher:/tmp/init/license.cypher:ro
-    command: ["--bolt-port=7689", "--init-file=/tmp/init/license.cypher","--data-recovery-on-startup=true", "--log-level=TRACE", "--data-directory=/tmp/mg_data_instance3", "--log-file=/tmp/instance3.log", "--management-port=10013", "--experimental-enabled=high-availability"]
+      - ./license.cypherl:/tmp/init/license.cypherl:ro
+    command: ["--bolt-port=7689", "--init-file=/tmp/init/license.cypherl","--data-recovery-on-startup=true", "--log-level=TRACE", "--data-directory=/tmp/mg_data_instance3", "--log-file=/tmp/instance3.log", "--management-port=10013", "--experimental-enabled=high-availability"]
     network_mode: host
 
 ```

--- a/pages/clustering/high-availability.mdx
+++ b/pages/clustering/high-availability.mdx
@@ -450,7 +450,7 @@ We support deploying Memgraph HA instances as part of the Kubernetes cluster. Yo
 
 The following example shows you how to setup Memgraph cluster using docker compose. The cluster will use host's network.
 
-License file `license.cypher` should be in the format (change TODO):
+License file `license.cypher` should be in the format:
 
 ```
 
@@ -473,7 +473,7 @@ SET INSTANCE instance_3 TO MAIN;
 
 ```
 
-You can directly the following `docker-compose.yml` file:
+You can directly use the following `docker-compose.yml` to start the cluster using `docker compose up`:
 
 ```
 services:
@@ -509,7 +509,7 @@ services:
     container_name: instance1
     volumes:
       - ./license.cypher:/tmp/init/license.cypher:ro
-    command: ["--bolt-port=7687", "--init-file=/tmp/init/license.cypher","--data-recovery-on-startup=true", "--replication-restore-state-on-startup=true",  "--log-level=TRACE", "--data-directory=/tmp/mg_data_instance1", "--log-file=/tmp/instance1.log", "--management-port=10011", "--experimental-enabled=high-availability"]
+    command: ["--bolt-port=7687", "--init-file=/tmp/init/license.cypher","--data-recovery-on-startup=true", "--log-level=TRACE", "--data-directory=/tmp/mg_data_instance1", "--log-file=/tmp/instance1.log", "--management-port=10011", "--experimental-enabled=high-availability"]
     network_mode: host
     
   instance2:
@@ -517,7 +517,7 @@ services:
     container_name: instance2
     volumes:
       - ./license.cypher:/tmp/init/license.cypher:ro
-    command: ["--bolt-port=7688", "--init-file=/tmp/init/license.cypher","--data-recovery-on-startup=true", "--replication-restore-state-on-startup=true",  "--log-level=TRACE", "--data-directory=/tmp/mg_data_instance2", "--log-file=/tmp/instance2.log", "--management-port=10012", "--experimental-enabled=high-availability"]
+    command: ["--bolt-port=7688", "--init-file=/tmp/init/license.cypher","--data-recovery-on-startup=true", "--log-level=TRACE", "--data-directory=/tmp/mg_data_instance2", "--log-file=/tmp/instance2.log", "--management-port=10012", "--experimental-enabled=high-availability"]
     network_mode: host
     
   instance3:
@@ -525,10 +525,12 @@ services:
     container_name: instance3
     volumes:
       - ./license.cypher:/tmp/init/license.cypher:ro
-    command: ["--bolt-port=7689", "--init-file=/tmp/init/license.cypher","--data-recovery-on-startup=true", "--replication-restore-state-on-startup=true",  "--log-level=TRACE", "--data-directory=/tmp/mg_data_instance3", "--log-file=/tmp/instance3.log", "--management-port=10013", "--experimental-enabled=high-availability"]
+    command: ["--bolt-port=7689", "--init-file=/tmp/init/license.cypher","--data-recovery-on-startup=true", "--log-level=TRACE", "--data-directory=/tmp/mg_data_instance3", "--log-file=/tmp/instance3.log", "--management-port=10013", "--experimental-enabled=high-availability"]
     network_mode: host
 
 ```
+
+Cluster can be shut-down using `docker compose down`.
 
 ## Manual Docker setup
 
@@ -555,17 +557,17 @@ docker run  --name coord3 -p 7692:7692 -p 7446:7444 memgraph/memgraph-mage --bol
 
 4. Start instance1:
 ```plaintext
-docker run  --name instance1 -p 7687:7687 -p 7447:7444 memgraph/memgraph-mage --bolt-port=7687 --log-level=TRACE --data-directory=/tmp/mg_data_instance1 --log-file=/tmp/instance1.log --also-log-to-stderr --management-port=10011 --experimental-enabled=high-availability
+docker run  --name instance1 -p 7687:7687 -p 7447:7444 memgraph/memgraph-mage --bolt-port=7687 --log-level=TRACE --data-directory=/tmp/mg_data_instance1 --log-file=/tmp/instance1.log --also-log-to-stderr --management-port=10011 --experimental-enabled=high-availability --data-recovery-on-startup=true
 ```
 
 5. Start instance2:
 ```plaintext
-docker run --name instance2 -p 7688:7688 -p 7448:7444 memgraph/memgraph-mage --bolt-port=7688 --log-level=TRACE --data-directory=/tmp/mg_data_instance2 --log-file=/tmp/instance2.log --also-log-to-stderr --management-port=10012 --experimental-enabled=high-availability
+docker run --name instance2 -p 7688:7688 -p 7448:7444 memgraph/memgraph-mage --bolt-port=7688 --log-level=TRACE --data-directory=/tmp/mg_data_instance2 --log-file=/tmp/instance2.log --also-log-to-stderr --management-port=10012 --experimental-enabled=high-availability --data-recovery-on-startup=true
 ```
 
 6. Start instance3:
 ```plaintext
-docker run --name instance3 -p 7689:7689  -p 7449:7444 memgraph/memgraph-mage --bolt-port=7689 --log-level=TRACE --data-directory=/tmp/mg_data_instance3 --log-file=/tmp/instance3.log --also-log-to-stderr --management-port=10013 --experimental-enabled=high-availability
+docker run --name instance3 -p 7689:7689  -p 7449:7444 memgraph/memgraph-mage --bolt-port=7689 --log-level=TRACE --data-directory=/tmp/mg_data_instance3 --log-file=/tmp/instance3.log --also-log-to-stderr --management-port=10013 --experimental-enabled=high-availability --data-recovery-on-startup=true
 ```
 
 ### Register instances

--- a/pages/clustering/high-availability.mdx
+++ b/pages/clustering/high-availability.mdx
@@ -446,7 +446,91 @@ working on 2 datacenter (2-DC) architecture.
 
 We support deploying Memgraph HA instances as part of the Kubernetes cluster. You can see example configurations [here](/getting-started/install-memgraph/kubernetes#helm-chart-for-memgraph-high-availability-cluster).
 
-## Example
+## Docker compose
+
+The following example shows you how to setup Memgraph cluster using docker compose. The cluster will use host's network.
+
+License file `license.cypher` should be in the format (change TODO):
+
+```
+
+SET DATABASE SETTING 'organization.name' TO '<YOUR_ORGANIZATION_NAME>';
+SET DATABASE SETTING 'enterprise.license' TO '<YOUR_ENTERPRISE_LICENSE>';
+
+```
+
+You can directly use initialization file `HA_init.cypher`:
+
+```
+
+ADD COORDINATOR 2 WITH CONFIG {"bolt_server": "localhost:7691", "coordinator_server": "localhost:10112"};
+ADD COORDINATOR 3 WITH CONFIG {"bolt_server": "localhost:7692", "coordinator_server": "localhost:10113"};
+
+REGISTER INSTANCE instance_1 WITH CONFIG {"bolt_server": "localhost:7687", "management_server": "localhost:10011", "replication_server": "localhost:10001"};
+REGISTER INSTANCE instance_2 WITH CONFIG {"bolt_server": "localhost:7688", "management_server": "localhost:10012", "replication_server": "localhost:10002"};
+REGISTER INSTANCE instance_3 WITH CONFIG {"bolt_server": "localhost:7689", "management_server": "localhost:10013", "replication_server": "localhost:10003"};
+SET INSTANCE instance_3 TO MAIN;
+
+```
+
+You can directly the following `docker-compose.yml` file:
+
+```
+services:
+  coord1:
+    image: "memgraph/memgraph-mage"
+    container_name: coord1
+    volumes:
+      - ./license.cypher:/tmp/init/license.cypher:ro
+      - ./HA_register.cypher:/tmp/init/HA_init.cypher:ro
+    environment:
+      - MEMGRAPH_HA_CLUSTER_INIT_QUERIES=/tmp/init/HA_register.cypher
+    command: ["--bolt-port=7690", "--init-file=/tmp/init/license.cypher", "--log-level=TRACE", "--data-directory=/tmp/mg_data_coord1", "--log-file=/tmp/coord1.log", "--coordinator-id=1", "--coordinator-port=10111", "--experimental-enabled=high-availability"]
+    network_mode: host
+
+  coord2:
+    image: "memgraph/memgraph-mage"
+    container_name: coord2
+    volumes:
+      - ./license.cypher:/tmp/init/license.cypher:ro
+    command: ["--bolt-port=7691", "--init-file=/tmp/init/license.cypher", "--log-level=TRACE", "--data-directory=/tmp/mg_data_coord2", "--log-file=/tmp/coord2.log", "--coordinator-id=2", "--coordinator-port=10112", "--experimental-enabled=high-availability"]
+    network_mode: host
+
+  coord3:
+    image: "memgraph/memgraph-mage"
+    container_name: coord3
+    volumes:
+      - ./license.cypher:/tmp/init/license.cypher:ro
+    command: ["--bolt-port=7692", "--init-file=/tmp/init/license.cypher", "--log-level=TRACE", "--data-directory=/tmp/mg_data_coord3", "--log-file=/tmp/coord3.log", "--coordinator-id=3", "--coordinator-port=10113", "--experimental-enabled=high-availability"]
+    network_mode: host
+    
+  instance1:
+    image: "memgraph/memgraph-mage"
+    container_name: instance1
+    volumes:
+      - ./license.cypher:/tmp/init/license.cypher:ro
+    command: ["--bolt-port=7687", "--init-file=/tmp/init/license.cypher","--data-recovery-on-startup=true", "--replication-restore-state-on-startup=true",  "--log-level=TRACE", "--data-directory=/tmp/mg_data_instance1", "--log-file=/tmp/instance1.log", "--management-port=10011", "--experimental-enabled=high-availability"]
+    network_mode: host
+    
+  instance2:
+    image: "memgraph/memgraph-mage"
+    container_name: instance2
+    volumes:
+      - ./license.cypher:/tmp/init/license.cypher:ro
+    command: ["--bolt-port=7688", "--init-file=/tmp/init/license.cypher","--data-recovery-on-startup=true", "--replication-restore-state-on-startup=true",  "--log-level=TRACE", "--data-directory=/tmp/mg_data_instance2", "--log-file=/tmp/instance2.log", "--management-port=10012", "--experimental-enabled=high-availability"]
+    network_mode: host
+    
+  instance3:
+    image: "memgraph/memgraph-mage"
+    container_name: instance3
+    volumes:
+      - ./license.cypher:/tmp/init/license.cypher:ro
+    command: ["--bolt-port=7689", "--init-file=/tmp/init/license.cypher","--data-recovery-on-startup=true", "--replication-restore-state-on-startup=true",  "--log-level=TRACE", "--data-directory=/tmp/mg_data_instance3", "--log-file=/tmp/instance3.log", "--management-port=10013", "--experimental-enabled=high-availability"]
+    network_mode: host
+
+```
+
+## Manual Docker setup
 
 This example will show how to set up a highly available cluster in Memgraph using three coordinators and 3 data instances.
 


### PR DESCRIPTION
### Description

Users can start cluster with one command: `docker compose up`. 
Cluster is turned off `docker compose down`.

### Pull request type

Please check what kind of PR this is:

- [x] Fix or improvement of an existing page
- [ ] New documentation page, release related

### Related PRs and issues

PR this doc page is related to: 
(especially necessary if the PR is related to a release)

Closes:
(paste the link to the issue it closes)


### Checklist:

- [x] Check all content with Grammarly
- [x] Perform a self-review of my code
- [x] Make corresponding changes to the rest of the documentation (consult with the DX team)
- [x] The build passes locally
- [x] My changes generate no new warnings or errors
- [x] Add a corresponding label
- [x] If release-related, add a product and version label
- [x] If release-related, add release note on product PR
