### PR TITLE
Patch release for Helm Charts HA

### DIFF
--- a/pages/getting-started/install-memgraph/kubernetes.mdx
+++ b/pages/getting-started/install-memgraph/kubernetes.mdx
@@ -486,7 +486,7 @@ the external network you are using for accessing instances from outside.
 
 The most cost-friendly way to manage a Memgraph HA cluster in K8s is using a `IngressNginx` contoller. This controller is capable of routing TCP messages on Bolt level protocol 
 to the K8s Memgraph services. To achieve this, it uses only a single `LoadBalancer` which means there is only a single external IP for connecting to the cluster. Users can connect 
-to any coordinator or data instance by distinguishing bolt ports. The only step required is to install Memgraph HA chart:
+to any coordinator or data instance by distinguishing Bolt ports. The only step required is to install Memgraph HA chart:
 
 ```
 helm install mem-ha-test ./charts/memgraph-high-availability --set \
@@ -508,9 +508,9 @@ finished. Liveness and readiness probes will start after the startup probe
 succeeds. By default, the startup probe on data instances has to succeed within 2 hours. If the
 recovery from backup takes longer than that, update the configuration to the
 value that is high enough. The liveness and readiness probe have to succeed at
-least once in 5 minutes for a pod to be considered ready on data instances. Coordinators
-have their own configuration for probes and they are receiving pings on NuRaft server compared
-to data instances which are receiving pings on bolt server.
+least once in 5 minutes for a pod to be considered ready on data instances.
+Coordinators have their own probe configuration and receive pings on the NuRaft
+server, whereas data instances receive pings on the Bolt server.
 
 ### Configuration options
 

--- a/pages/getting-started/install-memgraph/kubernetes.mdx
+++ b/pages/getting-started/install-memgraph/kubernetes.mdx
@@ -515,50 +515,63 @@ least once in 5 minutes for a pod to be considered ready.
 The following table lists the configurable parameters of the Memgraph HA chart and their default values.
 
 
-| Parameter                                   | Description                                                                                                                                                                                                                                                                                                                                                                                          | Default                    |
-| ------------------------------------------- | ----------------------------------------------------------------------------------------------------------- | -------------------------- |
-| `image.repository`                          | Memgraph Docker image repository                                                                            | `memgraph/memgraph`        |
-| `image.tag`                                 | Specific tag for the Memgraph Docker image. Overrides the image tag whose default is chart version.         | `3.0.0`                   |
-| `image.pullPolicy`                          | Image pull policy                                                                                           | `IfNotPresent`             |
-| `env.MEMGRAPH_ENTERPRISE_LICENSE`           | Memgraph enterprise license                                                                                 | `<your-license>`           |
-| `env.MEMGRAPH_ORGANIZATION_NAME`            | Organization name                                                                                           | `<your-organization-name>` |
-| `storage.libPVCSize`                        | Size of the storage PVC                                                                                     | `1Gi`                      |
-| `storage.libStorageClassName`               | The name of the storage class used for storing data.                                                        | `""`                       |
-| `storage.libStorageAccessMode`              | Access mode used for lib storage.                                                                           | `ReadWriteOnce`            |
-| `storage.logPVCSize`                        | Size of the log PVC                                                                                         | `1Gi`                      |
-| `storage.logStorageClassName`               | The name of the storage class used for storing logs.                                                        | `""`                       |
-| `storage.logStorageAccessMode`              | Access mode used for log storage.                                                                           | `ReadWriteOnce`            |
-| `externalAccess.coordinator.serviceType`    | IngressNginx, NodePort, CommonLoadBalancer or LoadBalancer.                                                 | `NodePort`                 |
-| `externalAccess.dataInstance.serviceType`   | IngressNginx, NodePort or LoadBalancer.                                                                     | `NodePort`                 |
-| `ports.boltPort`                            | Bolt port used on coordinator and data instances.                                                           | `7687`                     |
-| `ports.managementPort`                      | Management port used on coordinator and data instances.                                                     | `10000`                    |
-| `ports.replicationPort`                     | Replication port used on data instances.                                                                    | `20000`                    |
-| `ports.coordinatorPort`                     | Coordinator port used on coordinators.                                                                      | `12000`                    |
-| `affinity.unique`                           | Schedule pods on different nodes in the cluster                                                             | `false`                    |
-| `affinity.parity`                           | Schedule pods on the same node with maximum one coordinator and one data node                               | `false`                    |
-| `affinity.nodeSelection`                    | Schedule pods on nodes with specific labels                                                                 | `false`                    |
-| `affinity.roleLabelKey`                     | Label key for node selection                                                                                | `role`                     |
-| `affinity.dataNodeLabelValue`               | Label value for data nodes                                                                                  | `data-node`                |
-| `affinity.coordinatorNodeLabelValue`        | Label value for coordinator nodes                                                                           | `coordinator-node`         |
-| `container.livenessProbe.tcpSocket.port`    | Port used for TCP connection. Should be the same as bolt port.                                              | `7687`                     |
-| `container.livenessProbe.failureThreshold`  | Failure threshold for liveness probe                                                                        | `20`                       |
-| `container.livenessProbe.timeoutSeconds`    | Initial delay for readiness probe                                                                           | `10`                       |
-| `container.livenessProbe.periodSeconds`     | Period seconds for readiness probe                                                                          | `5`                        |
-| `container.readinessProbe.tcpSocket.port`   | Port used for TCP connection. Should be the same as bolt port.                                              | `7687`                     |
-| `container.readinessProbe.failureThreshold` | Failure threshold for readiness probe                                                                       | `20`                       |
-| `container.readinessProbe.timeoutSeconds`   | Initial delay for readiness probe                                                                           | `10`                       |
-| `container.readinessProbe.periodSeconds`    | Period seconds for readiness probe                                                                          | `5`                        |
-| `container.startupProbe.tcpSocket.port`     | Port used for TCP connection. Should be the same as bolt port.                                              | `7687`                     |
-| `container.startupProbe.failureThreshold`   | Failure threshold for startup probe                                                                         | `1440`                     |
-| `container.startupProbe.periodSeconds`      | Period seconds for startup probe                                                                            | `10`                       |
-| `data`                                      | Configuration for data instances                                                                            | See `data` section         |
-| `coordinators`                              | Configuration for coordinator instances                                                                     | See `coordinators` section |
-| `sysctlInitContainer.enabled`               | Enable the init container to set sysctl parameters                                                          | `true`                     |
-| `sysctlInitContainer.maxMapCount`           | Value for `vm.max_map_count` to be set by the init container                                                | `262144`                   |
-| `secrets.enabled`                           | Enable the use of Kubernetes secrets for Memgraph credentials                                               | `false`                    |
-| `secrets.name`                              | The name of the Kubernetes secret containing Memgraph credentials                                           | `memgraph-secrets`         |
-| `secrets.userKey`                           | The key in the Kubernetes secret for the Memgraph user, the value is passed to the `MEMGRAPH_USER` env.     | `USER`                     |
-| `secrets.passwordKey`                       | The key in the Kubernetes secret for the Memgraph password, the value is passed to the `MEMGRAPH_PASSWORD`. | `PASSWORD`                 |
+| Parameter                                                | Description                                                                                                 | Default                    |
+| -------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- | -------------------------- |
+| `image.repository`                                       | Memgraph Docker image repository                                                                            | `memgraph/memgraph`        |
+| `image.tag`                                              | Specific tag for the Memgraph Docker image. Overrides the image tag whose default is chart version.         | `3.1.0`                    |
+| `image.pullPolicy`                                       | Image pull policy                                                                                           | `IfNotPresent`             |
+| `env.MEMGRAPH_ENTERPRISE_LICENSE`                        | Memgraph enterprise license                                                                                 | `<your-license>`           |
+| `env.MEMGRAPH_ORGANIZATION_NAME`                         | Organization name                                                                                           | `<your-organization-name>` |
+| `storage.libPVCSize`                                     | Size of the storage PVC                                                                                     | `1Gi`                      |
+| `storage.libStorageClassName`                            | The name of the storage class used for storing data.                                                        | `""`                       |
+| `storage.libStorageAccessMode`                           | Access mode used for lib storage.                                                                           | `ReadWriteOnce`            |
+| `storage.logPVCSize`                                     | Size of the log PVC                                                                                         | `1Gi`                      |
+| `storage.logStorageClassName`                            | The name of the storage class used for storing logs.                                                        | `""`                       |
+| `storage.logStorageAccessMode`                           | Access mode used for log storage.                                                                           | `ReadWriteOnce`            |
+| `externalAccess.coordinator.serviceType`                 | IngressNginx, NodePort, CommonLoadBalancer or LoadBalancer.                                                 | `NodePort`                 |
+| `externalAccess.dataInstance.serviceType`                | IngressNginx, NodePort or LoadBalancer.                                                                     | `NodePort`                 |
+| `ports.boltPort`                                         | Bolt port used on coordinator and data instances.                                                           | `7687`                     |
+| `ports.managementPort`                                   | Management port used on coordinator and data instances.                                                     | `10000`                    |
+| `ports.replicationPort`                                  | Replication port used on data instances.                                                                    | `20000`                    |
+| `ports.coordinatorPort`                                  | Coordinator port used on coordinators.                                                                      | `12000`                    |
+| `affinity.unique`                                        | Schedule pods on different nodes in the cluster                                                             | `false`                    |
+| `affinity.parity`                                        | Schedule pods on the same node with maximum one coordinator and one data node                               | `false`                    |
+| `affinity.nodeSelection`                                 | Schedule pods on nodes with specific labels                                                                 | `false`                    |
+| `affinity.roleLabelKey`                                  | Label key for node selection                                                                                | `role`                     |
+| `affinity.dataNodeLabelValue`                            | Label value for data nodes                                                                                  | `data-node`                |
+| `affinity.coordinatorNodeLabelValue`                     | Label value for coordinator nodes                                                                           | `coordinator-node`         |
+| `container.data.livenessProbe.tcpSocket.port`            | Port used for TCP connection. Should be the same as bolt port.                                              | `7687`                     |
+| `container.data.livenessProbe.failureThreshold`          | Failure threshold for liveness probe                                                                        | `20`                       |
+| `container.data.livenessProbe.timeoutSeconds`            | Timeout for liveness probe                                                                                  | `10`                       |
+| `container.data.livenessProbe.periodSeconds`             | Period seconds for readiness probe                                                                          | `5`                        |
+| `container.data.readinessProbe.tcpSocket.port`           | Port used for TCP connection. Should be the same as bolt port.                                              | `7687`                     |
+| `container.data.readinessProbe.failureThreshold`         | Failure threshold for readiness probe                                                                       | `20`                       |
+| `container.data.readinessProbe.timeoutSeconds`           | Timeout for readiness probe                                                                                 | `10`                       |
+| `container.data.readinessProbe.periodSeconds`            | Period seconds for readiness probe                                                                          | `5`                        |
+| `container.data.startupProbe.tcpSocket.port`             | Port used for TCP connection. Should be the same as bolt port.                                              | `7687`                     |
+| `container.data.startupProbe.failureThreshold`           | Failure threshold for startup probe                                                                         | `1440`                     |
+| `container.data.startupProbe.timeoutSeconds`             | Timeout for probe                                                                                           | `10`                       |
+| `container.data.startupProbe.periodSeconds`              | Period seconds for startup probe                                                                            | `10`                       |
+| `container.coordinators.livenessProbe.tcpSocket.port`    | Port used for TCP connection. Should be the same as bolt port.                                              | `7687`                     |
+| `container.coordinators.livenessProbe.failureThreshold`  | Failure threshold for liveness probe                                                                        | `20`                       |
+| `container.coordinators.livenessProbe.timeoutSeconds`    | Timeout for liveness probe                                                                                  | `10`                       |
+| `container.coordinators.livenessProbe.periodSeconds`     | Period seconds for readiness probe                                                                          | `5`                        |
+| `container.coordinators.readinessProbe.tcpSocket.port`   | Port used for TCP connection. Should be the same as bolt port.                                              | `7687`                     |
+| `container.coordinators.readinessProbe.failureThreshold` | Failure threshold for readiness probe                                                                       | `20`                       |
+| `container.coordinators.readinessProbe.timeoutSeconds`   | Timeout for readiness probe                                                                                 | `10`                       |
+| `container.coordinators.readinessProbe.periodSeconds`    | Period seconds for readiness probe                                                                          | `5`                        |
+| `container.coordinators.startupProbe.tcpSocket.port`     | Port used for TCP connection. Should be the same as bolt port.                                              | `7687`                     |
+| `container.coordinators.startupProbe.failureThreshold`   | Failure threshold for startup probe                                                                         | `1440`                     |
+| `container.coordinators.startupProbe.timeoutSeconds`     | Timeout for probe                                                                                           | `10`                       |
+| `container.coordinators.startupProbe.periodSeconds`      | Period seconds for startup probe                                                                            | `10`                       |
+| `data`                                                   | Configuration for data instances                                                                            | See `data` section         |
+| `coordinators`                                           | Configuration for coordinator instances                                                                     | See `coordinators` section |
+| `sysctlInitContainer.enabled`                            | Enable the init container to set sysctl parameters                                                          | `true`                     |
+| `sysctlInitContainer.maxMapCount`                        | Value for `vm.max_map_count` to be set by the init container                                                | `262144`                   |
+| `secrets.enabled`                                        | Enable the use of Kubernetes secrets for Memgraph credentials                                               | `false`                    |
+| `secrets.name`                                           | The name of the Kubernetes secret containing Memgraph credentials                                           | `memgraph-secrets`         |
+| `secrets.userKey`                                        | The key in the Kubernetes secret for the Memgraph user, the value is passed to the `MEMGRAPH_USER` env.     | `USER`                     |
+| `secrets.passwordKey`                                    | The key in the Kubernetes secret for the Memgraph password, the value is passed to the `MEMGRAPH_PASSWORD`. | `PASSWORD`                 |
 
 
 For the `data` and `coordinators` sections, each item in the list has the following parameters:

--- a/pages/getting-started/install-memgraph/kubernetes.mdx
+++ b/pages/getting-started/install-memgraph/kubernetes.mdx
@@ -552,15 +552,15 @@ The following table lists the configurable parameters of the Memgraph HA chart a
 | `container.data.startupProbe.failureThreshold`           | Failure threshold for startup probe                                                                         | `1440`                     |
 | `container.data.startupProbe.timeoutSeconds`             | Timeout for probe                                                                                           | `10`                       |
 | `container.data.startupProbe.periodSeconds`              | Period seconds for startup probe                                                                            | `10`                       |
-| `container.coordinators.livenessProbe.tcpSocket.port`    | Port used for TCP connection. Should be the same as bolt port.                                              | `7687`                     |
+| `container.coordinators.livenessProbe.tcpSocket.port`    | Port used for TCP connection. Should be the same as bolt port.                                              | `12000`                    |
 | `container.coordinators.livenessProbe.failureThreshold`  | Failure threshold for liveness probe                                                                        | `20`                       |
 | `container.coordinators.livenessProbe.timeoutSeconds`    | Timeout for liveness probe                                                                                  | `10`                       |
 | `container.coordinators.livenessProbe.periodSeconds`     | Period seconds for readiness probe                                                                          | `5`                        |
-| `container.coordinators.readinessProbe.tcpSocket.port`   | Port used for TCP connection. Should be the same as bolt port.                                              | `7687`                     |
+| `container.coordinators.readinessProbe.tcpSocket.port`   | Port used for TCP connection. Should be the same as bolt port.                                              | `12000`                    |
 | `container.coordinators.readinessProbe.failureThreshold` | Failure threshold for readiness probe                                                                       | `20`                       |
 | `container.coordinators.readinessProbe.timeoutSeconds`   | Timeout for readiness probe                                                                                 | `10`                       |
 | `container.coordinators.readinessProbe.periodSeconds`    | Period seconds for readiness probe                                                                          | `5`                        |
-| `container.coordinators.startupProbe.tcpSocket.port`     | Port used for TCP connection. Should be the same as bolt port.                                              | `7687`                     |
+| `container.coordinators.startupProbe.tcpSocket.port`     | Port used for TCP connection. Should be the same as bolt port.                                              | `12000`                    |
 | `container.coordinators.startupProbe.failureThreshold`   | Failure threshold for startup probe                                                                         | `1440`                     |
 | `container.coordinators.startupProbe.timeoutSeconds`     | Timeout for probe                                                                                           | `10`                       |
 | `container.coordinators.startupProbe.periodSeconds`      | Period seconds for startup probe                                                                            | `10`                       |

--- a/pages/getting-started/install-memgraph/kubernetes.mdx
+++ b/pages/getting-started/install-memgraph/kubernetes.mdx
@@ -505,10 +505,12 @@ probe is used to determine when a container should be restarted. The readiness
 probe is used to determine when a container is ready to start accepting traffic.
 The startup probe will succeed only after the recovery of the Memgraph has
 finished. Liveness and readiness probes will start after the startup probe
-succeeds. By default, the startup probe has to succeed within 2 hours. If the
+succeeds. By default, the startup probe on data instances has to succeed within 2 hours. If the
 recovery from backup takes longer than that, update the configuration to the
 value that is high enough. The liveness and readiness probe have to succeed at
-least once in 5 minutes for a pod to be considered ready.
+least once in 5 minutes for a pod to be considered ready on data instances. Coordinators
+have their own configuration for probes and they are receiving pings on NuRaft server compared
+to data instances which are receiving pings on bolt server.
 
 ### Configuration options
 


### PR DESCRIPTION
### Release note

Probes are now added specifically for coordinators and data instances. Coordinators are getting pinged on NuRaft server while data instances on bolt server.

### Related product PRs

PRs from product repo this doc page is related to: 
https://github.com/memgraph/helm-charts/pull/120

### Checklist:

- [x] Add appropriate milestone (current release cycle)
- [x] Add `bugfix` or `feature` label, based on the product PR type you're documenting
- [x] Make sure all relevant tech details are documented
    - [x] Update reference pages (e.g. [clauses](https://memgraph.com/docs/querying/clauses), [functions](https://memgraph.com/docs/querying/functions), [flags](https://memgraph.com/docs/database-management/configuration#list-of-configuration-flags), [experimental](https://memgraph.com/docs/database-management/experimental-features), [monitoring](https://memgraph.com/docs/database-management/monitoring), [Cypher differences](https://memgraph.com/docs/querying/differences-in-cypher-implementations))
    - [x] Search for the feature you are working on (mentions) and make updates if needed
    - [x] Provide a basic example of usage
    - [x] In case your feature is an Enterprise one, list it under [ME page](https://memgraph.com/docs/database-management/enabling-memgraph-enterprise) and mark its page with Enterprise ([example](https://memgraph.com/docs/database-management/authentication-and-authorization/role-based-access-control)).
- [x] Check all content with Grammarly
- [x] Perform a self-review of my code
- [x] The build passes locally
- [x] My changes generate no new warnings or errors