### PR TITLE
fix: Fix broken url in release notes

### DIFF
--- a/pages/release-notes.mdx
+++ b/pages/release-notes.mdx
@@ -183,14 +183,14 @@ asterisks (*).
 - Introduced the [`SHOW ACTIVE USERS
 INFO`](/database-management/server-stats#active-users-information) command,
 which allows users to view a list of active users along with detailed session
-information. 
+information.
 [#2183](https://github.com/memgraph/memgraph/pull/2183)
 
 - Added support for [periodic
 commits](/querying/read-and-modify-data#periodic-execution) within Cypher
 queries, allowing for batched execution. This enhancement prevents memory
 exhaustion by committing intermediate results during the execution of large
-queries. 
+queries.
 [#2182](https://github.com/memgraph/memgraph/pull/2182)
 [#2194](https://github.com/memgraph/memgraph/pull/2194)
 [#2196](https://github.com/memgraph/memgraph/pull/2196)
@@ -208,7 +208,7 @@ secure authentication methods.
 
 - Added property compression across the graph using the zlib compression
 library. This feature introduces [new configuration
-flags](/fundamentals/storage-memory-usage/property-compression)
+flags](/fundamentals/storage-memory-usage#property-compression)
 `--storage-property-store-compression-enabled` and
 `--storage-property-store-compression-level`, allowing users to enable
 compression and set the desired compression level.
@@ -223,7 +223,7 @@ compression and set the desired compression level.
 - Optimized the deletion process for nodes and edges by deferring the removal of
 obsolete index entries to the garbage collector (GC). This change improves
 deletion performance by reclaiming memory after the GC cycle instead of
-immediately. 
+immediately.
 [#2242](https://github.com/memgraph/memgraph/pull/2242)
 
 - Fixed an issue where coordinators did not yield leadership according to the


### PR DESCRIPTION
### Description

URL for property-compression in the release notes for Memgraph 2.19 leads to `404 not found`. This PR fixes the link.

### Pull request type

Please check what kind of PR this is:

- [x] Fix or improvement of an existing page
- [ ] New documentation page, release related

### Related PRs and issues

None

### Checklist:

- [x] Check all content with Grammarly
- [x] Perform a self-review of my code
- [x] Make corresponding changes to the rest of the documentation (consult with the DX team)
- [x] The build passes locally
- [x] My changes generate no new warnings or errors
- [x] Add a corresponding label
- [ ] If release-related, add a product and version label
- [ ] If release-related, add release note on product PR
