### PR TITLE
Add support for starting HA chart without external network configuration

### DIFF
--- a/pages/getting-started/install-memgraph/kubernetes.mdx
+++ b/pages/getting-started/install-memgraph/kubernetes.mdx
@@ -548,64 +548,64 @@ server, whereas data instances receive pings on the Bolt server.
 The following table lists the configurable parameters of the Memgraph HA chart and their default values.
 
 
-| Parameter                                                | Description                                                                                                 | Default                    |
-| -------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- | -------------------------- |
-| `image.repository`                                       | Memgraph Docker image repository                                                                            | `memgraph/memgraph`        |
-| `image.tag`                                              | Specific tag for the Memgraph Docker image. Overrides the image tag whose default is chart version.         | `3.1.0`                    |
-| `image.pullPolicy`                                       | Image pull policy                                                                                           | `IfNotPresent`             |
-| `env.MEMGRAPH_ENTERPRISE_LICENSE`                        | Memgraph enterprise license                                                                                 | `<your-license>`           |
-| `env.MEMGRAPH_ORGANIZATION_NAME`                         | Organization name                                                                                           | `<your-organization-name>` |
-| `storage.libPVCSize`                                     | Size of the storage PVC                                                                                     | `1Gi`                      |
-| `storage.libStorageClassName`                            | The name of the storage class used for storing data.                                                        | `""`                       |
-| `storage.libStorageAccessMode`                           | Access mode used for lib storage.                                                                           | `ReadWriteOnce`            |
-| `storage.logPVCSize`                                     | Size of the log PVC                                                                                         | `1Gi`                      |
-| `storage.logStorageClassName`                            | The name of the storage class used for storing logs.                                                        | `""`                       |
-| `storage.logStorageAccessMode`                           | Access mode used for log storage.                                                                           | `ReadWriteOnce`            |
-| `externalAccess.coordinator.serviceType`                 | IngressNginx, NodePort, CommonLoadBalancer or LoadBalancer.                                                 | `NodePort`                 |
-| `externalAccess.dataInstance.serviceType`                | IngressNginx, NodePort or LoadBalancer.                                                                     | `NodePort`                 |
-| `headlessService.enabled`                                | Specifies whether headless services will be used inside K8s network on all instances.                       | `false`                    |
-| `ports.boltPort`                                         | Bolt port used on coordinator and data instances.                                                           | `7687`                     |
-| `ports.managementPort`                                   | Management port used on coordinator and data instances.                                                     | `10000`                    |
-| `ports.replicationPort`                                  | Replication port used on data instances.                                                                    | `20000`                    |
-| `ports.coordinatorPort`                                  | Coordinator port used on coordinators.                                                                      | `12000`                    |
-| `affinity.unique`                                        | Schedule pods on different nodes in the cluster                                                             | `false`                    |
-| `affinity.parity`                                        | Schedule pods on the same node with maximum one coordinator and one data node                               | `false`                    |
-| `affinity.nodeSelection`                                 | Schedule pods on nodes with specific labels                                                                 | `false`                    |
-| `affinity.roleLabelKey`                                  | Label key for node selection                                                                                | `role`                     |
-| `affinity.dataNodeLabelValue`                            | Label value for data nodes                                                                                  | `data-node`                |
-| `affinity.coordinatorNodeLabelValue`                     | Label value for coordinator nodes                                                                           | `coordinator-node`         |
-| `container.data.livenessProbe.tcpSocket.port`            | Port used for TCP connection. Should be the same as bolt port.                                              | `7687`                     |
-| `container.data.livenessProbe.failureThreshold`          | Failure threshold for liveness probe                                                                        | `20`                       |
-| `container.data.livenessProbe.timeoutSeconds`            | Timeout for liveness probe                                                                                  | `10`                       |
-| `container.data.livenessProbe.periodSeconds`             | Period seconds for readiness probe                                                                          | `5`                        |
-| `container.data.readinessProbe.tcpSocket.port`           | Port used for TCP connection. Should be the same as bolt port.                                              | `7687`                     |
-| `container.data.readinessProbe.failureThreshold`         | Failure threshold for readiness probe                                                                       | `20`                       |
-| `container.data.readinessProbe.timeoutSeconds`           | Timeout for readiness probe                                                                                 | `10`                       |
-| `container.data.readinessProbe.periodSeconds`            | Period seconds for readiness probe                                                                          | `5`                        |
-| `container.data.startupProbe.tcpSocket.port`             | Port used for TCP connection. Should be the same as bolt port.                                              | `7687`                     |
-| `container.data.startupProbe.failureThreshold`           | Failure threshold for startup probe                                                                         | `1440`                     |
-| `container.data.startupProbe.timeoutSeconds`             | Timeout for probe                                                                                           | `10`                       |
-| `container.data.startupProbe.periodSeconds`              | Period seconds for startup probe                                                                            | `10`                       |
-| `container.coordinators.livenessProbe.tcpSocket.port`    | Port used for TCP connection. Should be the same as bolt port.                                              | `12000`                    |
-| `container.coordinators.livenessProbe.failureThreshold`  | Failure threshold for liveness probe                                                                        | `20`                       |
-| `container.coordinators.livenessProbe.timeoutSeconds`    | Timeout for liveness probe                                                                                  | `10`                       |
-| `container.coordinators.livenessProbe.periodSeconds`     | Period seconds for readiness probe                                                                          | `5`                        |
-| `container.coordinators.readinessProbe.tcpSocket.port`   | Port used for TCP connection. Should be the same as bolt port.                                              | `12000`                    |
-| `container.coordinators.readinessProbe.failureThreshold` | Failure threshold for readiness probe                                                                       | `20`                       |
-| `container.coordinators.readinessProbe.timeoutSeconds`   | Timeout for readiness probe                                                                                 | `10`                       |
-| `container.coordinators.readinessProbe.periodSeconds`    | Period seconds for readiness probe                                                                          | `5`                        |
-| `container.coordinators.startupProbe.tcpSocket.port`     | Port used for TCP connection. Should be the same as bolt port.                                              | `12000`                    |
-| `container.coordinators.startupProbe.failureThreshold`   | Failure threshold for startup probe                                                                         | `1440`                     |
-| `container.coordinators.startupProbe.timeoutSeconds`     | Timeout for probe                                                                                           | `10`                       |
-| `container.coordinators.startupProbe.periodSeconds`      | Period seconds for startup probe                                                                            | `10`                       |
-| `data`                                                   | Configuration for data instances                                                                            | See `data` section         |
-| `coordinators`                                           | Configuration for coordinator instances                                                                     | See `coordinators` section |
-| `sysctlInitContainer.enabled`                            | Enable the init container to set sysctl parameters                                                          | `true`                     |
-| `sysctlInitContainer.maxMapCount`                        | Value for `vm.max_map_count` to be set by the init container                                                | `262144`                   |
-| `secrets.enabled`                                        | Enable the use of Kubernetes secrets for Memgraph credentials                                               | `false`                    |
-| `secrets.name`                                           | The name of the Kubernetes secret containing Memgraph credentials                                           | `memgraph-secrets`         |
-| `secrets.userKey`                                        | The key in the Kubernetes secret for the Memgraph user, the value is passed to the `MEMGRAPH_USER` env.     | `USER`                     |
-| `secrets.passwordKey`                                    | The key in the Kubernetes secret for the Memgraph password, the value is passed to the `MEMGRAPH_PASSWORD`. | `PASSWORD`                 |
+| Parameter                                                | Description                                                                                                  | Default                    |
+| -------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ | -------------------------- |
+| `image.repository`                                       | Memgraph Docker image repository                                                                             | `memgraph/memgraph`        |
+| `image.tag`                                              | Specific tag for the Memgraph Docker image. Overrides the image tag whose default is chart version.          | `3.1.0`                    |
+| `image.pullPolicy`                                       | Image pull policy                                                                                            | `IfNotPresent`             |
+| `env.MEMGRAPH_ENTERPRISE_LICENSE`                        | Memgraph enterprise license                                                                                  | `<your-license>`           |
+| `env.MEMGRAPH_ORGANIZATION_NAME`                         | Organization name                                                                                            | `<your-organization-name>` |
+| `storage.libPVCSize`                                     | Size of the storage PVC                                                                                      | `1Gi`                      |
+| `storage.libStorageClassName`                            | The name of the storage class used for storing data.                                                         | `""`                       |
+| `storage.libStorageAccessMode`                           | Access mode used for lib storage.                                                                            | `ReadWriteOnce`            |
+| `storage.logPVCSize`                                     | Size of the log PVC                                                                                          | `1Gi`                      |
+| `storage.logStorageClassName`                            | The name of the storage class used for storing logs.                                                         | `""`                       |
+| `storage.logStorageAccessMode`                           | Access mode used for log storage.                                                                            | `ReadWriteOnce`            |
+| `externalAccess.coordinator.serviceType`                 | IngressNginx, NodePort, CommonLoadBalancer or LoadBalancer. By default, no external service will be created. | `""`                       |
+| `externalAccess.dataInstance.serviceType`                | IngressNginx, NodePort or LoadBalancer. By default, no external service will be created.                     | `""`                       |
+| `headlessService.enabled`                                | Specifies whether headless services will be used inside K8s network on all instances.                        | `false`                    |
+| `ports.boltPort`                                         | Bolt port used on coordinator and data instances.                                                            | `7687`                     |
+| `ports.managementPort`                                   | Management port used on coordinator and data instances.                                                      | `10000`                    |
+| `ports.replicationPort`                                  | Replication port used on data instances.                                                                     | `20000`                    |
+| `ports.coordinatorPort`                                  | Coordinator port used on coordinators.                                                                       | `12000`                    |
+| `affinity.unique`                                        | Schedule pods on different nodes in the cluster                                                              | `false`                    |
+| `affinity.parity`                                        | Schedule pods on the same node with maximum one coordinator and one data node                                | `false`                    |
+| `affinity.nodeSelection`                                 | Schedule pods on nodes with specific labels                                                                  | `false`                    |
+| `affinity.roleLabelKey`                                  | Label key for node selection                                                                                 | `role`                     |
+| `affinity.dataNodeLabelValue`                            | Label value for data nodes                                                                                   | `data-node`                |
+| `affinity.coordinatorNodeLabelValue`                     | Label value for coordinator nodes                                                                            | `coordinator-node`         |
+| `container.data.livenessProbe.tcpSocket.port`            | Port used for TCP connection. Should be the same as bolt port.                                               | `7687`                     |
+| `container.data.livenessProbe.failureThreshold`          | Failure threshold for liveness probe                                                                         | `20`                       |
+| `container.data.livenessProbe.timeoutSeconds`            | Timeout for liveness probe                                                                                   | `10`                       |
+| `container.data.livenessProbe.periodSeconds`             | Period seconds for readiness probe                                                                           | `5`                        |
+| `container.data.readinessProbe.tcpSocket.port`           | Port used for TCP connection. Should be the same as bolt port.                                               | `7687`                     |
+| `container.data.readinessProbe.failureThreshold`         | Failure threshold for readiness probe                                                                        | `20`                       |
+| `container.data.readinessProbe.timeoutSeconds`           | Timeout for readiness probe                                                                                  | `10`                       |
+| `container.data.readinessProbe.periodSeconds`            | Period seconds for readiness probe                                                                           | `5`                        |
+| `container.data.startupProbe.tcpSocket.port`             | Port used for TCP connection. Should be the same as bolt port.                                               | `7687`                     |
+| `container.data.startupProbe.failureThreshold`           | Failure threshold for startup probe                                                                          | `1440`                     |
+| `container.data.startupProbe.timeoutSeconds`             | Timeout for probe                                                                                            | `10`                       |
+| `container.data.startupProbe.periodSeconds`              | Period seconds for startup probe                                                                             | `10`                       |
+| `container.coordinators.livenessProbe.tcpSocket.port`    | Port used for TCP connection. Should be the same as bolt port.                                               | `12000`                    |
+| `container.coordinators.livenessProbe.failureThreshold`  | Failure threshold for liveness probe                                                                         | `20`                       |
+| `container.coordinators.livenessProbe.timeoutSeconds`    | Timeout for liveness probe                                                                                   | `10`                       |
+| `container.coordinators.livenessProbe.periodSeconds`     | Period seconds for readiness probe                                                                           | `5`                        |
+| `container.coordinators.readinessProbe.tcpSocket.port`   | Port used for TCP connection. Should be the same as bolt port.                                               | `12000`                    |
+| `container.coordinators.readinessProbe.failureThreshold` | Failure threshold for readiness probe                                                                        | `20`                       |
+| `container.coordinators.readinessProbe.timeoutSeconds`   | Timeout for readiness probe                                                                                  | `10`                       |
+| `container.coordinators.readinessProbe.periodSeconds`    | Period seconds for readiness probe                                                                           | `5`                        |
+| `container.coordinators.startupProbe.tcpSocket.port`     | Port used for TCP connection. Should be the same as bolt port.                                               | `12000`                    |
+| `container.coordinators.startupProbe.failureThreshold`   | Failure threshold for startup probe                                                                          | `1440`                     |
+| `container.coordinators.startupProbe.timeoutSeconds`     | Timeout for probe                                                                                            | `10`                       |
+| `container.coordinators.startupProbe.periodSeconds`      | Period seconds for startup probe                                                                             | `10`                       |
+| `data`                                                   | Configuration for data instances                                                                             | See `data` section         |
+| `coordinators`                                           | Configuration for coordinator instances                                                                      | See `coordinators` section |
+| `sysctlInitContainer.enabled`                            | Enable the init container to set sysctl parameters                                                           | `true`                     |
+| `sysctlInitContainer.maxMapCount`                        | Value for `vm.max_map_count` to be set by the init container                                                 | `262144`                   |
+| `secrets.enabled`                                        | Enable the use of Kubernetes secrets for Memgraph credentials                                                | `false`                    |
+| `secrets.name`                                           | The name of the Kubernetes secret containing Memgraph credentials                                            | `memgraph-secrets`         |
+| `secrets.userKey`                                        | The key in the Kubernetes secret for the Memgraph user, the value is passed to the `MEMGRAPH_USER` env.      | `USER`                     |
+| `secrets.passwordKey`                                    | The key in the Kubernetes secret for the Memgraph password, the value is passed to the `MEMGRAPH_PASSWORD`.  | `PASSWORD`                 |
 
 
 For the `data` and `coordinators` sections, each item in the list has the following parameters:

