### PR TITLE
Changelog for 2.20.1

### DIFF
--- a/pages/release-notes.mdx
+++ b/pages/release-notes.mdx
@@ -193,6 +193,16 @@ Memgraph (v2.11.1 and lower).
   are now aligned. Instead of breaking the connection due to
   permission issues, users will now see "N/A" where applicable.
 
+## Memgraph v2.20.1 - Oct 10, 2024
+
+{<h3> Bug fixes </h3>}
+
+- When a replica gets promoted to main upon [failover](/clustering/high-availability#failover), it will now use correctly incremented durable timestamp. [#2366](https://github.com/memgraph/memgraph/pull/2366)
+- Replica will now take MAIN's [uuid](/clustering/high-availability#how-replica-knows-which-main-to-listen) only when REPLICA's current sequence number is 0. [#2388](https://github.com/memgraph/memgraph/pull/2388)
+- Eliminated deadlock caused by concurrent calls to Stop method on the Scheduler. Eliminated deadlock caused by calling Pause after Stop from different threads. [#2398](https://github.com/memgraph/memgraph/pull/2398)
+- Fixed a problem where [EdgeType index](/fundamentals/indexes#edge-type-index) would assign every element as obsolete which then caused the index to be incorrectly emptied by the GC. Fixed another problem where [EdgeTypeProperty index](/fundamentals/indexes#edge-type-property-index) never ran its GC. Now properly prevents edge index creation when properties-on-edges is disabled - the user must explicitly [provide](/database-management/configuration#storage) --storage-properties-on-edges. Now correctly prevents Edge indices being recovered when properties-on-edges is disabled by causing an assert during recovery. [Replication](/clustering/replication) now updates edge indices. [#2390](https://github.com/memgraph/memgraph/pull/2390)
+- Replica now correctly reflects database registration success or failure.  When replica receives a request for registering replica, it will now return status code NOT_MAIN.  If attempting to undo an incomplete registration fails, then the Memgraph instance will be intentionally crashed because the system is in unrecoverable state.  Main instance can now deal with stale RPC message GetReplicaUUID without crashing the instance.  [#2373](https://github.com/memgraph/memgraph/pull/2373)
+- Closing instance no longer crashes due to [streams](/data-streams) and/or [TTL](/querying/time-to-live) running in the background. [#2361](https://github.com/memgraph/memgraph/pull/2361)
 
 ## Memgraph v2.20.0 - Sep 25, 2024
 
@@ -302,7 +312,7 @@ limit for nodes deemed unhealthy.
 [#2224](https://github.com/memgraph/memgraph/pull/2224)
 
 - Leadership now expires as it was intended, before the election period starts.
-[#2224](https://github.com/memgraph/memgraph/pull/2224
+[#2224](https://github.com/memgraph/memgraph/pull/2224)
 
 - Fixed a bug where no default database was selected when `MG_ENTERPRISE=OFF`.
 [#2267](https://github.com/memgraph/memgraph/pull/2267)

--- a/pages/release-notes.mdx
+++ b/pages/release-notes.mdx
@@ -166,6 +166,17 @@ Memgraph (v2.11.1 and lower).
 
 </Callout>
 
+## Memgraph v2.20.1 - Oct 10, 2024
+
+{<h3> Bug fixes </h3>}
+
+- When a replica gets promoted to main upon [failover](/clustering/high-availability#failover), it will now use correctly incremented durable timestamp. [#2366](https://github.com/memgraph/memgraph/pull/2366)
+- Replica will now take MAIN's [uuid](/clustering/high-availability#how-replica-knows-which-main-to-listen) only when REPLICA's current sequence number is 0. [#2388](https://github.com/memgraph/memgraph/pull/2388)
+- Eliminated deadlock caused by concurrent calls to Stop method on the Scheduler. Eliminated deadlock caused by calling Pause after Stop from different threads. [#2398](https://github.com/memgraph/memgraph/pull/2398)
+- Fixed a problem where [EdgeType index](/fundamentals/indexes#edge-type-index) would assign every element as obsolete which then caused the index to be incorrectly emptied by the GC. Fixed another problem where [EdgeTypeProperty index](/fundamentals/indexes#edge-type-property-index) never ran its GC. Now properly prevents edge index creation when properties-on-edges is disabled - the user must explicitly [provide](/database-management/configuration#storage) --storage-properties-on-edges. Now correctly prevents Edge indices being recovered when properties-on-edges is disabled by causing an assert during recovery. [Replication](/clustering/replication) now updates edge indices. [#2390](https://github.com/memgraph/memgraph/pull/2390)
+- Replica now correctly reflects database registration success or failure.  When replica receives a request for registering replica, it will now return status code NOT_MAIN.  If attempting to undo an incomplete registration fails, then the Memgraph instance will be intentionally crashed because the system is in unrecoverable state.  Main instance can now deal with stale RPC message GetReplicaUUID without crashing the instance.  [#2373](https://github.com/memgraph/memgraph/pull/2373)
+- Closing instance no longer crashes due to [streams](/data-streams) and/or [TTL](/querying/time-to-live) running in the background. [#2361](https://github.com/memgraph/memgraph/pull/2361)
+
 
 ## Lab v2.17.0 - Sep 25, 2024
 
@@ -193,16 +204,6 @@ Memgraph (v2.11.1 and lower).
   are now aligned. Instead of breaking the connection due to
   permission issues, users will now see "N/A" where applicable.
 
-## Memgraph v2.20.1 - Oct 10, 2024
-
-{<h3> Bug fixes </h3>}
-
-- When a replica gets promoted to main upon [failover](/clustering/high-availability#failover), it will now use correctly incremented durable timestamp. [#2366](https://github.com/memgraph/memgraph/pull/2366)
-- Replica will now take MAIN's [uuid](/clustering/high-availability#how-replica-knows-which-main-to-listen) only when REPLICA's current sequence number is 0. [#2388](https://github.com/memgraph/memgraph/pull/2388)
-- Eliminated deadlock caused by concurrent calls to Stop method on the Scheduler. Eliminated deadlock caused by calling Pause after Stop from different threads. [#2398](https://github.com/memgraph/memgraph/pull/2398)
-- Fixed a problem where [EdgeType index](/fundamentals/indexes#edge-type-index) would assign every element as obsolete which then caused the index to be incorrectly emptied by the GC. Fixed another problem where [EdgeTypeProperty index](/fundamentals/indexes#edge-type-property-index) never ran its GC. Now properly prevents edge index creation when properties-on-edges is disabled - the user must explicitly [provide](/database-management/configuration#storage) --storage-properties-on-edges. Now correctly prevents Edge indices being recovered when properties-on-edges is disabled by causing an assert during recovery. [Replication](/clustering/replication) now updates edge indices. [#2390](https://github.com/memgraph/memgraph/pull/2390)
-- Replica now correctly reflects database registration success or failure.  When replica receives a request for registering replica, it will now return status code NOT_MAIN.  If attempting to undo an incomplete registration fails, then the Memgraph instance will be intentionally crashed because the system is in unrecoverable state.  Main instance can now deal with stale RPC message GetReplicaUUID without crashing the instance.  [#2373](https://github.com/memgraph/memgraph/pull/2373)
-- Closing instance no longer crashes due to [streams](/data-streams) and/or [TTL](/querying/time-to-live) running in the background. [#2361](https://github.com/memgraph/memgraph/pull/2361)
 
 ## Memgraph v2.20.0 - Sep 25, 2024
 


### PR DESCRIPTION
### Description

- When a replica gets promoted to main upon [failover](/clustering/high-availability#failover), it will now use correctly incremented durable timestamp. [#2366](https://github.com/memgraph/memgraph/pull/2366)
- Replica will now take MAIN's [uuid](/clustering/high-availability#how-replica-knows-which-main-to-listen) only when REPLICA's current sequence number is 0. [#2388](https://github.com/memgraph/memgraph/pull/2388)
- Eliminated deadlock caused by concurrent calls to Stop method on the Scheduler. Eliminated deadlock caused by calling Pause after Stop from different threads. [#2398](https://github.com/memgraph/memgraph/pull/2398)
- Fixed a problem where [EdgeType index](/fundamentals/indexes#edge-type-index) would assign every element as obsolete which then caused the index to be incorrectly emptied by the GC. Fixed another problem where [EdgeTypeProperty index](/fundamentals/indexes#edge-type-property-index) never ran its GC. Now properly prevents edge index creation when properties-on-edges is disabled - the user must explicitly [provide](/database-management/configuration#storage) --storage-properties-on-edges. Now correctly prevents Edge indices being recovered when properties-on-edges is disabled by causing an assert during recovery. [Replication](/clustering/replication) now updates edge indices. [#2390](https://github.com/memgraph/memgraph/pull/2390)
- Replica now correctly reflects database registration success or failure.  When replica receives a request for registering replica, it will now return status code NOT_MAIN.  If attempting to undo an incomplete registration fails, then the Memgraph instance will be intentionally crashed because the system is in unrecoverable state.  Main instance can now deal with stale RPC message GetReplicaUUID without crashing the instance.  [#2373](https://github.com/memgraph/memgraph/pull/2373)
- Closing instance no longer crashes due to [streams](/data-streams) and/or [TTL](/querying/time-to-live) running in the background. [#2361](https://github.com/memgraph/memgraph/pull/2361)

### Pull request type

Please check what kind of PR this is:

- [ ] Fix or improvement of an existing page
- [ ] New documentation page, release related

### Related PRs and issues

PR this doc page is related to: 
(especially necessary if the PR is related to a release)

Closes:
(paste the link to the issue it closes)


### Checklist:

- [ ] Check all content with Grammarly
- [ ] Perform a self-review of my code
- [ ] Make corresponding changes to the rest of the documentation (consult with the DX team)
- [ ] The build passes locally
- [ ] My changes generate no new warnings or errors
- [ ] Add a corresponding label
- [ ] If release-related, add a product and version label
- [ ] If release-related, add release note on product PR
