### PR TITLE
docs: Add signature for two-argument version of `collect()`

### DIFF
--- a/pages/querying/functions.mdx
+++ b/pages/querying/functions.mdx
@@ -135,6 +135,7 @@ This section contains the list of supported functions.
 |-----------|--------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------|
 | `avg`     | `avg(row: int\|float) -> (float)`                                  | Returns an average value of rows with numerical values generated with the `MATCH` or `UNWIND` clause.                             |
 | `collect` | `collect(values: any) -> (List[any])`                              | Returns a single aggregated list containing returned values.                                                                      |
+| `collect` | `collect(key: string, value: any) -> (Map[string, any])`           | Returns a single aggregated map containing key-value pairs.                                                                       |
 | `count`   | `count(values: any) -> (integer)`                                  | Counts the number of non-null values returned by the expression.                                                                  |
 | `max`     | `max(row: integer\|float\|temporal) -> (integer\|float\|temporal)` | Returns the maximum value in a set of values. Supported temporal types: `Date`, `LocalTime`, `LocalDateTime` and `ZonedDateTime`. |
 | `min`     | `min(row: integer\|float\|temporal) -> (integer\|float\|temporal)` | Returns the minimum value in a set of values. Supported temporal types: `Date`, `LocalTime`, `LocalDateTime` and `ZonedDateTime`. |


### PR DESCRIPTION
### Release note

Add signature for two-argument version of `collect()`

Fixes #1101 

### Checklist:

- [ ] Add appropriate milestone (current release cycle)
- [x] Add `bugfix` or `feature` label, based on the product PR type you're documenting
- [x] Make sure all relevant tech details are documented
    - [x] Update reference pages (e.g. [clauses](https://memgraph.com/docs/querying/clauses), [functions](https://memgraph.com/docs/querying/functions), [flags](https://memgraph.com/docs/database-management/configuration#list-of-configuration-flags), [experimental](https://memgraph.com/docs/database-management/experimental-features), [monitoring](https://memgraph.com/docs/database-management/monitoring), [Cypher differences](https://memgraph.com/docs/querying/differences-in-cypher-implementations))
    - [ ] Search for the feature you are working on (mentions) and make updates if needed
    - [ ] Provide a basic example of usage
    - [ ] In case your feature is an Enterprise one, list it under [ME page](https://memgraph.com/docs/database-management/enabling-memgraph-enterprise) and mark its page with Enterprise ([example](https://memgraph.com/docs/database-management/authentication-and-authorization/role-based-access-control)).
- [x] Check all content with Grammarly
- [x] Perform a self-review of my code
- [x] The build passes locally
- [x] My changes generate no new warnings or errors