### PR TITLE
Remove zoned time as unsupported

### DIFF
--- a/pages/querying/differences-in-cypher-implementations.mdx
+++ b/pages/querying/differences-in-cypher-implementations.mdx
@@ -241,7 +241,6 @@ RETURN val, valueType(val) = "INTEGER"
 ### Unsupported data types
 
 - `POINT` -> Track progress on [GitHub](https://github.com/memgraph/memgraph/issues/1583) and add a comment if you require such a feature.
-- `ZONED TIME` -> Open a [GitHub](https://github.com/memgraph/memgraph/) issue if you require such a feature.
 
 ### Unsupported functions
 


### PR DESCRIPTION
### Description

I removed zoned datetime as unsupported data type since it was added to Memgraph. 

### Pull request type

- [x] Fix or improvement of an existing page

### Checklist:

- [ ] Check all content with Grammarly
- [ ] Perform a self-review of my code
- [ ] Make corresponding changes to the rest of the documentation (consult with the DX team)
- [ ] The build passes locally
- [ ] My changes generate no new warnings or errors
- [ ] Add a corresponding label
- [ ] If release-related, add a product and version label
- [ ] If release-related, add release note on product PR
