### PR TITLE
Update release notes

### DIFF
--- a/pages/release-notes.mdx
+++ b/pages/release-notes.mdx
@@ -12,64 +12,29 @@ what's new and understand the pivotal shifts that might affect your experience.
 Dive into detailed listings of each version's changes, ensuring you stay
 informed and prepared.
 
-## Important changes
+## Important updates
 
 New releases might affect your existing code, queries or configuration.
 Ensure they're updated to align with the latest updates and changes.
 
-### Upgrading to Memgraph v2.21.0 breaking change
+{<h3>Unavailable algorithms in MAGE v1.14.0 and newer versions</h3>}
 
-<Callout type="error">
+<Callout type="info">
 
-Coordinator log store directory in `--data-directory` needs to be started from
-scratch since new type of Raft log is added and some old ones were deleted.
-Memgraph could crash without deleting old logs from log store directory.
+Due to a symbol loading collision between Memgraph and modules, we have removed
+some modules from MAGE until the issue is resolved. The following algorithms are
+not available in MAGE v1.14.0 and newer versions:
+- [link_prediction with
+  GNN](/advanced-algorithms/available-algorithms/gnn_link_prediction) [#469](https://github.com/memgraph/mage/issues/469)
+- [node_classification with
+  GNN](/advanced-algorithms/available-algorithms/gnn_node_classification) [#470](https://github.com/memgraph/mage/issues/470)
+- [text](/advanced-algorithms/available-algorithms/text) [#448](https://github.com/memgraph/mage/issues/448)
 
-</Callout>
-
-### Upgrading to Memgraph v2.20.0 breaking change
-
-<Callout type="error">
-
-In this version of Memgraph, we have removed the experimental classification for
-system replication.  Going forward, the `--experimental-enabled` configuration
-flag no longer recognizes the `system-replication` argument which was introduced
-in v2.15.
-[System replication](/clustering/replication/system-replication) is now a fully
-supported Enterprise-licensed feature.
+In case you need the above algorithms for your use case, please leave a comment on the issue.
 
 </Callout>
 
-### Upgrading to Memgraph v2.18.0
-
-<Callout type="error">
-
-If you are upgrading to Memgraph v2.18.0 from any previous versions and you
-have a persistent configuration file (docker volumes or native install) due to
-the [breaking changes in the configuration
-file](/release-notes#memgraph-v2180---jul-3-2024) you need to set manually
-`--data-recovery-on-startup=true` to restore data on startup.
-
-If you do not set `--data-recovery-on-startup=true`, Memgraph will start without
-data recovery and your data (snapshots at `var/lib/memgraph/snapshots`) will be
-overwritten by the newly created periodical snapshots, potentially causing data
-loss, depending on the configurations of snapshot creation.
-
-If you think you have experienced data loss and added
-`--data-recovery-on-startup=true`, stopping Memgraph creates a new snapshot by
-default, and starting Memgraph will restore the data from the last snapshot,
-there is a possibility that the snapshot with data is still present in the
-`var/lib/memgraph/snapshots` folder, depending on how long Memgraph was running
-and how many times it was restarted.
-
-To prevent data loss in all cases, before upgrading to Memgraph v2.18.0,
-create a
-[backup of your data directory](https://memgraph.com/docs/deployment/linux#backup-data) (`var/lib/memgraph`).
-
-</Callout>
-
-
-### Transition to multi-container Memgraph Platform from version 2.15
+{<h3>Transition to multi-container Memgraph Platform from version 2.15</h3>}
 
 <Callout type="info">
 
@@ -88,92 +53,18 @@ updated.
 
 </Callout>
 
-### Unavailable algorithms in MAGE v1.14.0 and newer versions
-
-<Callout type="info">
-
-Due to a symbol loading collision between Memgraph and modules, we have removed
-some modules from MAGE until the issue is resolved. The following algorithms are
-not available in MAGE v1.14.0 and newer versions:
-- [link_prediction with
-  GNN](/advanced-algorithms/available-algorithms/gnn_link_prediction)
-- [node_classification with
-  GNN](/advanced-algorithms/available-algorithms/gnn_node_classification)
-- [text](/advanced-algorithms/available-algorithms/text)
-
-</Callout>
-
-### Upgrading to Memgraph v2.15.0
-
-<Callout type="info">
-
-Starting from Memgraph version 2.15.0, password hashing
-has been fortified with salt for improved security. Previously, passwords were
-hashed using SHA256 without salt. Please note that bcrypt, which is the default
-hashing algorithm, has always incorporated salt for enhanced security.
-
-- **Automatic Migration:** Passwords hashed without salt will be automatically
-  reverted to the saltless algorithm upon upgrade. Subsequent successful logins
-  trigger a rehashing process with salt, updating the data on disk.
-- **Seamless Transition:** Most users will experience a seamless transition
-  without any manual intervention. A user's first login post-upgrade triggers
-  the hash update.
-- **Migration Considerations:** Upon starting Memgraph version 2.15.0 for the
-first time, ensure that the `--password-encryption-algorithm` flag is correctly
-set to match the actual hashing algorithm used. This is crucial for maintaining
-authentication data integrity.
-
-</Callout>
-
-### Upgrading to Memgraph v2.13.0
-
-<Callout type="info">
-
-Existence and unique [constraints](/fundamentals/constraints) can now also be
-recovered in parallel, just like [indexes](/fundamentals/indexes). That is why
-the `storage-parallel-index-recovery` configuration flag has been deprecated,
-and now you can enable this behavior using the
-[`storage-parallel-schema-recovery`
-configuration](/configuration/configuration-settings#storage) flag.
-
-</Callout>
-
-### Upgrading to Memgraph v2.12.1
-
-<Callout type="info">
-
-Cached query plans are no longer saved during the time interval defined by the
-`--query-plan-cache-ttl`, rather they are cached by count.
-
-This means that you need to replace any custom setting of the
-`--query-plan-cache-ttl` with the `--query-plan-cache-max-size` [configuration
-flag](/configuration/configuration-settings#query). By default, the maximum
-number of cached query plans is
-1000.
-
-This change has been made to reduce the memory usage of queries with `MERGE`
-queries and variables.
-
-</Callout>
-
-### Upgrading to Memgraph v2.12.0
-
-<Callout type="info">
-
-- The [`SHOW STORAGE INFO;`](/configuration/server-stats) query now returns memory
-allocations in B, KiB, MiB, GiB or TiB, rather than just B so if any of your
-code depends on this information be sure to make the appropriate adjustments.
-
-- Snapshot and WAL files versions have been updated. Snapshot and WAL files created
-with Memgraph v2.12.0 and higher won't be usable in previous versions of
-Memgraph (v2.11.1 and lower).
-
-- You no longer need the MAGE library to run `schema` procedures or
-`convert.str2object()` function.
-
-</Callout>
 
 ## Memgraph v2.21.0 - Nov 6, 2024
+
+{<h3> Upgrading to Memgraph v2.21.0 breaking change </h3>}
+
+<Callout type="info">
+
+Coordinator log store directory in `--data-directory` needs to be started from
+scratch since new type of Raft log is added and some old ones were deleted.
+Memgraph could crash without deleting old logs from log store directory.
+
+</Callout>
 
 {<h3> New features and improvements </h3>}
 
@@ -333,6 +224,19 @@ labeled with `jepsen`).
 
 ## Memgraph v2.20.0 - Sep 25, 2024
 
+{<h3> Upgrading to Memgraph v2.20.0 breaking change </h3>}
+
+<Callout type="info">
+
+In this version of Memgraph, we have removed the experimental classification for
+system replication. Going forward, the `--experimental-enabled` configuration
+flag no longer recognizes the `system-replication` argument which was introduced
+in v2.15.
+[System replication](/clustering/replication/system-replication) is now a fully
+supported Enterprise-licensed feature.
+
+</Callout>
+
 {<h3> New features and improvements </h3>}
 
 - [Enterprise] Graduated replication to “production” from “experimental”. [#2295](https://github.com/memgraph/memgraph/pull/2295)
@@ -359,8 +263,6 @@ labeled with `jepsen`).
 
 ## Memgraph v2.19.0 - Aug 14, 2024
 
-<Callout type="error">
-
 {<h3> Breaking changes </h3>}
 
 - Fixed an issue where `LocalDateTime` did not convert user date to UTC
@@ -375,8 +277,6 @@ accurate `LocalDateTime` conversions.
 ensures that all user data will be recovered on startup without needing to
 specify any configuration options.
 [#2178](https://github.com/memgraph/memgraph/pull/2178)
-
-</Callout>
 
 {<h3> New features and improvements </h3>}
 
@@ -496,8 +396,6 @@ non-negative integer due to bumping Gensim version.
 
 ## Memgraph v2.18.1 - Jul 23, 2024
 
-<Callout type="error">
-
 {<h3> Breaking changes </h3>}
 
 - Introduced [management servers on coordinators](/clustering/high-availability)
@@ -505,8 +403,6 @@ to get the health state of the cluster. Each coordinator now has a management
 server and client connection to all other coordinators. This allows follower
 coordinators to correctly report health states by contacting the leader
 coordinator. [#2138](https://github.com/memgraph/memgraph/pull/2138)
-
-</Callout>
 
 {<h3> New features and improvements </h3>}
 
@@ -563,8 +459,33 @@ the reader was positioned incorrectly.
 
 ## Memgraph v2.18.0 - Jul 3, 2024
 
+{<h3> Upgrading to Memgraph v2.18.0 </h3>}
 
-<Callout type="error">
+<Callout type="info">
+
+If you are upgrading to Memgraph v2.18.0 from any previous versions and you
+have a persistent configuration file (docker volumes or native install) due to
+the [breaking changes in the configuration
+file](/release-notes#memgraph-v2180---jul-3-2024) you need to set manually
+`--data-recovery-on-startup=true` to restore data on startup.
+
+If you do not set `--data-recovery-on-startup=true`, Memgraph will start without
+data recovery and your data (snapshots at `var/lib/memgraph/snapshots`) will be
+overwritten by the newly created periodical snapshots, potentially causing data
+loss, depending on the configurations of snapshot creation.
+
+If you think you have experienced data loss and added
+`--data-recovery-on-startup=true`, stopping Memgraph creates a new snapshot by
+default, and starting Memgraph will restore the data from the last snapshot,
+there is a possibility that the snapshot with data is still present in the
+`var/lib/memgraph/snapshots` folder, depending on how long Memgraph was running
+and how many times it was restarted.
+
+To prevent data loss in all cases, before upgrading to Memgraph v2.18.0,
+create a
+[backup of your data directory](https://memgraph.com/docs/deployment/linux#backup-data) (`var/lib/memgraph`).
+
+</Callout>
 
 {<h3> Breaking changes </h3>}
 
@@ -593,16 +514,6 @@ snapshot durability if required.
   `--auth-module-create-missing-user`, `--auth-module-create-missing-role`,
   `--auth-module-manage-roles`, `--storage-parallel-index-recovery`.
 [#1916](https://github.com/memgraph/memgraph/pull/1916)
-
-</Callout>
-
-<Callout type="error">
-
-If you plan to upgrade to Memgraph v2.18.0 from any
-previous versions, read the [important upgrade
-information](/release-notes#upgrading-to-memgraph-v2180) to prevent data loss.
-
-</Callout>
 
 
 {<h3> New features and improvements </h3>}
@@ -805,8 +716,6 @@ correctly.
 
 ## Memgraph v2.17.0 - May 22, 2024
 
-<Callout type="error">
-
 {<h3> Breaking changes </h3>}
 
 - The flag
@@ -821,8 +730,6 @@ the WebSocket server fails, the `LoggerSink` will not be added to it.
 Additionally, Memgraph will crash if the authentication folder cannot be
 created.
 [#2017](https://github.com/memgraph/memgraph/pull/2017)
-
-</Callout>
 
 {<h3> New features and improvements </h3>}
 
@@ -875,8 +782,6 @@ successfully created once it behaves as a leader.
 
 ## Memgraph v2.16.1 - May 15, 2024
 
-<Callout type="error">
-
 {<h3> Breaking changes </h3>}
 
 - Replicate only durable commits to replicas during recovery. This ensures that
@@ -885,7 +790,6 @@ successfully created once it behaves as a leader.
   improving overall system consistency.
   [#1991](https://github.com/memgraph/memgraph/pull/1991)
 
-</Callout>
 
 {<h3> New features and improvements </h3>}
 
@@ -1190,6 +1094,28 @@ of new transactions. [#1759](https://github.com/memgraph/memgraph/pull/1759)
 
 ## Memgraph v2.15.0 - Feb 28, 2024
 
+{<h3> Upgrading to Memgraph v2.15.0 </h3>}
+
+<Callout type="info">
+
+Starting from Memgraph version 2.15.0, password hashing
+has been fortified with salt for improved security. Previously, passwords were
+hashed using SHA256 without salt. Please note that bcrypt, which is the default
+hashing algorithm, has always incorporated salt for enhanced security.
+
+- **Automatic Migration:** Passwords hashed without salt will be automatically
+  reverted to the saltless algorithm upon upgrade. Subsequent successful logins
+  trigger a rehashing process with salt, updating the data on disk.
+- **Seamless Transition:** Most users will experience a seamless transition
+  without any manual intervention. A user's first login post-upgrade triggers
+  the hash update.
+- **Migration Considerations:** Upon starting Memgraph version 2.15.0 for the
+first time, ensure that the `--password-encryption-algorithm` flag is correctly
+set to match the actual hashing algorithm used. This is crucial for maintaining
+authentication data integrity.
+
+</Callout>
+
 {<h3> New features and improvements </h3>}
 
 - Enhanced security by integrating a password hashing algorithm into
@@ -1309,7 +1235,6 @@ of new transactions. [#1759](https://github.com/memgraph/memgraph/pull/1759)
   restored to its prior condition only when changes have occurred.
   [#1745](https://github.com/memgraph/memgraph/pull/1745)
 
-
 ## MAGE v1.15.0 - Feb 28, 2024
 
 {<h3> Bug fixes </h3>}
@@ -1423,6 +1348,19 @@ of new transactions. [#1759](https://github.com/memgraph/memgraph/pull/1759)
   now properly handled. [#400](https://github.com/memgraph/mage/pull/400)
 
 ## Memgraph v2.13.0 - Dec 8, 2023
+ 
+{<h3> Upgrading to Memgraph v2.13.0 </h3>}
+
+<Callout type="info">
+
+Existence and unique [constraints](/fundamentals/constraints) can now also be
+recovered in parallel, just like [indexes](/fundamentals/indexes). That is why
+the `storage-parallel-index-recovery` configuration flag has been deprecated,
+and now you can enable this behavior using the
+[`storage-parallel-schema-recovery`
+configuration](/configuration/configuration-settings#storage) flag.
+
+</Callout>
 
 {<h3> New features and improvements </h3>}
 
@@ -1513,6 +1451,24 @@ of new transactions. [#1759](https://github.com/memgraph/memgraph/pull/1759)
 - Changes to internal utilities. [#415](https://github.com/memgraph/mage/pull/415)
 
 ## Memgraph v2.12.1 - Nov 17, 2023
+
+{<h3>Upgrading to Memgraph v2.12.1</h3>}
+
+<Callout type="info">
+
+Cached query plans are no longer saved during the time interval defined by the
+`--query-plan-cache-ttl`, rather they are cached by count.
+
+This means that you need to replace any custom setting of the
+`--query-plan-cache-ttl` with the `--query-plan-cache-max-size` [configuration
+flag](/configuration/configuration-settings#query). By default, the maximum
+number of cached query plans is
+1000.
+
+This change has been made to reduce the memory usage of queries with `MERGE`
+queries and variables.
+
+</Callout>
 
 {<h3> New features and improvements </h3>}
 
@@ -1612,6 +1568,23 @@ of new transactions. [#1759](https://github.com/memgraph/memgraph/pull/1759)
   versions higher than `2.12.1`.
 
 ## Memgraph v2.12.0 - Nov 1, 2023
+
+{<h3>Upgrading to Memgraph v2.12.0</h3>}
+
+<Callout type="info">
+
+- The [`SHOW STORAGE INFO;`](/configuration/server-stats) query now returns memory
+allocations in B, KiB, MiB, GiB or TiB, rather than just B so if any of your
+code depends on this information be sure to make the appropriate adjustments.
+
+- Snapshot and WAL files versions have been updated. Snapshot and WAL files created
+with Memgraph v2.12.0 and higher won't be usable in previous versions of
+Memgraph (v2.11.1 and lower).
+
+- You no longer need the MAGE library to run `schema` procedures or
+`convert.str2object()` function.
+
+</Callout>
 
 {<h3> New features and improvements </h3>}
 
@@ -3209,16 +3182,12 @@ Golang's client. [#667](https://github.com/memgraph/memgraph/pull/667)
 
 ## Memgraph v2.1.1 - Dec 07, 2021
 
-<Callout type="error">
-
 {<h3> Breaking Changes </h3>}
 
 - Loading streams created by versions of Memgraph older than 2.1 is not
   possible. We suggest you extract the necessary information using the older
   version of Memgraph and recreate the streams in a newer version (Memgraph 2.1
   and newer).
-
-</Callout>
 
 {<h3> Major Features and Improvements </h3>}
 
@@ -3245,8 +3214,6 @@ Golang's client. [#667](https://github.com/memgraph/memgraph/pull/667)
 
 ## Memgraph v2.1.0 - Nov 22, 2021
 
-<Callout type="error">
-
 {<h3> Breaking Changes </h3>}
 
 - Loading streams created by older versions cause Memgraph to crash. The only
@@ -3257,8 +3224,6 @@ Golang's client. [#667](https://github.com/memgraph/memgraph/pull/667)
   is `/var/lib/memgraph` by default).
 - The query for creating a Kafka stream now requires the `KAFKA` keyword. The
   previous form `CREATE STREAM ...` was changed to `CREATE KAFKA STREAM ...`.
-
-</Callout>
 
 {<h3> Major Features and Improvements </h3>}
 
@@ -3348,8 +3313,6 @@ Golang's client. [#667](https://github.com/memgraph/memgraph/pull/667)
 
 ## Memgraph v2.0.0 - Oct 5, 2021
 
-<Callout type="error">
-
 {<h3> Breaking Changes </h3>}
 
 - Changed the `timestamp()` function to return `microseconds` instead of
@@ -3362,8 +3325,6 @@ Golang's client. [#667](https://github.com/memgraph/memgraph/pull/667)
 - The first user created using the `CREATE USER` query will have all the
   privileges granted to him. Previously, you could've locked yourself out of
   Memgraph by creating a user and immediately disconnecting.
-
-</Callout>
 
 {<h3> Major Features and Improvements </h3>}
 
@@ -3432,13 +3393,10 @@ Golang's client. [#667](https://github.com/memgraph/memgraph/pull/667)
 
 ## Memgraph v1.6.0 - Jul 7, 2021
 
-<Callout type="error">
-
 {<h3> Breaking Changes </h3>}
 
 - Changed the `LOCK_PATH` permission to `DURABILITY`.
 
-</Callout>
 
 {<h3> Major Features and Improvements </h3>}
 
@@ -3505,13 +3463,9 @@ Golang's client. [#667](https://github.com/memgraph/memgraph/pull/667)
 
 ## Memgraph v1.4.0 - Apr 2, 2021
 
-<Callout type="error">
-
 {<h3> Breaking Changes </h3>}
 
 - Changed `MEMORY LIMIT num (KB|MB)` clause in the procedure calls to `PROCEDURE MEMORY LIMIT num (KB|MB)`. The functionality is still the same.
-
-</Callout>
 
 {<h3> Major Features and Improvements </h3>}
 
@@ -3578,16 +3532,12 @@ Golang's client. [#667](https://github.com/memgraph/memgraph/pull/667)
 
 ## Memgraph v1.3.0 - Jan 26, 2021
 
-<Callout type="error">
-
 {<h3> Breaking Changes </h3>}
 
 - Added extra information in durability files to support replication, making it
   incompatible with the durability files generated by older versions of
   Memgraph. Even though the replication is an Enterprise feature, the files are
   compatible with the Community version.
-
-</Callout>
 
 {<h3> Major Features and Improvements </h3>}
 
@@ -3629,14 +3579,10 @@ Golang's client. [#667](https://github.com/memgraph/memgraph/pull/667)
 
 ## Memgraph v1.2.0 - Oct 20, 2020
 
-<Callout type="error">
-
 {<h3> Breaking Changes </h3>}
 
 - SSL is disabled by default (`--bolt-cert-file` and `--bolt-key-file are
   empty`). This change might only affect the client connection configuration.
-
-</Callout>
 
 {<h3> Major Features and Improvements </h3>}
 
@@ -3808,8 +3754,6 @@ Golang's client. [#667](https://github.com/memgraph/memgraph/pull/667)
 
 ## Memgraph v0.50.0 - Dec 11, 2019
 
-<Callout type="error">
-
 {<h3> Breaking Changes </h3>}
 
 - [Enterprise Ed.] Remove support for Kafka streams.
@@ -3818,8 +3762,6 @@ Golang's client. [#667](https://github.com/memgraph/memgraph/pull/667)
 - Label indexes aren't created automatically, create them explicitly instead.
 - Renamed several database flags. Please see the configuration file for a list
   of current flags.
-
-</Callout>
 
 {<h3> Major Features and Improvements </h3>}
 
@@ -3844,8 +3786,6 @@ Golang's client. [#667](https://github.com/memgraph/memgraph/pull/667)
 
 ## Memgraph v0.15.0 - Jul 17, 2019
 
-<Callout type="error">
-
 {<h3> Breaking Changes </h3>}
 
 - Snapshot and write-ahead log format changed (not backward compatible).
@@ -3853,8 +3793,6 @@ Golang's client. [#667](https://github.com/memgraph/memgraph/pull/667)
 - Removed support for unique index. Use unique constraints instead.
 - `CREATE UNIQUE INDEX ON :label (property)` replaced with `CREATE CONSTRAINT ON (n:label) ASSERT n.property IS UNIQUE`.
 - Changed semantics for `COUNTER` openCypher function.
-
-</Callout>
 
 {<h3> Major Features and Improvements </h3>}
 
@@ -3889,13 +3827,9 @@ Golang's client. [#667](https://github.com/memgraph/memgraph/pull/667)
 
 ## Memgraph v0.14.0 - Oct 30, 2018
 
-<Callout type="error">
-
 {<h3> Breaking Changes </h3>}
 
 - Write-ahead log format changed (not backward compatible).
-
-</Callout>
 
 {<h3> Major Features and Improvements </h3>}
 
@@ -3912,14 +3846,10 @@ Golang's client. [#667](https://github.com/memgraph/memgraph/pull/667)
 
 ## Memgraph v0.13.0 - Oct 18, 2018
 
-<Callout type="error">
-
 {<h3> Breaking Changes </h3>}
 
 - Write-ahead log format changed (not backward compatible).
 - Snapshot format changed (not backward compatible).
-
-</Callout>
 
 {<h3> Major Features and Improvements </h3>}
 
@@ -3947,13 +3877,9 @@ Golang's client. [#667](https://github.com/memgraph/memgraph/pull/667)
 
 ## Memgraph v0.12.0 - Jul 4, 2018
 
-<Callout type="error">
-
 {<h3> Breaking Changes </h3>}
 
 - Snapshot format changed (not backward compatible).
-
-</Callout>
 
 {<h3> Major Features and Improvements </h3>}
 
@@ -3984,13 +3910,9 @@ Golang's client. [#667](https://github.com/memgraph/memgraph/pull/667)
 
 ## Memgraph v0.10.0 - Apr 24, 2018
 
-<Callout type="error">
-
 {<h3> Breaking Changes </h3>}
 
 - Snapshot format changed (not backward compatible).
-
-</Callout>
 
 {<h3> Major Features and Improvements </h3>}
 
@@ -4016,14 +3938,10 @@ Golang's client. [#667](https://github.com/memgraph/memgraph/pull/667)
 
 ## Memgraph v0.9.0 - Dec 18, 2017
 
-<Callout type="error">
-
 {<h3> Breaking Changes </h3>}
 
 - Snapshot format changed (not backward compatible).
 - Snapshot configuration flags changed, general durability flags added.
-
-</Callout>
 
 {<h3> Major Features and Improvements </h3>}
 


### PR DESCRIPTION
### Description

I updated the release notes so they don't have red warnings at the beginning of the document. I turned all error warnings into info (blue) and put them under the related release. 

Closes #1042 