### PR TITLE
fix: Fix the incorrect inline reference for GSS

### DIFF
--- a/pages/data-visualization/graph-style-script/directive-properties.md
+++ b/pages/data-visualization/graph-style-script/directive-properties.md
@@ -400,7 +400,7 @@ Example:
 
 Sets the element's background to be an image from the image URL. Supported
 format are `png`, `jpeg`, `gif` (static, not dynamic), `webp` or base 64 encoded
-image using `inline data:image/png;base64`.
+image using inline `data:image/png;base64`.
 
 
  It will
@@ -418,7 +418,7 @@ Examples:
 
 Sets the element's background to be an image from the image URL on mouse select
 event. Supported format are `png`, `jpeg`, `gif` (static, not dynamic), `webp`
-or base 64 encoded image using `inline data:image/png;base64`. It will override
+or base 64 encoded image using inline `data:image/png;base64`. It will override
 the value defined with the property `color-selected`.
 
 Example:


### PR DESCRIPTION
### Release note

Inline image value in GSS was incorrectly styled with markdown adding confusion for the users.

### Related product PRs

-

### Checklist:

- [ ] Add appropriate milestone (current release cycle)
- [x] Add `bugfix` or `feature` label, based on the product PR type you're documenting
- [ ] Make sure all relevant tech details are documented
    - [ ] Update reference pages (e.g. [clauses](https://memgraph.com/docs/querying/clauses), [functions](https://memgraph.com/docs/querying/functions), [flags](https://memgraph.com/docs/database-management/configuration#list-of-configuration-flags), [experimental](https://memgraph.com/docs/database-management/experimental-features), [monitoring](https://memgraph.com/docs/database-management/monitoring), [Cypher differences](https://memgraph.com/docs/querying/differences-in-cypher-implementations))
    - [ ] Search for the feature you are working on (mentions) and make updates if needed
    - [ ] Provide a basic example of usage
    - [ ] In case your feature is an Enterprise one, list it under [ME page](https://memgraph.com/docs/database-management/enabling-memgraph-enterprise) and mark its page with Enterprise ([example](https://memgraph.com/docs/database-management/authentication-and-authorization/role-based-access-control)).
- [x] Check all content with Grammarly
- [x] Perform a self-review of my code
- [x] The build passes locally
- [x] My changes generate no new warnings or errors