### PR TITLE
Query resources and storage access timeout

### DIFF
--- a/pages/fundamentals/query_access.mdx
+++ b/pages/fundamentals/query_access.mdx
@@ -1,0 +1,8 @@
+---
+title: Resources accessed by different queries and their interaction
+description: Understand what resources different queries require and how they interplay.
+---
+
+import { Callout } from 'nextra/components'
+
+# TODO

--- a/pages/fundamentals/query_access.mdx
+++ b/pages/fundamentals/query_access.mdx
@@ -1,8 +1,0 @@
----
-title: Resources accessed by different queries and their interaction
-description: Understand what resources different queries require and how they interplay.
----
-
-import { Callout } from 'nextra/components'
-
-# TODO

--- a/pages/help-center/errors/transactions.mdx
+++ b/pages/help-center/errors/transactions.mdx
@@ -12,6 +12,7 @@ import {CommunityLinks} from '/components/social-card/CommunityLinks'
 While working with Memgraph, you can encounter various transaction errors. Here are some of them, along with the instructions on how to handle them:
 - [Conflicting transactions](#conflicting-transaction)
 - [Transaction timeout](#transaction-timeout)
+- [Storage access timeout](#storage-access-timeout)
 
 ## Conflicting transactions
 
@@ -114,3 +115,32 @@ Here are the [instructions](/configuration/configuration-settings#using-flags-an
 
 
 <CommunityLinks/>
+
+## Storage access timeout
+Storage access errors can occur while preparing a query. Here are the storage access error messages you might encounter:
+- [Shared access timeout](#shared-access-timeout)
+- [Unique access timeout](#shared-access-timeout)
+
+### Error messages
+
+1. **Cannot access storage, unique access query is running. Try again later.**
+2. **Cannot get unique access to the storage. Try stopping other queries that are running in parallel.**
+
+### Understanding storage access timeout
+
+Storage access timeouts occur during query preparation when the query execution engine cannot get the required type of access to the storage. There are two types of storage access:
+
+- **Shared access:** Multiple queries can have shared access at the same time, but shared access cannot be granted while a query with unique access is running.
+- **Unique access:** Only one query can have unique access at a time, and no other query can have any type of access during that period.
+
+These timeouts prevent worker starvation and database blocking that could occur if queries were to wait indefinitely for storage access.
+
+### Handling storage access timeout
+
+When you encounter a storage access timeout:
+
+1. Check for long-running queries that might be blocking storage access
+2. Consider breaking down complex queries that require unique access into smaller operations
+3. Retry the query after other queries have completed
+4. If possible, schedule queries requiring unique access during periods of lower database activity
+

--- a/pages/help-center/errors/transactions.mdx
+++ b/pages/help-center/errors/transactions.mdx
@@ -113,15 +113,11 @@ To change that, update the flag `--query-execution-timeout-sec` value to a value
 
 Here are the [instructions](/configuration/configuration-settings#using-flags-and-config-file) on how to update the configuration. 
 
-
-<CommunityLinks/>
-
 ## Storage access timeout
-Storage access errors can occur while preparing a query. Here are the storage access error messages you might encounter:
-- [Shared access timeout](#shared-access-timeout)
-- [Unique access timeout](#shared-access-timeout)
 
 ### Error messages
+
+Here are the storage access error messages you might encounter:
 
 1. **Cannot access storage, unique access query is running. Try again later.**
 2. **Cannot get unique access to the storage. Try stopping other queries that are running in parallel.**
@@ -130,8 +126,8 @@ Storage access errors can occur while preparing a query. Here are the storage ac
 
 Storage access timeouts occur during query preparation when the query execution engine cannot get the required type of access to the storage. There are two types of storage access:
 
-- **Shared access:** Multiple queries can have shared access at the same time, but shared access cannot be granted while a query with unique access is running.
-- **Unique access:** Only one query can have unique access at a time, and no other query can have any type of access during that period.
+- **Shared access**: Multiple queries can have shared access at the same time, but shared access cannot be granted while a query with unique access is running.
+- **Unique access**: Only one query can have unique access at a time, and no other query can have any type of access during that period.
 
 These timeouts prevent worker starvation and database blocking that could occur if queries were to wait indefinitely for storage access.
 
@@ -139,8 +135,9 @@ These timeouts prevent worker starvation and database blocking that could occur 
 
 When you encounter a storage access timeout:
 
-1. Check for long-running queries that might be blocking storage access
-2. Consider breaking down complex queries that require unique access into smaller operations
-3. Retry the query after other queries have completed
-4. If possible, schedule queries requiring unique access during periods of lower database activity
+1. Check for long-running queries that might be blocking storage access.
+2. Consider breaking down complex queries that require unique access into smaller operations.
+3. Retry the query after other queries have completed.
+4. If possible, schedule queries requiring unique access during periods of lower database activity.
 
+<CommunityLinks/>


### PR DESCRIPTION
### Release note

Queries that access storage can now timeout if storage access cannot be granted. Fixes potential deadlock under heavy load.

### Related product PRs

PRs from product repo this doc page is related to: 
https://github.com/memgraph/memgraph/pull/2651

### Checklist:

- [x] Add appropriate milestone (current release cycle)
- [x] Add `bugfix` or `feature` label, based on the product PR type you're documenting
- [x] Make sure all relevant tech details are documented
    - [x] Update reference pages (e.g. [clauses](https://memgraph.com/docs/querying/clauses), [functions](https://memgraph.com/docs/querying/functions), [flags](https://memgraph.com/docs/database-management/configuration#list-of-configuration-flags), [experimental](https://memgraph.com/docs/database-management/experimental-features), [monitoring](https://memgraph.com/docs/database-management/monitoring), [Cypher differences](https://memgraph.com/docs/querying/differences-in-cypher-implementations))
    - [x] Search for the feature you are working on (mentions) and make updates if needed
    - [x] Provide a basic example of usage
    - [x] In case your feature is an Enterprise one, list it under [ME page](https://memgraph.com/docs/database-management/enabling-memgraph-enterprise) and mark its page with Enterprise ([example](https://memgraph.com/docs/database-management/authentication-and-authorization/role-based-access-control)).
- [x] Check all content with Grammarly
- [x] Perform a self-review of my code
- [ ] The build passes locally
- [ ] My changes generate no new warnings or errors