--- a/pages/getting-started/install-memgraph/kubernetes.mdx
+++ b/pages/getting-started/install-memgraph/kubernetes.mdx
@@ -548,6 +548,7 @@ server, whereas data instances receive pings on the Bolt server.
 
 The following table lists the configurable parameters of the Memgraph HA chart and their default values.
 
+
 | Parameter                                                | Description                                                                                                  | Default                    |
 | -------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ | -------------------------- |
 | `image.repository`                                       | Memgraph Docker image repository                                                                             | `memgraph/memgraph`        |


### PR DESCRIPTION
### Release note

Added support for starting HA chart without external network configuration

### Related product PRs

PRs from product repo this doc page is related to: 
https://github.com/memgraph/helm-charts/pull/131

### Checklist:

- [x] Add appropriate milestone (current release cycle)
- [x] Add `bugfix` or `feature` label, based on the product PR type you're documenting
- [x] Make sure all relevant tech details are documented
    - [x] Update reference pages (e.g. [clauses](https://memgraph.com/docs/querying/clauses), [functions](https://memgraph.com/docs/querying/functions), [flags](https://memgraph.com/docs/database-management/configuration#list-of-configuration-flags), [experimental](https://memgraph.com/docs/database-management/experimental-features), [monitoring](https://memgraph.com/docs/database-management/monitoring), [Cypher differences](https://memgraph.com/docs/querying/differences-in-cypher-implementations))
    - [x] Search for the feature you are working on (mentions) and make updates if needed
    - [x] Provide a basic example of usage
    - [x] In case your feature is an Enterprise one, list it under [ME page](https://memgraph.com/docs/database-management/enabling-memgraph-enterprise) and mark its page with Enterprise ([example](https://memgraph.com/docs/database-management/authentication-and-authorization/role-based-access-control)).
- [x] Check all content with Grammarly
- [x] Perform a self-review of my code
- [x] The build passes locally
- [x] My changes generate no new warnings or errors