### PR TITLE
Typo fix in the example for the cpp custom query module

### DIFF
--- a/pages/custom-query-modules/cpp/cpp-example.mdx
+++ b/pages/custom-query-modules/cpp/cpp-example.mdx
@@ -58,7 +58,7 @@ The same goes for `cmake`, you can use any other build system you want or call t
 Now that all of the required dependencies are installed, you can create a directory for your query module. You can do this by running the following command:
 
 ```bash
-mkdir /hello_query_module
+mkdir hello_query_module
 cd hello_query_module
 ```
 


### PR DESCRIPTION
### Description

Fix for the typo when creating a directory in the [C++ example](https://memgraph.com/docs/custom-query-modules/cpp/cpp-example#create-a-directory-for-your-query-module) for the custom query modules section of the docs, reported by user.

### Pull request type

Please check what kind of PR this is:

- [x] Fix or improvement of an existing page


