### PR TITLE
Explicitly use quotes in the RECOVER SNAPSHOT query

### DIFF
--- a/pages/database-management/backup-and-restore.mdx
+++ b/pages/database-management/backup-and-restore.mdx
@@ -74,7 +74,7 @@ Follow these steps to create database backup:
 Issue the following command from an already running Memgraph instance:
 
 ```
-RECOVER SNAPSHOT /path/to/snapshot [FORCE];
+RECOVER SNAPSHOT "/path/to/snapshot" [FORCE];
 ```
 
 The query will try to copy the defined file into the local data directory and


### PR DESCRIPTION
### Release note

Small fix for the RECOVER SNAPSHOT query. Needs a string as the path and so, needs quotes around the path.

### Related product PRs

PRs from product repo this doc page is related to: 
https://github.com/memgraph/memgraph/pull/2435

### Checklist:

- [x] Add appropriate milestone (current release cycle)
- [ ] Add `bugfix` or `feature` label, based on the product PR type you're documenting
- [ ] Make sure all relevant tech details are documented
    - [ ] Update reference pages (e.g. [clauses](https://memgraph.com/docs/querying/clauses), [functions](https://memgraph.com/docs/querying/functions), [flags](https://memgraph.com/docs/database-management/configuration#list-of-configuration-flags), [experimental](https://memgraph.com/docs/database-management/experimental-features), [monitoring](https://memgraph.com/docs/database-management/monitoring), [Cypher differences](https://memgraph.com/docs/querying/differences-in-cypher-implementations))
    - [ ] Search for the feature you are working on (mentions) and make updates if needed
    - [ ] Provide a basic example of usage
    - [ ] In case your feature is an Enterprise one, list it under [ME page](https://memgraph.com/docs/database-management/enabling-memgraph-enterprise) and mark its page with Enterprise ([example](https://memgraph.com/docs/database-management/authentication-and-authorization/role-based-access-control)).
- [ ] Check all content with Grammarly
- [ ] Perform a self-review of my code
- [ ] The build passes locally
- [ ] My changes generate no new warnings or errors