### PR TITLE
Wrong information for HA docker compose setup

### DIFF
--- a/pages/clustering/high-availability.mdx
+++ b/pages/clustering/high-availability.mdx
@@ -562,16 +562,19 @@ You can directly use initialization file `HA_register.cypherl`:
 
 ```
 
-ADD COORDINATOR 1 WITH CONFIG {"bolt_server": "coord1:7691", "coordinator_server": "coord1:10111", "management_server": "coord1:12121"};
-ADD COORDINATOR 2 WITH CONFIG {"bolt_server": "coord2:7692", "coordinator_server": "coord2:10112", "management_server": "coord2:12122"};
-ADD COORDINATOR 3 WITH CONFIG {"bolt_server": "coord3:7693", "coordinator_server": "coord3:10113", "management_server": "coord3:12123"};
+ADD COORDINATOR 1 WITH CONFIG {"bolt_server": "localhost:7691", "coordinator_server": "coord1:10111", "management_server": "coord1:12121"};
+ADD COORDINATOR 2 WITH CONFIG {"bolt_server": "localhost:7692", "coordinator_server": "coord2:10112", "management_server": "coord2:12122"};
+ADD COORDINATOR 3 WITH CONFIG {"bolt_server": "localhost:7693", "coordinator_server": "coord3:10113", "management_server": "coord3:12123"};
 
-REGISTER INSTANCE instance_1 WITH CONFIG {"bolt_server": "instance1:7687", "management_server": "instance1:13011", "replication_server": "instance1:10001"};
-REGISTER INSTANCE instance_2 WITH CONFIG {"bolt_server": "instance2:7688", "management_server": "instance2:13012", "replication_server": "instance2:10002"};
-REGISTER INSTANCE instance_3 WITH CONFIG {"bolt_server": "instance3:7689", "management_server": "instance3:13013", "replication_server": "instance3:10003"};
+REGISTER INSTANCE instance_1 WITH CONFIG {"bolt_server": "localhost:7687", "management_server": "instance1:13011", "replication_server": "instance1:10001"};
+REGISTER INSTANCE instance_2 WITH CONFIG {"bolt_server": "localhost:7688", "management_server": "instance2:13012", "replication_server": "instance2:10002"};
+REGISTER INSTANCE instance_3 WITH CONFIG {"bolt_server": "localhost:7689", "management_server": "instance3:13013", "replication_server": "instance3:10003"};
 SET INSTANCE instance_3 TO MAIN;
 
 ```
+
+Bolt servers in docker compose setup need to always have localhost defined as `bolt_server` because the host
+is not able to resolve the IP for coordinators and data instances.
 
 You can directly use the following `docker-compose.yml` to start the cluster using `docker compose up`:
 

--- a/pages/clustering/high-availability.mdx
+++ b/pages/clustering/high-availability.mdx
@@ -547,7 +547,7 @@ You can see example configurations [here](/getting-started/install-memgraph/kube
 
 ## Docker Compose
 
-The following example shows you how to setup Memgraph cluster using docker compose. The cluster will use user-defined bridge network.
+The following example shows you how to setup Memgraph cluster using Docker Compose. The cluster will use user-defined bridge network.
 
 License file `license.cypherl` should be in the format:
 
@@ -573,8 +573,8 @@ SET INSTANCE instance_3 TO MAIN;
 
 ```
 
-Bolt servers in docker compose setup need to always have localhost defined as `bolt_server` because the host
-is not able to resolve the IP for coordinators and data instances.
+Since the host can't resolve the IP for coordinators and data instances, Bolt
+servers in Docker Compose setup require `bolt_server` set to `localhost:<port>`.
 
 You can directly use the following `docker-compose.yml` to start the cluster using `docker compose up`:
 


### PR DESCRIPTION
### Release note

Changing the hostname for coordinators and data instances in docker compose.

### Checklist:

- [X] Add appropriate milestone (current release cycle)
- [X] Add `bugfix` or `feature` label, based on the product PR type you're documenting
- [X] Make sure all relevant tech details are documented
    - [X] Update reference pages (e.g. [clauses](https://memgraph.com/docs/querying/clauses), [functions](https://memgraph.com/docs/querying/functions), [flags](https://memgraph.com/docs/database-management/configuration#list-of-configuration-flags), [experimental](https://memgraph.com/docs/database-management/experimental-features), [monitoring](https://memgraph.com/docs/database-management/monitoring), [Cypher differences](https://memgraph.com/docs/querying/differences-in-cypher-implementations))
    - [X] Search for the feature you are working on (mentions) and make updates if needed
    - [X] Provide a basic example of usage
    - [X] In case your feature is an Enterprise one, list it under [ME page](https://memgraph.com/docs/database-management/enabling-memgraph-enterprise) and mark its page with Enterprise ([example](https://memgraph.com/docs/database-management/authentication-and-authorization/role-based-access-control)).
- [X] Check all content with Grammarly
- [X] Perform a self-review of my code
- [X] The build passes locally
- [X] My changes generate no new warnings or errors