### PR TITLE
Add annotations support for external access services in HA chart

### DIFF
--- a/pages/getting-started/install-memgraph/kubernetes.mdx
+++ b/pages/getting-started/install-memgraph/kubernetes.mdx
@@ -562,7 +562,9 @@ The following table lists the configurable parameters of the Memgraph HA chart a
 | `storage.logStorageClassName`                            | The name of the storage class used for storing logs.                                                        | `""`                       |
 | `storage.logStorageAccessMode`                           | Access mode used for log storage.                                                                           | `ReadWriteOnce`            |
 | `externalAccess.coordinator.serviceType`                 | IngressNginx, NodePort, CommonLoadBalancer or LoadBalancer.                                                 | `NodePort`                 |
+| `externalAccess.coordinator.annotations`                 | Annotations for external services attached to coordinators.                                                 | `{}`                       |
 | `externalAccess.dataInstance.serviceType`                | IngressNginx, NodePort or LoadBalancer.                                                                     | `NodePort`                 |
+| `externalAccess.dataInstance.annotations`                | Annotations for external services attached to data instances.                                               | `{}`                       |
 | `headlessService.enabled`                                | Specifies whether headless services will be used inside K8s network on all instances.                       | `false`                    |
 | `ports.boltPort`                                         | Bolt port used on coordinator and data instances.                                                           | `7687`                     |
 | `ports.managementPort`                                   | Management port used on coordinator and data instances.                                                     | `10000`                    |


### PR DESCRIPTION
### Release note

HA chart can now be configured annotations on external services attached to coordinators and data instances.

### Related product PRs

PRs from product repo this doc page is related to: 
https://github.com/memgraph/helm-charts/pull/129/files

### Checklist:

- [ ] Add appropriate milestone (current release cycle)
- [ ] Add `bugfix` or `feature` label, based on the product PR type you're documenting
- [ ] Make sure all relevant tech details are documented
    - [ ] Update reference pages (e.g. [clauses](https://memgraph.com/docs/querying/clauses), [functions](https://memgraph.com/docs/querying/functions), [flags](https://memgraph.com/docs/database-management/configuration#list-of-configuration-flags), [experimental](https://memgraph.com/docs/database-management/experimental-features), [monitoring](https://memgraph.com/docs/database-management/monitoring), [Cypher differences](https://memgraph.com/docs/querying/differences-in-cypher-implementations))
    - [ ] Search for the feature you are working on (mentions) and make updates if needed
    - [ ] Provide a basic example of usage
    - [ ] In case your feature is an Enterprise one, list it under [ME page](https://memgraph.com/docs/database-management/enabling-memgraph-enterprise) and mark its page with Enterprise ([example](https://memgraph.com/docs/database-management/authentication-and-authorization/role-based-access-control)).
- [ ] Check all content with Grammarly
- [ ] Perform a self-review of my code
- [ ] The build passes locally
- [ ] My changes generate no new warnings or errors