### PR TITLE
C++ API remove mgp::memory usage

### DIFF
--- a/pages/custom-query-modules/cpp/cpp-api.md
+++ b/pages/custom-query-modules/cpp/cpp-api.md
@@ -6,30 +6,36 @@ description: Get your hands on the API documentation for mgp.hpp, covering decla
 # Query modules C++ API
 
 This is the API documentation for `mgp.hpp`, which contains declarations of all
-functions in the C++ API for implementing query module procedures and functions.
-The source file can be found in the Memgraph installation directory, under
-`/usr/include/memgraph`.
+functions in the C++ API for implementing query module procedures and
+functions. The source file can be found in the Memgraph installation directory,
+under `/usr/include/memgraph`.
 
-To see how to implement query modules in C++, take a look at
-[the example we provided](/custom-query-modules/python/python-example).
+To see how to implement query modules in C++, take a look at [the example we
+provided](/custom-query-modules/python/python-example).
 
 If you install any C++ modules after running Memgraph, you’ll need to [load
-them into Memgraph](/custom-query-modules/manage-query-modules#loading-query-modules) or restart
-Memgraph in order to use them.
+them into
+Memgraph](/custom-query-modules/manage-query-modules#loading-query-modules) or
+restart Memgraph in order to use them.
 
 ## Functions and procedures
 
-With this API it’s possible to extend your Cypher queries with **functions** and **procedures** with
-`AddProcedure` and `AddFunction`.
+With this API it’s possible to extend your Cypher queries with **functions**
+and **procedures** with `AddProcedure` and `AddFunction`.
 
-The API needs memory access to add procedures and functions, this can be done with `mgp::MemoryDispatcherGuard guard(memory);`. Old code used `mgp::memory = memory;`, but this is not thread-safe and has been deprecated. v2.18.1 onwards you should modify your C++ modules and recompile.
+The API needs memory access to add procedures and functions, this can be done
+with `mgp::MemoryDispatcherGuard guard(memory);`. Old code used `mgp::memory =
+memory;`, but this is not thread-safe and has been deprecated. v2.18.1 onwards
+you should modify your C++ modules and recompile. v2.21 onwards setting
+`mgp::memory` will cause a compilation error, so the guard has to be used.
 
-Functions are simple operations that return a single value and can be used in any expression or predicate.
+Functions are simple operations that return a single value and can be used in
+any expression or predicate.
 
-Procedures are more complex computations that may modify the graph, and their output is available to
-later processing steps in your query. A procedure may only be run from `CALL` clauses.
-The output is a stream of **records** that is made accessible with a `YIELD` clause.
-
+Procedures are more complex computations that may modify the graph, and their
+output is available to later processing steps in your query. A procedure may
+only be run from `CALL` clauses. The output is a stream of **records** that is
+made accessible with a `YIELD` clause.
 
 ### AddProcedure
 

--- a/pages/custom-query-modules/cpp/cpp-api.md
+++ b/pages/custom-query-modules/cpp/cpp-api.md
@@ -22,7 +22,7 @@ Memgraph in order to use them.
 With this API it’s possible to extend your Cypher queries with **functions** and **procedures** with
 `AddProcedure` and `AddFunction`.
 
-The API needs memory access to add procedures and functions, this can be done with either `mgp::MemoryDispatcherGuard guard(memory);` or `mgp::memory = memory;`, where the use of the former is advised since `mgp::memory = memory;` is not thread-safe and will be deprecated in the future.
+The API needs memory access to add procedures and functions, this can be done with `mgp::MemoryDispatcherGuard guard(memory);`. Old code used `mgp::memory = memory;`, but this is not thread-safe and has been deprecated. v2.18.1 onwards you should modify your C++ modules and recompile.
 
 Functions are simple operations that return a single value and can be used in any expression or predicate.
 

--- a/pages/custom-query-modules/cpp/cpp-example.mdx
+++ b/pages/custom-query-modules/cpp/cpp-example.mdx
@@ -392,13 +392,13 @@ void RandomWalk(mgp_list *args, mgp_graph *memgraph_graph, mgp_result *result, m
 
 <Callout type="error">
 
-As `mgp::memory` is a global object, that means all of the procedures and
+`mgp::memory` was a global object, that meant all of the procedures and
 functions in a single shared library will refer to the same `mgp::memory`
 object. As a result, calling such callables simultaneously from multiple threads
 will lead to incorrect memory usage. This also includes the case when the same
-callable is called from different user sessions. This is a constraint when using
-`mgp::memory` so the use of the thread-safe `MemoryDispatcherGuard guard(memory)`
-is advised instead.
+callable is called from different user sessions. For some versions of memgraph 
+this was deprecated and the use of the thread-safe `MemoryDispatcherGuard guard(memory)`
+is advised instead. Its has now been removed and C++ modules should be recompiled for v2.18.1+.
 
 </Callout>
 

--- a/pages/custom-query-modules/cpp/cpp-example.mdx
+++ b/pages/custom-query-modules/cpp/cpp-example.mdx
@@ -394,11 +394,14 @@ void RandomWalk(mgp_list *args, mgp_graph *memgraph_graph, mgp_result *result, m
 
 `mgp::memory` was a global object, that meant all of the procedures and
 functions in a single shared library will refer to the same `mgp::memory`
-object. As a result, calling such callables simultaneously from multiple threads
-will lead to incorrect memory usage. This also includes the case when the same
-callable is called from different user sessions. For some versions of memgraph 
-this was deprecated and the use of the thread-safe `MemoryDispatcherGuard guard(memory)`
-is advised instead. Its has now been removed and C++ modules should be recompiled for v2.18.1+.
+object. As a result, calling such callables simultaneously from multiple
+threads will lead to incorrect memory usage. This also includes the case when
+the same callable is called from different user sessions. For some versions of
+memgraph this was deprecated and the use of the thread-safe
+`MemoryDispatcherGuard guard(memory)` is advised instead. Its has now been
+removed and C++ modules should be recompiled for v2.18.1+. v2.21 onwards
+setting `mgp::memory` will cause a compilation error, so the guard has to be
+used.
 
 </Callout>
 


### PR DESCRIPTION
### Description

Change wording to change the focus around mgp::memory. It was softly deprecated before, but now we want to encourage modules to be updated.

### Pull request type

Please check what kind of PR this is:

- [x] Fix or improvement of an existing page
- [ ] New documentation page, release related

### Related PRs and issues

PR this doc page is related to: 
memgraph/memgraph#2424

Closes:
(paste the link to the issue it closes)


### Checklist:

- [x] Check all content with Grammarly
- [x] Perform a self-review of my code
- [ ] Make corresponding changes to the rest of the documentation (consult with the DX team)
- [ ] The build passes locally
- [ ] My changes generate no new warnings or errors
- [ ] Add a corresponding label
- [ ] If release-related, add a product and version label
- [ ] If release-related, add release note on product PR
