### PR TITLE
Define user with a pre-hashed password

### DIFF
--- a/pages/database-management/authentication-and-authorization/users.mdx
+++ b/pages/database-management/authentication-and-authorization/users.mdx
@@ -58,6 +58,22 @@ Users can change their own password by running the following command:
 SET PASSWORD TO 'newPassword' REPLACE 'oldPassword';
 ```
 
+Password does not need to be in plain-text, a user can be identified via an already hashed password.
+
+Example where "user" is identified by "password":
+```cypher
+CREATE USER user IDENTIFIED BY 'sha256:5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8';
+```
+
+The string identifying the hashed password is formatted as: algorithm-name:hash
+
+Supported algorithms:
+1. "bcrypt"
+1. "sha256"
+1. "sha256-multiple"
+
+Hash is the alphanumerical string of 64 characters for sha256 and 60 characters form bcrypt;
+
 To delete a user, run the following command:
 
 ```cypher


### PR DESCRIPTION
### Description

Describing how users can be defined using prehashed password.

### Pull request type

Please check what kind of PR this is:

- [x] Fix or improvement of an existing page
- [ ] New documentation page, release related

### Related PRs and issues

PR this doc page is related to: 
[2148](https://github.com/memgraph/memgraph/pull/2148)

### Checklist:

- [ ] Check all content with Grammarly
- [ ] Perform a self-review of my code
- [ ] Make corresponding changes to the rest of the documentation (consult with the DX team)
- [ ] The build passes locally
- [ ] My changes generate no new warnings or errors
- [ ] Add a corresponding label
- [ ] If release-related, add a product and version label
- [ ] If release-related, add release note on product PR
