### PR TITLE
fix: Add better explanation for Cloud snapshots vs CREATE SNAPSHOT command

### DIFF
--- a/pages/getting-started/install-memgraph/memgraph-cloud.mdx
+++ b/pages/getting-started/install-memgraph/memgraph-cloud.mdx
@@ -13,7 +13,7 @@ allows you to create projects with Enterprise instances of Memgraph from your
 browser. The instances can use up to 32 GB of RAM and up to 8 CPU cores. You can connect to them
 using [Memgraph Lab](/data-visualization), [mgconsole](/getting-started/cli) or
 various [client libraries](/client-libraries). All connections use SSL
-encryption with a self-signed certificate. 
+encryption with a self-signed certificate.
 
 Use Memgraph Cloud to stream data into Memgraph in real-time and run complex
 graph algorithms and modules developed within the [MAGE](/advanced-algorithms)
@@ -34,7 +34,7 @@ with feedback on [Discord](https://discord.com/invite/memgraph):
 
 1. Go to [Memgraph Cloud](https://cloud.memgraph.com).
 2. Log in with a Google account or create a Memgraph Cloud account.
-3. Give your project a name and provide a password. 
+3. Give your project a name and provide a password.
 4. Your project is up and running - connect to the instance, import data and
    start querying!
 
@@ -49,23 +49,23 @@ To create Memgraph Cloud account:
 
 1. Go to [Memgraph Cloud sign-up](https://cloud.memgraph.com/signup) page.
 2. Provide your personal information, set up a password and accept the terms of
-   service. 
+   service.
 3. Verify your email address by clicking on the link in the email you got from
    Memgraph.
 4. Before you start using Cloud, help us by choosing a programming language you
    prefer. In return, we can direct our support better, and adding languages
    that we haven’t listed helps us leave no man behind once a user base is
-   established. 
+   established.
 
 <Callout>
 
-You can also register to Memgraph Cloud with your Google account. 
+You can also register to Memgraph Cloud with your Google account.
 
 </Callout>
 
 
 As a new user, you will start using a 14-day free trial version of Memgraph
-Cloud, in which you can create one project that uses up to 2GB RAM. 
+Cloud, in which you can create one project that uses up to 2GB RAM.
 
 If you require more compute power, enter a valid payment method and upgrade your
 project.
@@ -87,8 +87,8 @@ To change your Memgraph Cloud account password, login into your account and:
 If you forgot your Memgraph Cloud account password, you can reset it:
 
 1. Visit [Forgot your
-   password](https://cloud.memgraph.com/reset-password-request) page. 
-2. Enter your email address and click **Send recovery email**. 
+   password](https://cloud.memgraph.com/reset-password-request) page.
+2. Enter your email address and click **Send recovery email**.
 3. Click on the link in the *Reset the password for Memgraph Cloud* email. It
    will redirect you to the *Reset your password* page.
 4. Enter a new password and **Confirm changes**.
@@ -103,10 +103,10 @@ for Memgraph Cloud projects.
 ### Manage payment methods
 
 In the **Account** section of Memgraph Cloud you can **Add Credit Card**,
-**Redeem Code** or switch to the **Invoice** tab to check paid and due invoices. 
+**Redeem Code** or switch to the **Invoice** tab to check paid and due invoices.
 
 For more details and current rates, visit the [payment](/getting-started/install-memgraph/memgraph-cloud) section of the
-docs. 
+docs.
 
 ## Cloud projects
 
@@ -125,11 +125,11 @@ be made during the project creation process.
 ### Create a new Memgraph Cloud project
 
 If you are using a 14-day free trial version of Memgraph Cloud, you can create
-one project that uses up to 2GB of RAM. 
+one project that uses up to 2GB of RAM.
 
 If you are using a paid version of Memgraph Cloud, you can create a maximum of 3
 projects with the following [rates](#charge-rates). If you need more projects,
-feel free to [contact us](/help-center). 
+feel free to [contact us](/help-center).
 
 To create a new project:
 
@@ -139,7 +139,7 @@ To create a new project:
    Memgraph version and click **Next**.
 4. Add a password to your project to connect to your Memgraph project and click
    **Next**. Keep in mind that Memgraph can't retrieve this password if you lose
-   it. 
+   it.
 5. Click **Go to project** to complete the project creation.
 
 ### Pause, resume or delete a project
@@ -176,10 +176,10 @@ a snapshot if you are using a 14-day free trial version of Memgraph Cloud.
 
 If you are using a paid version of Memgraph Cloud, you can create a maximum of 5
 snapshots with the following [rates](#charge-rates). If you need more snapshots,
-feel free to [contact us](/help-center). 
+feel free to [contact us](/help-center).
 
 The size of the snapshot is 8 GB smaller than the disk size the project is
-using. If you are using 1 GB of RAM and 11 GB of disk, the snapshot size is 3GB. 
+using. If you are using 1 GB of RAM and 11 GB of disk, the snapshot size is 3GB.
 
 To create a snapshot:
 1. Click **Projects** in the left sidebar.
@@ -189,6 +189,20 @@ To create a snapshot:
 
 You can manage your snapshots in the **Snapshots** view, where you can **Edit
 Name** or **Delete Snapshot**.
+
+<Callout>
+
+**Snapshot on the Cloud interface is not the same as the snapshot command in Memgraph:** When
+you run the `CREATE SNAPSHOT` command in Memgraph, it creates a snapshot file on the
+disk. However, this snapshot won't automatically show up in the Cloud interface. The
+snapshots you see in the Cloud interface are copies of the entire disk (like an AWS
+EBS volume), which includes any Memgraph snapshots. Since the Cloud service doesn't
+have access to Memgraph's internal commands for security reasons, it can't automatically
+create a new disk copy when you use `CREATE SNAPSHOT` in Memgraph.
+So, while the command creates a snapshot locally, it doesn't trigger a new snapshot in
+the Cloud interface.
+
+</Callout>
 
 ## Restore or clone a project
 
@@ -201,7 +215,7 @@ To restore or clone a project:
 3. In the **Actions** section, click **Reboot as Project**.
 4. In the pop-up, give the new project a name, set password and select project
    size, then **RESTORE**.
-   
+
 ### Resize a project
 
 When your project becomes to big for the current compute, upgrade it:
@@ -231,15 +245,15 @@ privileges](/database-management/authentication-and-authorization/role-based-acc
 You can connect to an instance running within the Memgraph Cloud project via
 [Memgraph Lab](/data-visualization), a visual interface,
 [mgconsole](/getting-started/cli), command-line interface, or one of many
-[client libraries](#connect-with-clients). 
+[client libraries](#connect-with-clients).
 
 ### Connect with Memgraph Lab
 
 Memgraph Lab comes in two flavors, as a desktop application and as an in-browser
-application. 
+application.
 
 To connect using the in-browser application:
-1. Click **Projects** in the left sidebar. 
+1. Click **Projects** in the left sidebar.
 2. Locate **Connect via client** section.
 3. Click **Connect in browser** button to open Memgraph Lab in your browser. The
    login form will be automatically filled with the connection data, except for
@@ -251,7 +265,7 @@ To use the desktop version of Memgraph Lab:
 1. Download [Memgraph Lab](https://memgraph.com/download/#individual).
 2. Open Memgraph Lab and switch to **Connect Manually**.
 3. Extend the **Advanced Settings** and fill out the connection fields with the
-   data from the **Connect via client** section from the Memgraph Cloud project. 
+   data from the **Connect via client** section from the Memgraph Cloud project.
 4. Enable SSL **Encryption** and **Connect now**.
 
 ### Connect with CLI `mgconsole`
@@ -727,7 +741,7 @@ Read more about it on [Node.js Quick Start Guide](/client-libraries/nodejs).
 ## Payment
 
 Below are instructions on how to manage Memgraph Cloud payment, and current
-Cloud rates. 
+Cloud rates.
 
 ### Add a payment method
 
@@ -738,7 +752,7 @@ To add a payment method:
 3. Verify the credit card
 
 You can replace the current credit card with a new credit card by following the
-same steps, and the **Remove** button will remove the credit card completely. 
+same steps, and the **Remove** button will remove the credit card completely.
 
 ### Redeem coupon code
 
@@ -749,19 +763,19 @@ method](#add-a-payment-method), then:
 2. Enter the coupon code and **Redeem code**
 
 Each code has an expiration date. If you do not create a project or snapshot within
-that period, the code will expire. 
+that period, the code will expire.
 
 Once you redeem a code, it will be applied to your next invoice, regardless of
 the amount of fees on the invoice, which means that the whole coupon will
 applied even if the value of the coupon is higher than the amount of the invoice
-it is applied to. 
+it is applied to.
 
 ### Check paid and due invoices
 
 To check pay and due invoices:
 
 1. Go to **Account** and open the **Invoices** tab
-2. Check an estimate for the next payment or the amount of paid invoices 
+2. Check an estimate for the next payment or the amount of paid invoices
 
 You can also download paid invoices as PDF to check the cost breakdown.
 

--- a/pages/help-center/errors/snapshots.mdx
+++ b/pages/help-center/errors/snapshots.mdx
@@ -37,7 +37,7 @@ start Memgraph again.
 When you stop a Docker container, the data and state within that container are
 preserved until the container is explicitly removed. This means that any data or
 changes you've made within the container are retained and can be accessed again
-when the container is restarted. 
+when the container is restarted.
 
 To access this data, you need to ensure you're starting the same container
 instance that you used previously. Here's how you can do that:
@@ -73,6 +73,17 @@ docker start [CONTAINER_ID]
 
 Replace `[CONTAINER_ID]` with the actual ID you noted down. Once executed, your
 container will be up and running again, with all its data intact.
+
+## Why can't I see a snapshot in the Cloud interface after I call the `CREATE SNAPSHOT` command?
+
+When you run the `CREATE SNAPSHOT` command in Memgraph, it creates a snapshot
+file on the disk. However, this snapshot won't automatically show up in the
+Cloud interface. The snapshots you see in the Cloud interface are copies of
+the entire disk (like an AWS EBS volume), which includes any Memgraph snapshots.
+Since the Cloud service doesn't have access to Memgraph's internal commands
+for security reasons, it can't automatically create a new disk copy when you
+use `CREATE SNAPSHOT` in Memgraph. So, while the command creates a snapshot
+locally, it doesn't trigger a new snapshot in the Cloud interface.
 
 ---
 


### PR DESCRIPTION
### Description

An additional explanation has been added to the `help center > errors > snapshots` and `getting started > cloud > snapshots` to give users more context about Cloud snapshots and their difference from the `CREATE SNAPSHOT` Cypher command within Memgraph.

### Pull request type

Please check what kind of PR this is:

- [x] Fix or improvement of an existing page
- [ ] New documentation page, release related

### Related PRs and issues

None.

### Checklist:

- [x] Check all content with Grammarly
- [x] Perform a self-review of my code
- [x] Make corresponding changes to the rest of the documentation (consult with the DX team)
- [x] The build passes locally
- [x] My changes generate no new warnings or errors
- [x] Add a corresponding label
- [x] If release-related, add a product and version label
- [x] If release-related, add release note on product PR
