### PR TITLE
Update error message when unloading query modules

### DIFF
--- a/pages/custom-query-modules/manage-query-modules.mdx
+++ b/pages/custom-query-modules/manage-query-modules.mdx
@@ -127,7 +127,10 @@ update was successful.
 Loads or reloads the given module. Module name provided in the input file is a string of the module name, without the file extension.
 A module can only be reloaded if it is not in use, and if it exists in the module directory.
 If the module that would be reloaded is being used by another thread while this is run then this will fail
-the error: `Unable to unload module 'module_name', either it doesn't exist, or it is currently being used.`.
+the error: `Unable to unload module 'module_name', either it doesn't exist, or it is currently being used.
+In order to check whether the module exists, please use CALL mg.procedures() YIELD * for custom
+query procedures, or CALL mg.functions() YIELD * for custom query functions.`
+
 To resolve this rerun the procedure when the module isn't in use.
 
 Example of a Cypher query:

--- a/pages/custom-query-modules/manage-query-modules.mdx
+++ b/pages/custom-query-modules/manage-query-modules.mdx
@@ -124,7 +124,11 @@ update was successful.
 
 ### `mg.load`
 
-Loads or reloads the given module. A module can only be reloaded if it is not in use. If the module that would be reloaded is being used by another thread while this is run then this will fail the error: `Unable to unload module 'module_name', it is currently being used`. To resolve this rerun the procedure when the module isn't in use.
+Loads or reloads the given module. Module name provided in the input file is a string of the module name, without the file extension.
+A module can only be reloaded if it is not in use, and if it exists in the module directory.
+If the module that would be reloaded is being used by another thread while this is run then this will fail
+the error: `Unable to unload module 'module_name', either it doesn't exist, or it is currently being used.`.
+To resolve this rerun the procedure when the module isn't in use.
 
 Example of a Cypher query:
 

--- a/pages/custom-query-modules/manage-query-modules.mdx
+++ b/pages/custom-query-modules/manage-query-modules.mdx
@@ -124,9 +124,9 @@ update was successful.
 
 ### `mg.load`
 
-Loads or reloads the given module. Module name provided in the input file is a string of the module name, without the file extension.
-A module can only be reloaded if it is not in use, and if it exists in the module directory.
-If the module that would be reloaded is being used by another thread while this is run then this will fail
+Loads or reloads the given module. The module name provided in the input file is a module name string without the file extension.
+A module can only be reloaded if it is not in use and if it exists in the module directory.
+If the module that would be reloaded is being used by another thread while this is run, then this will fail
 the error: `Unable to unload module 'module_name', either it doesn't exist, or it is currently being used.
 In order to check whether the module exists, please use CALL mg.procedures() YIELD * for custom
 query procedures, or CALL mg.functions() YIELD * for custom query functions.`


### PR DESCRIPTION
### Release note

Error message updated in the documentation for unloading query modules.

### Related product PRs

https://github.com/memgraph/memgraph/issues/2548

### Checklist:

- [X] Add appropriate milestone (current release cycle)
- [X] Add `bugfix` or `feature` label, based on the product PR type you're documenting
- [X] Make sure all relevant tech details are documented
    - [X] Update reference pages (e.g. [clauses](https://memgraph.com/docs/querying/clauses), [functions](https://memgraph.com/docs/querying/functions), [flags](https://memgraph.com/docs/database-management/configuration#list-of-configuration-flags), [experimental](https://memgraph.com/docs/database-management/experimental-features), [monitoring](https://memgraph.com/docs/database-management/monitoring), [Cypher differences](https://memgraph.com/docs/querying/differences-in-cypher-implementations))
    - [X] Search for the feature you are working on (mentions) and make updates if needed
    - [X] Provide a basic example of usage
    - [X] In case your feature is an Enterprise one, list it under [ME page](https://memgraph.com/docs/database-management/enabling-memgraph-enterprise) and mark its page with Enterprise ([example](https://memgraph.com/docs/database-management/authentication-and-authorization/role-based-access-control)).
- [X] Check all content with Grammarly
- [X] Perform a self-review of my code
- [X] The build passes locally
- [X] My changes generate no new warnings or errors