### PR TITLE
Remove that periodic execution is not supported

### DIFF
--- a/pages/querying/differences-in-cypher-implementations.mdx
+++ b/pages/querying/differences-in-cypher-implementations.mdx
@@ -162,9 +162,6 @@ LIMIT 5
 
 ### Unsupported constructs
 
-{<h4 className="custom-header">CALL subqueries in transactions</h4>}
-Such a query is not supported in Memgraph, but you can use the [periodic](/advanced-algorithms/available-algorithms/periodic) module to execute a query periodically in batches.
-
 {<h4 className="custom-header">EXISTS subqueries</h4>}
 Such clause is not supported in Memgraph, but you can use `exists()` [pattern function](/querying/functions#pattern-functions) with the `WHERE` clause to [filter with pattern expressions](/querying/clauses/where#17-filter-with-pattern-expressions). 
 


### PR DESCRIPTION
Removed info that said periodic execution is not present in Memgraph. The feature was added a few releases ago.