### PR TITLE
Update default value for query log directory

### DIFF
--- a/pages/database-management/configuration.mdx
+++ b/pages/database-management/configuration.mdx
@@ -436,7 +436,7 @@ execution in Memgraph.
 | --query-modules-directory=/usr/lib/memgraph/query_modules                     | Directory where modules with custom query procedures are stored. NOTE: Multiple comma-separated directories can be defined.                                                                                      | `[string]` |
 | --query-plan-cache-max-size=1000                                              | Maximum number of query plans to cache.                                                                                                                                                                          | `[int32]`  |
 | --query-vertex-count-to-expand-existing=10                                    | Maximum count of indexed vertices which provoke indexed lookup and then expand to existing, <br/>instead of a regular expand. Default is 10, to turn off use -1.                                                 | `[int64]`  |
-| --query-log-directory                                                         | Location to store log files for session tracing.                                                                                                                                                                 | `[string]` |
+| --query-log-directory=/var/log/memgraph/session_trace                         | Location to store log files for session tracing.                                                                                                                                                                 | `[string]` |
 
 ### Storage
 

--- a/pages/database-management/monitoring.mdx
+++ b/pages/database-management/monitoring.mdx
@@ -521,7 +521,7 @@ execution. This can be invaluable for understanding performance bottlenecks and 
 
 Before enabling session trace, you need to define a directory where the session logs will be stored. This is done using
 the `--query-log-directory` [configuration flag](/database-management/configuration#query), which can be set either at
-Memgraph startup via the command line, or during an active session.
+Memgraph startup via the command line, or during an active session. By default, `--query-log-directory` is set to `/var/log/memgraph/session_trace`.
 
 To set the query log directory while launching from the command line using Docker, do the following:
 ```shell


### PR DESCRIPTION
### Description

I updated the default value of the query log directory in config and monitoring docs.

Closing #1008 

