### PR TITLE
Update getting-started docs to specify memgraph-mage container

### DIFF
--- a/pages/getting-started.mdx
+++ b/pages/getting-started.mdx
@@ -96,7 +96,7 @@ You can connect to the Memgraph instance using the command-line interface
 mgconsole by running the following command in a new terminal:
 
 ```terminal
-# with `docker ps` get the Memgraph container id 
+# use `docker ps` to get the Memgraph container id for memgraph-mage
 docker exec -ti <container-id> mgconsole
 ```
 


### PR DESCRIPTION
### Description

The Getting Started page gives directions to open mgconsole by using the Memgraph container id, but there are two containers. This PR specifies the container to use (memgraph-mage) for this step.

### Pull request type

Please check what kind of PR this is:

- [X] Fix or improvement of an existing page
- [ ] New documentation page, release related

### Checklist:

- [X] Check all content with Grammarly
- [X] Perform a self-review of my code
- [ ] Make corresponding changes to the rest of the documentation (consult with the DX team)
- [X] The build passes locally
- [X] My changes generate no new warnings or errors
- [ ] Add a corresponding label  (I do not have permissions to add a label)
- [ ] If release-related, add a product and version label
- [ ] If release-related, add release note on product PR
