### PR TITLE
Update temporal function signatures

### DIFF
--- a/pages/querying/functions.mdx
+++ b/pages/querying/functions.mdx
@@ -25,14 +25,14 @@ This section contains the list of supported functions.
 
 ### Temporal functions
 
- | Name            | Signature                                                                  | Description                                                               |
- | --------------- | -------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
- | `duration`      | `duration(value: string\|Duration) -> (Duration)`                          | Returns the data type that represents a period of time.                   |
- | `date`          | `date(value: string\|Date\|LocalDateTime) -> (Date)`                       | Returns the data type that represents a date with year, month, and day.   |
- | `localTime`     | `localTime(value: string\|LocalTime\|LocalDateTime) -> (LocalTime)`        | Returns the data type that represents time within a day without timezone. |
- | `localDateTime` | `localDateTime(value: string\|LocalDateTime)-> (LocalDateTime)`            | Returns the data type that represents a date and local time.              |
- | `datetime`      | `datetime(value: NULL\|string\|map)-> (ZonedDateTime)`                     | Returns the `ZonedDateTime` value defined by the given parameters.        |
-
+ | Name            | Signature                                                                                 | Description                                                               |
+ | --------------- | ----------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
+ | `duration`      | `duration(value: string\|Duration) -> (Duration)`                                         | Returns the data type that represents a period of time.                   |
+ | `date`          | `date(value: string\|Date\|LocalDateTime\|ZonedDateTime) -> (Date)`                       | Returns the data type that represents a date with year, month, and day.   |
+ | `localTime`     | `localTime(value: string\|LocalTime\|LocalDateTime\|ZonedDateTime) -> (LocalTime)`        | Returns the data type that represents time within a day without timezone. |
+ | `localDateTime` | `localDateTime(value: string\|LocalDateTime\|ZonedDateTime)-> (LocalDateTime)`            | Returns the data type that represents a date and local time.              |
+ | `datetime`      | `datetime(value: NULL\|string\|map\|ZonedDateTime)-> (ZonedDateTime)`                     | Returns the `ZonedDateTime` value defined by the given parameters.        |
+ 
  ### Scalar functions
 
  | Name             | Signature                                                                                         | Description                                                                                                                                                                                                                                      |


### PR DESCRIPTION
### Release note

Update the signatures of duration(), localTime(), localDateTime(), and datetime() to correctly show accepted input types.

### Related product PRs
https://github.com/memgraph/memgraph/pull/2630

---
This PR is based on on https://github.com/memgraph/documentation/pull/1110; it was easier/quicker to create new PR than rebasing and resolving conflicts.

cc @colinbarry, all looks good, will merge to Memgraph 3.1 docs. 