### PR TITLE
Remove warning

### DIFF
--- a/pages/fundamentals/indexes.mdx
+++ b/pages/fundamentals/indexes.mdx
@@ -133,15 +133,6 @@ labels and properties inside the `MATCH` pattern.
 
 ### Edge-type index
 
-<Callout type="warning">
-We've identified a **critical issue** with edge-type indexes during
-rollbacks/aborts. The current behavior is inherently unsafe. 
-
-**Avoid using edge-type indexes for now**. A safer, more reliable version is
-expected in the next release by the end of January 2025. We appreciate your
-understanding and patience. 
-</Callout>
-
 To optimize queries that fetch only the edges by specific edge-types, you need
 to create an edge-type index. Creating an edge-type index requires the
 `--storage-properties-on-edges` flag to be set to true.
@@ -165,15 +156,6 @@ Named parameters are not supported for edge-type indexes.
 </Callout>
 
 ### Edge-type property index
-
-<Callout type="warning">
-We've identified a **critical issue** with edge-type property indexes during
-rollbacks/aborts. The current behavior is inherently unsafe. 
-
-**Avoid using edge-type property indexes for now**. A safer, more reliable version is
-expected in the next release by the end of January 2025. We appreciate your
-understanding and patience. 
-</Callout>
 
 To optimize queries that fetch only the edges by specific edge types and
 properties, you need to create an edge-type property index. Creating an


### PR DESCRIPTION
### Release note

We’ve fixed a critical issue with edge-type indexes during rollbacks/aborts.

### Related product PRs

PRs from product repo this doc page is related to: 
https://github.com/memgraph/memgraph/pull/2596

Closing #1091 

### Checklist:

- [x] Add appropriate milestone (current release cycle)
- [x] Add `bugfix` or `feature` label, based on the product PR type you're documenting
- [x] Make sure all relevant tech details are documented
    - [x] Update reference pages (e.g. [clauses](https://memgraph.com/docs/querying/clauses), [functions](https://memgraph.com/docs/querying/functions), [flags](https://memgraph.com/docs/database-management/configuration#list-of-configuration-flags), [experimental](https://memgraph.com/docs/database-management/experimental-features), [monitoring](https://memgraph.com/docs/database-management/monitoring), [Cypher differences](https://memgraph.com/docs/querying/differences-in-cypher-implementations))
    - [x] Search for the feature you are working on (mentions) and make updates if needed
    - [x] Provide a basic example of usage
    - [x] In case your feature is an Enterprise one, list it under [ME page](https://memgraph.com/docs/database-management/enabling-memgraph-enterprise) and mark its page with Enterprise ([example](https://memgraph.com/docs/database-management/authentication-and-authorization/role-based-access-control)).
- [x] Check all content with Grammarly
- [x] Perform a self-review of my code
- [x] The build passes locally
- [x] My changes generate no new warnings or errors