### PR TITLE
[main < fix-rn-20240718] Remove release note for feature that was reverted

### DIFF
--- a/pages/release-notes.mdx
+++ b/pages/release-notes.mdx
@@ -192,12 +192,6 @@ If you plan to upgrade to Memgraph v2.18.0 from any previous versions, read the 
 
 {<h3> New features and improvements </h3>}
 
-- Improved the removal process of obsolete indexes. When discarding deltas and
-removing vertices from indexes, Memgraph now targets only the relevant indexes
-instead of processing all indexes, resulting in faster vertex deletion in cases
-with numerous index entries.
-[#2043](https://github.com/memgraph/memgraph/pull/2043)
-
 - Implemented lazy evaluation of replication DNS. When using DNS in replication,
 its resolution is postponed until streaming data using RPC connections,
 improving efficiency in replication setups. The replication durability version


### PR DESCRIPTION
### Description

- Remove entry from release note for a change that was reverted -> https://github.com/memgraph/memgraph/pull/2149

### Pull request type

Please check what kind of PR this is:

- [x] Fix or improvement of an existing page
- [ ] New documentation page, release related

### Related PRs and issues

PR this doc page is related to: 
(especially necessary if the PR is related to a release)

Closes:
(paste the link to the issue it closes)


### Checklist:

- [x] Check all content with Grammarly
- [x] Perform a self-review of my code
- [x] Make corresponding changes to the rest of the documentation (consult with the DX team)
- [x] The build passes locally
- [x] My changes generate no new warnings or errors
- [x] Add a corresponding label
- [ ] If release-related, add a product and version label
- [ ] If release-related, add release note on product PR
