### PR TITLE
Add schema assert warning

### DIFF
--- a/pages/fundamentals/indexes.mdx
+++ b/pages/fundamentals/indexes.mdx
@@ -214,7 +214,7 @@ choice may cause queries to perform poorly.
 
 ### Schema-related procedures
 
-You can [delete all node indexes](#delete-all-node-indexes) or modify them using the [`schema.assert()` procedure](/querying/schema#assert).
+You can modify indexes using the [`schema.assert()` procedure](/querying/schema#assert).
 
 ### Speed comparison
 
@@ -284,6 +284,11 @@ These queries instruct all active transactions to abort as soon as possible.
 Once all transactions have finished, the index will be deleted.
 
 ### Delete all node indexes
+
+<Callout type="warning">
+The `schema.assert()` procedure will not drop edge-type and point indexes. 
+Our plan is to update it, and you can track the progress on our [GitHub](https://github.com/memgraph/memgraph/issues/2462). 
+</Callout>
 
 To delete all indexes, use the [`schema.assert()`](/querying/schema#assert) procedure with the following parameters:
 - `indices_map` = `{}`

--- a/pages/querying/schema.mdx
+++ b/pages/querying/schema.mdx
@@ -434,7 +434,13 @@ Results:
 
 #### Delete all node indexes
 
-The `assert()` procedure can be used to delete all indexes and constraints, **except for edge-type indices**. By
+<Callout type="warning">
+The `schema.assert()` procedure will not drop edge-type and point indexes. 
+Our plan is to update it, and you can track the progress on our [GitHub](https://github.com/memgraph/memgraph/issues/2462). 
+</Callout>
+
+
+The `assert()` procedure can be used to delete all indexes and constraints. By
 providing empty `indices_map`, `unique_constraints` and `existence_constraints` as
 well as `drop_existing` set to `true`, ensure that there are no indexes or
 constraints in the database. Here is the query for deleting all indexes and constraints:


### PR DESCRIPTION
### Description

I put a temporary warning that schema assert will not drop all indexes until https://github.com/memgraph/memgraph/issues/2462 is fixed.

