### PR TITLE
Mage Node2Vec update after bumping Gensim version

### DIFF
--- a/pages/advanced-algorithms/available-algorithms/node2vec.mdx
+++ b/pages/advanced-algorithms/available-algorithms/node2vec.mdx
@@ -118,10 +118,10 @@ The procedure returns calculated embeddings and the corresponding list of embedd
   training progresses.
 - `sg : {0, 1}` ➡ Training algorithm: 1 for skip-gram; otherwise CBOW.
 - `hs : {0, 1}` ➡ If 1, hierarchical softmax will be used for model training. If
-  0, and `negative` is positive, negative sampling will be used.
+  0, and `negative` is > 0, negative sampling will be used.
 - `negative : integer` ➡ If > 0, negative sampling will be used, the integer for
   negative specifies how many "noise words" should be drawn (usually
-  between 5-20). If set to 0, no negative sampling is used. Either `negative` must be a positive or `hs` must be set to 1.
+  between 5-20). If set to 0, no negative sampling is used. Either `negative` must be > 0 or `hs` must be set to 1.
 - `epochs : integer (default=5)`
 - `edge_weight_property : string (default="weight")`
 

--- a/pages/advanced-algorithms/available-algorithms/node2vec.mdx
+++ b/pages/advanced-algorithms/available-algorithms/node2vec.mdx
@@ -118,10 +118,10 @@ The procedure returns calculated embeddings and the corresponding list of embedd
   training progresses.
 - `sg : {0, 1}` ➡ Training algorithm: 1 for skip-gram; otherwise CBOW.
 - `hs : {0, 1}` ➡ If 1, hierarchical softmax will be used for model training. If
-  0, and `negative` is non-zero, negative sampling will be used.
+  0, and `negative` is positive, negative sampling will be used.
 - `negative : integer` ➡ If > 0, negative sampling will be used, the integer for
   negative specifies how many "noise words" should be drawn (usually
-  between 5-20). If set to 0, no negative sampling is used.
+  between 5-20). If set to 0, no negative sampling is used. Either `negative` must be a positive or `hs` must be set to 1.
 - `epochs : integer (default=5)`
 - `edge_weight_property : string (default="weight")`
 


### PR DESCRIPTION
### Description

Bumping Gensim version from 4.0.0 to 4.3.3 which is used in Node2Vec changed some default values which needed to be updated.

### Pull request type

Please check what kind of PR this is:

- [x] Fix or improvement of an existing page
- [ ] New documentation page, release related

### Related PRs and issues

PR this doc page is related to: 
[MAGE/PR502](https://github.com/memgraph/mage/pull/502)

Closes:
(paste the link to the issue it closes)


### Checklist:

- [x] Check all content with Grammarly
- [x] Perform a self-review of my code
- [x] Make corresponding changes to the rest of the documentation (consult with the DX team)
- [x] The build passes locally
- [x] My changes generate no new warnings or errors
- [x] Add a corresponding label
- [x] If release-related, add a product and version label
- [x] If release-related, add release note on product PR
