### PR TITLE
Update `convert.str2object` function documentation

### DIFF
--- a/pages/querying/functions.mdx
+++ b/pages/querying/functions.mdx
@@ -174,6 +174,6 @@ All aggregation functions can be used with the `DISTINCT` operator to perform ca
 
 ### Conversion functions
 
- | Name                 | Signature                                                          | Description                                                                                           |
- | -------------------- | ------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------- |
- | `convert.str2object` | `convert.str2object(string: string) -> (object: any)`              | Converts the input string to an object it presents using Python's `json.dumps` function.                |
+ | Name                 | Signature                                                          | Description                                         |
+ | -------------------- | ------------------------------------------------------------------ | --------------------------------------------------- |
+ | `convert.str2object` | `convert.str2object(string: string) -> (object: any)`              | Converts the input string to an object it presents. |


### PR DESCRIPTION
### Release note

Documentation for `convert.str2object` is updated because it was rewritten to C++.

### Related product PRs

PRs from product repo this doc page is related to: 
(paste the links to the PRs)

### Checklist:

- [X] Add appropriate milestone (current release cycle)
- [X] Add `bugfix` or `feature` label, based on the product PR type you're documenting
- [X] Make sure all relevant tech details are documented
    - [X] Update reference pages (e.g. [clauses](https://memgraph.com/docs/querying/clauses), [functions](https://memgraph.com/docs/querying/functions), [flags](https://memgraph.com/docs/database-management/configuration#list-of-configuration-flags), [experimental](https://memgraph.com/docs/database-management/experimental-features), [monitoring](https://memgraph.com/docs/database-management/monitoring), [Cypher differences](https://memgraph.com/docs/querying/differences-in-cypher-implementations))
    - [X] Search for the feature you are working on (mentions) and make updates if needed
    - [X] Provide a basic example of usage
    - [X] In case your feature is an Enterprise one, list it under [ME page](https://memgraph.com/docs/database-management/enabling-memgraph-enterprise) and mark its page with Enterprise ([example](https://memgraph.com/docs/database-management/authentication-and-authorization/role-based-access-control)).
- [X] Check all content with Grammarly
- [X] Perform a self-review of my code
- [X] The build passes locally
- [X] My changes generate no new warnings or errors