### PR TITLE
Add two argument `project()`

### DIFF
--- a/pages/querying/functions.mdx
+++ b/pages/querying/functions.mdx
@@ -146,13 +146,12 @@ This section contains the list of supported functions.
 All aggregation functions can be used with the `DISTINCT` operator to perform calculations only on unique values. For example, `count(DISTINCT n.prop)` and `collect(DISTINCT n.prop)`.
 </Callout>
 
- ### Graph projection functions
+### Graph projection functions
 
- | Name      | Signature                                                          | Description                                                                                           |
- | --------- | ------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------- |
- | `project` | `project(row: path) -> map("nodes":list[Node], "edges":list[Edge])`| Creates a projected graph consisting of nodes and relationships from aggregated paths.                |
-
-
+ | Name      | Signature                                                                                    | Description                                                                                                                                                   |
+ | --------- | -------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+ | `project` | `project(row: path) -> map("nodes":list[Node], "edges":list[Edge])`                          | Creates a projected graph consisting of nodes and relationships from aggregated paths.                                                                        |
+ | `project` | `project(nodes: List[Node], edges:List[Edge]) -> map("nodes":list[Node], "edges":list[Edge])`| Creates a projected graph consisting of nodes and relationships from a list of nodes and a list of relationships, ignoring duplicate nodes and relationships. |
 
 
 ### String functions


### PR DESCRIPTION
### Release note

Added function signature for the two-argument overload of `project()` function.

### Related product PRs

https://github.com/memgraph/memgraph/pull/2611

---
This PR is based on on https://github.com/memgraph/documentation/pull/1111; it was easier/quicker to create new PR than rebasing and resolving conflicts.

cc @colinbarry, all looks good, will merge to Memgraph 3.1 docs. 