### PR TITLE
Added links for Ubuntu 24.04 toolchain v5

### DIFF
--- a/pages/getting-started/build-memgraph-from-source.mdx
+++ b/pages/getting-started/build-memgraph-from-source.mdx
@@ -121,6 +121,8 @@ Download the toolchain for your operating system from one of the following links
 - [Ubuntu 20.04](https://s3-eu-west-1.amazonaws.com/deps.memgraph.io/toolchain-v5/toolchain-v5-binaries-ubuntu-20.04-amd64.tar.gz)
 - [Ubuntu 22.04 (x86_64)](https://s3-eu-west-1.amazonaws.com/deps.memgraph.io/toolchain-v5/toolchain-v5-binaries-ubuntu-22.04-amd64.tar.gz)
 - [Ubuntu 22.04 (arm64)](https://s3-eu-west-1.amazonaws.com/deps.memgraph.io/toolchain-v5/toolchain-v5-binaries-ubuntu-22.04-arm64.tar.gz)
+- [Ubuntu 24.04 (x86_64)](https://s3-eu-west-1.amazonaws.com/deps.memgraph.io/toolchain-v5/toolchain-v5-binaries-ubuntu-24.04-amd64.tar.gz)
+- [Ubuntu 24.04 (arm64)](https://s3-eu-west-1.amazonaws.com/deps.memgraph.io/toolchain-v5/toolchain-v5-binaries-ubuntu-24.04-arm64.tar.gz)
 
 Extract the toolchain with the following command:
 


### PR DESCRIPTION
### Description

Starting from this Slack thread: https://memgraph.slack.com/archives/CS5827FK3/p1727682515391479

Added the correct Toolchain v5 links for Ubuntu 24.04 on the "Getting Started > Building Memgraph From Source" page.

### Pull request type

Please check what kind of PR this is:

- [x] Fix or improvement of an existing page
- [ ] New documentation page, release related

### Related PRs and issues

PR this doc page is related to: 
(especially necessary if the PR is related to a release)

Closes:
(paste the link to the issue it closes)


### Checklist:

- [x] Check all content with Grammarly
- [x] Perform a self-review of my code
- [x] Make corresponding changes to the rest of the documentation (consult with the DX team)
- [x] The build passes locally
- [x] My changes generate no new warnings or errors
- [x] Add a corresponding label
- [ ] If release-related, add a product and version label
- [ ] If release-related, add release note on product PR
