### PR TITLE
Add mgp_result_reserve to C-API

### DIFF
--- a/pages/custom-query-modules/c/c-api.mdx
+++ b/pages/custom-query-modules/c/c-api.mdx
@@ -4052,6 +4052,8 @@ enum mgp_error mgp_result_set_error_msg(struct mgp_result *res, const char *erro
 
 enum mgp_error mgp_result_new_record(struct mgp_result *res, struct mgp_result_record **result);
 
+enum mgp_error mgp_result_reserve(struct mgp_result *res, size_t n);
+
 enum mgp_error mgp_result_record_insert(struct mgp_result_record *record, const char *field_name,
                                         struct mgp_value *val);
 

--- a/pages/custom-query-modules/c/c-api.mdx
+++ b/pages/custom-query-modules/c/c-api.mdx
@@ -143,6 +143,7 @@ Memgraph in order to use them.
 | enum [mgp_error](#variable-mgp-error) | **[mgp_path_equal](#function-mgp-path-equal)**(struct mgp_path * p1, struct mgp_path * p2, int * result)<br />Result is non-zero if given paths are equal, otherwise 0.  |
 | enum [mgp_error](#variable-mgp-error) | **[mgp_result_set_error_msg](#function-mgp-result-set-error-msg)**(struct mgp_result * res, const char * error_msg)<br />Set the error as the result of the procedure.  |
 | enum [mgp_error](#variable-mgp-error) | **[mgp_result_new_record](#function-mgp-result-new-record)**(struct mgp_result * res, struct mgp_result_record ** result)<br />Create a new record for results.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_result_reserve](#function-mgp-result-reserve)**(struct mgp_result * res, size_t n)<br />Reserves memory for `n` result records.  |
 | enum [mgp_error](#variable-mgp-error) | **[mgp_result_record_insert](#function-mgp-result-record-insert)**(struct mgp_result_record * record, const char * field_name, struct mgp_value * val)<br />Assign a value to a field in the given record.  |
 | void | **[mgp_properties_iterator_destroy](#function-mgp-properties-iterator-destroy)**(struct mgp_properties_iterator * it)<br />Free the memory used by a mgp_properties_iterator.  |
 | enum [mgp_error](#variable-mgp-error) | **[mgp_properties_iterator_get](#function-mgp-properties-iterator-get)**(struct mgp_properties_iterator * it, struct [mgp_property](#mgp_property) ** result)<br />Get the current property pointed to by the iterator.  |
@@ -1659,6 +1660,17 @@ Create a new record for results.
 
 The previously obtained mgp_result_record pointer is no longer valid, and you must not use it. Return MGP_ERROR_UNABLE_TO_ALLOCATE if unable to allocate a mgp_result_record.
 
+### mgp_result_reserve [#function-mgp-result-reserve]
+```cpp
+enum mgp_error mgp_result_reserve(
+    struct mgp_result * res,
+    size_t n
+)
+```
+
+Reserves memory for `n` result records.
+
+Returns MGP_ERROR_UNABLE_TO_ALLOCATE if there's no memory for allocating the records.
 
 ### mgp_result_record_insert [#function-mgp-result-record-insert]
 ```cpp


### PR DESCRIPTION
### Release note

Add docs about new C-API function `mgp_result_reserve`.

### Related product PRs

https://github.com/memgraph/memgraph/pull/2790

### Checklist:

- [x] Add appropriate milestone (current release cycle)
- [x] Add `bugfix` or `feature` label, based on the product PR type you're documenting
- [x] Make sure all relevant tech details are documented
    - [ ] Update reference pages (e.g. [clauses](https://memgraph.com/docs/querying/clauses), [functions](https://memgraph.com/docs/querying/functions), [flags](https://memgraph.com/docs/database-management/configuration#list-of-configuration-flags), [experimental](https://memgraph.com/docs/database-management/experimental-features), [monitoring](https://memgraph.com/docs/database-management/monitoring), [Cypher differences](https://memgraph.com/docs/querying/differences-in-cypher-implementations))
    - [ ] Search for the feature you are working on (mentions) and make updates if needed
    - [ ] Provide a basic example of usage
    - [ ] In case your feature is an Enterprise one, list it under [ME page](https://memgraph.com/docs/database-management/enabling-memgraph-enterprise) and mark its page with Enterprise ([example](https://memgraph.com/docs/database-management/authentication-and-authorization/role-based-access-control)).
- [x] Check all content with Grammarly
- [x] Perform a self-review of my code
- [x] The build passes locally
- [x] My changes generate no new warnings or errors