### PR TITLE
Document newly added approximation functions in C API

### DIFF
--- a/pages/custom-query-modules/c/c-api.mdx
+++ b/pages/custom-query-modules/c/c-api.mdx
@@ -199,7 +199,7 @@ Memgraph in order to use them.
 | enum [mgp_error](#variable-mgp-error) | **[mgp_graph_edge_change_type](#function-mgp-graph-edge-change-type)**(struct mgp_graph * graph, struct mgp_edge * e, struct mgp_edge_type new_type, struct mgp_memory * memory, struct mgp_edge ** result)<br /> Change edge type.  |
 | enum [mgp_error](#variable-mgp-error) | **[mgp_graph_delete_edge](#function-mgp-graph-delete-edge)**(struct mgp_graph * graph, struct mgp_edge * edge)<br />Delete an edge from the graph.  |
 | enum [mgp_error](#variable-mgp-error) | **[mgp_graph_approximate_vertex_count](#function-mgp-graph-approximate-vertex-count)**(struct mgp_graph * graph, size_t * result)<br />Retrieves an approximate count of vertices in the graph. Note that this number is not exact and should be used with caution. | 
-| enum [mgp_error](#variable-mgp-error) | **[mgp_graph_approximate_edges_count](#function-mgp-graph-approximate-edges-count)**(struct mgp_graph * graph, size_t * result)<br />Retrieves an approximate count of edges in the graph. Note that this number is not exact and should be used with caution. | 
+| enum [mgp_error](#variable-mgp-error) | **[mgp_graph_approximate_edge_count](#function-mgp-graph-approximate-edges-count)**(struct mgp_graph * graph, size_t * result)<br />Retrieves an approximate count of edges in the graph. Note that this number is not exact and should be used with caution. | 
 | void | **[mgp_vertices_iterator_destroy](#function-mgp-vertices-iterator-destroy)**(struct mgp_vertices_iterator * it)<br />Free the memory used by a mgp_vertices_iterator.  |
 | enum [mgp_error](#variable-mgp-error) | **[mgp_graph_iter_vertices](#function-mgp-graph-iter-vertices)**(struct mgp_graph * g, struct mgp_memory * memory, struct mgp_vertices_iterator ** result)<br />Start iterating over vertices of the given graph.  |
 | enum [mgp_error](#variable-mgp-error) | **[mgp_vertices_iterator_underlying_graph_is_mutable](#function-mgp-vertices-iterator-underlying-graph-is-mutable)**(struct mgp_vertices_iterator * it, int * result)<br />Result is non-zero if the vertices returned by this iterator can be modified.  |
@@ -2427,9 +2427,9 @@ enum mgp_error mgp_graph_approximate_vertex_count(
 
 Retrieves an approximate count of vertices in the graph. Note that this number is not exact and should be used with caution.
 
-### mgp_graph_approximate_edges_count [#function-mgp-graph-approximate-edges-count]
+### mgp_graph_approximate_edge_count [#function-mgp-graph-approximate-edges-count]
 ```cpp
-enum mgp_error mgp_graph_approximate_edges_count(
+enum mgp_error mgp_graph_approximate_edge_count(
     struct mgp_graph * graph,
     size_t * result
 )

--- a/pages/custom-query-modules/c/c-api.mdx
+++ b/pages/custom-query-modules/c/c-api.mdx
@@ -198,6 +198,8 @@ Memgraph in order to use them.
 | enum [mgp_error](#variable-mgp-error) | **[mgp_graph_edge_set_to](#function-mgp-graph-edge-set-to)**(struct mgp_graph * graph, struct mgp_edge * e, struct mgp_vertex * new_to, struct mgp_memory * memory, struct mgp_edge ** result)<br /> Change edge to (end) vertex.  |
 | enum [mgp_error](#variable-mgp-error) | **[mgp_graph_edge_change_type](#function-mgp-graph-edge-change-type)**(struct mgp_graph * graph, struct mgp_edge * e, struct mgp_edge_type new_type, struct mgp_memory * memory, struct mgp_edge ** result)<br /> Change edge type.  |
 | enum [mgp_error](#variable-mgp-error) | **[mgp_graph_delete_edge](#function-mgp-graph-delete-edge)**(struct mgp_graph * graph, struct mgp_edge * edge)<br />Delete an edge from the graph.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_graph_approximate_vertex_count](#function-mgp-graph-approximate-vertex-count)**(struct mgp_graph * graph, size_t * result)<br />Retrieves an approximate count of vertices in the graph. Note that this number is not exact and should be used with caution. | 
+| enum [mgp_error](#variable-mgp-error) | **[mgp_graph_approximate_edges_count](#function-mgp-graph-approximate-edges-count)**(struct mgp_graph * graph, size_t * result)<br />Retrieves an approximate count of edges in the graph. Note that this number is not exact and should be used with caution. | 
 | void | **[mgp_vertices_iterator_destroy](#function-mgp-vertices-iterator-destroy)**(struct mgp_vertices_iterator * it)<br />Free the memory used by a mgp_vertices_iterator.  |
 | enum [mgp_error](#variable-mgp-error) | **[mgp_graph_iter_vertices](#function-mgp-graph-iter-vertices)**(struct mgp_graph * g, struct mgp_memory * memory, struct mgp_vertices_iterator ** result)<br />Start iterating over vertices of the given graph.  |
 | enum [mgp_error](#variable-mgp-error) | **[mgp_vertices_iterator_underlying_graph_is_mutable](#function-mgp-vertices-iterator-underlying-graph-is-mutable)**(struct mgp_vertices_iterator * it, int * result)<br />Result is non-zero if the vertices returned by this iterator can be modified.  |
@@ -2415,6 +2417,25 @@ Delete an edge from the graph. When the first parameter to a procedure is a proj
 
 Return MGP_ERROR_IMMUTABLE_OBJECT if `graph` is immutable. Return MGP_ERROR_SERIALIZATION_ERROR if `edge`, its source or destination vertex has been modified by another transaction.
 
+### mgp_graph_approximate_vertex_count [#function-mgp-graph-approximate-vertex-count]
+```cpp
+enum mgp_error mgp_graph_approximate_vertex_count(
+    struct mgp_graph * graph,
+    size_t * result
+)
+```
+
+Retrieves an approximate count of vertices in the graph. Note that this number is not exact and should be used with caution.
+
+### mgp_graph_approximate_edges_count [#function-mgp-graph-approximate-edges-count]
+```cpp
+enum mgp_error mgp_graph_approximate_edges_count(
+    struct mgp_graph * graph,
+    size_t * result
+)
+```
+
+Retrieves an approximate count of edges in the graph. Note that this number is not exact and should be used with caution.
 
 ### mgp_vertices_iterator_destroy [#function-mgp-vertices-iterator-destroy]
 ```cpp
@@ -4186,6 +4207,10 @@ void mgp_vertices_iterator_destroy(struct mgp_vertices_iterator *it);
 
 enum mgp_error mgp_graph_iter_vertices(struct mgp_graph *g, struct mgp_memory *memory,
                                        struct mgp_vertices_iterator **result);
+
+enum mgp_error mgp_graph_approximate_vertex_count(struct mgp_graph *graph, size_t *result);
+
+enum mgp_error mgp_graph_approximate_edge_count(struct mgp_graph *graph, size_t *result);
 
 enum mgp_error mgp_vertices_iterator_underlying_graph_is_mutable(struct mgp_vertices_iterator *it, int *result);
 


### PR DESCRIPTION
### Release note

Document newly added approximation functions in C API. Functions are:
```
enum mgp_error mgp_graph_approximate_vertex_count(struct mgp_graph *graph, size_t *result);
enum mgp_error mgp_graph_approximate_edge_count(struct mgp_graph *graph, size_t *result);
```
### Related product PRs

https://github.com/memgraph/memgraph/pull/2762
https://github.com/memgraph/memgraph/pull/2767

### Checklist:

- [x] Add appropriate milestone (current release cycle)
- [ ] Add `bugfix` or `feature` label, based on the product PR type you're documenting
- [x] Make sure all relevant tech details are documented
    - [x] Update reference pages (e.g. [clauses](https://memgraph.com/docs/querying/clauses), [functions](https://memgraph.com/docs/querying/functions), [flags](https://memgraph.com/docs/database-management/configuration#list-of-configuration-flags), [experimental](https://memgraph.com/docs/database-management/experimental-features), [monitoring](https://memgraph.com/docs/database-management/monitoring), [Cypher differences](https://memgraph.com/docs/querying/differences-in-cypher-implementations))
    - [x] Search for the feature you are working on (mentions) and make updates if needed
    - [x] Provide a basic example of usage
    - [x] In case your feature is an Enterprise one, list it under [ME page](https://memgraph.com/docs/database-management/enabling-memgraph-enterprise) and mark its page with Enterprise ([example](https://memgraph.com/docs/database-management/authentication-and-authorization/role-based-access-control)).
- [x] Check all content with Grammarly
- [x] Perform a self-review of my code
- [x] The build passes locally
- [x] My changes generate no new warnings or errors