### PR TITLE
Update MAGE tag info

### DIFF
--- a/pages/advanced-algorithms/install-mage.mdx
+++ b/pages/advanced-algorithms/install-mage.mdx
@@ -22,12 +22,27 @@ data.
 
 You can download a specific version of MAGE
 
-For example, if you want to download version `3.1.1`, you should run the following
+For example, if you want to download version `3.2`, you should run the following
 command:
+
+```shell
+docker run -p 7687:7687 --name memgraph memgraph/memgraph-mage:3.2
+```
+
+The following tags are available on Docker Hub:
+- `x.y` - production MAGE image
+- `x.y-relwithdebinfo` - contains debugging symbols and `gdb`
+- `x.y-malloc` - Memgraph compiled with `malloc`instead of `jemalloc` (x86_64 only)
+
+For versions prior to `3.2`, MAGE image tags included both MAGE and Memgraph versions, e.g.
 
 ```shell
 docker run -p 7687:7687 --name memgraph memgraph/memgraph-mage:3.1.1-memgraph-3.1.1
 ```
+
+A `no-ml` image (e.g. `3.1.1-memgraph-3.1.1-no-ml`) was also provided, but this has now been 
+discontinued as of `3.2` onwards.
+
 
 </Callout>
 


### PR DESCRIPTION
### Release note

Updated "Install MAGE" page to say the following:
- discontinued `no-ml` image
- shortened tags by removing Memgraph version, since they are locked together

### Related product PRs

PRs from product repo this doc page is related to: 
[#590](https://github.com/memgraph/mage/pull/590)
[#600](https://github.com/memgraph/mage/pull/600)

### Checklist:

- [ ] Add appropriate milestone (current release cycle)
- [ ] Add `bugfix` or `feature` label, based on the product PR type you're documenting
- [ ] Make sure all relevant tech details are documented
    - [ ] Update reference pages (e.g. [clauses](https://memgraph.com/docs/querying/clauses), [functions](https://memgraph.com/docs/querying/functions), [flags](https://memgraph.com/docs/database-management/configuration#list-of-configuration-flags), [experimental](https://memgraph.com/docs/database-management/experimental-features), [monitoring](https://memgraph.com/docs/database-management/monitoring), [Cypher differences](https://memgraph.com/docs/querying/differences-in-cypher-implementations))
    - [ ] Search for the feature you are working on (mentions) and make updates if needed
    - [ ] Provide a basic example of usage
    - [ ] In case your feature is an Enterprise one, list it under [ME page](https://memgraph.com/docs/database-management/enabling-memgraph-enterprise) and mark its page with Enterprise ([example](https://memgraph.com/docs/database-management/authentication-and-authorization/role-based-access-control)).
- [ ] Check all content with Grammarly
- [ ] Perform a self-review of my code
- [ ] The build passes locally
- [ ] My changes generate no new warnings or errors