### PR TITLE
Added storage access timeout flag

### DIFF
--- a/pages/database-management/configuration.mdx
+++ b/pages/database-management/configuration.mdx
@@ -465,6 +465,7 @@ in Memgraph.
 | `--storage-automatic-edge-type-index-creation-enabled=false`    | Enables automatic creation of indices on edge types. Only usable in IN_MEMORY_TRANSACTIONAL mode.                                  | `[bool]`   |
 | `--storage-property-store-compression-enabled=false`            | Controls whether the properties should be compressed in the storage.                                                               | `[bool]`   |
 | `--storage-property-store-compression-level=mid`                | Controls property store compression level. Allowed values: low, mid, high                                                          | `[string]` |
+| `--storage-access-timeout-sec=1`                                | Storage access timeout in seconds. Used to fine-tune the responsiveness and guard against queries indefinitely waiting.            | `[uint64]` |
 
 ### Streams
 


### PR DESCRIPTION
### Release note

Added the missing comma line flag --storage-access-timeout-sec

### Related product PRs

PRs from product repo this doc page is related to: 
https://github.com/memgraph/memgraph/pull/2831

### Checklist:

- [ ] Add appropriate milestone (current release cycle)
- [ ] Add `bugfix` or `feature` label, based on the product PR type you're documenting
- [ ] Make sure all relevant tech details are documented
    - [ ] Update reference pages (e.g. [clauses](https://memgraph.com/docs/querying/clauses), [functions](https://memgraph.com/docs/querying/functions), [flags](https://memgraph.com/docs/database-management/configuration#list-of-configuration-flags), [experimental](https://memgraph.com/docs/database-management/experimental-features), [monitoring](https://memgraph.com/docs/database-management/monitoring), [Cypher differences](https://memgraph.com/docs/querying/differences-in-cypher-implementations))
    - [ ] Search for the feature you are working on (mentions) and make updates if needed
    - [ ] Provide a basic example of usage
    - [ ] In case your feature is an Enterprise one, list it under [ME page](https://memgraph.com/docs/database-management/enabling-memgraph-enterprise) and mark its page with Enterprise ([example](https://memgraph.com/docs/database-management/authentication-and-authorization/role-based-access-control)).
- [ ] Check all content with Grammarly
- [ ] Perform a self-review of my code
- [ ] The build passes locally
- [ ] My changes generate no new warnings or errors