### PR TITLE
Document failovering to sync replicas only

### DIFF
--- a/pages/clustering/high-availability.mdx
+++ b/pages/clustering/high-availability.mdx
@@ -391,8 +391,8 @@ Users can also choose whether failover to the async replica is allowed by using 
 SET COORDINATOR SETTING 'sync_failover_only' TO 'true'/'false' ;
 ```
 
-By the default the value is true which means that only sync replicas are candidates in the election. When the value is set to false, async replica is also considered but
-there is then an additional risk of experiencing a data loss. However, failovering to async replica may be necessary when other sync replicas are down and you want to
+By default, the value is `true`, which means that only sync replicas are candidates in the election. When the value is set to `false`, the async replica is also considered, but
+there is an additional risk of experiencing data loss. However, failover to an async replica may be necessary when other sync replicas are down and you want to
 manually perform a failover.
 
 

--- a/pages/clustering/high-availability.mdx
+++ b/pages/clustering/high-availability.mdx
@@ -385,19 +385,7 @@ check the status of the replication instance to update its status. Flag `--insta
 pass before the coordinator starts considering the instance to be down. 
 
 
-
-
-
-
-
-
-
-
-
-
-
-
-Users can also choose whether failovering to async replica is allowed by using the following query:
+Users can also choose whether failover to the async replica is allowed by using the following query:
 
 ```
 SET COORDINATOR SETTING 'sync_failover_only' TO 'true'/'false' ;

--- a/pages/clustering/high-availability.mdx
+++ b/pages/clustering/high-availability.mdx
@@ -384,6 +384,30 @@ server that coordinator instances use for communication. Flag `--instance-health
 check the status of the replication instance to update its status. Flag `--instance-down-timeout-sec` gives the user the ability to control how much time should
 pass before the coordinator starts considering the instance to be down. 
 
+
+
+
+
+
+
+
+
+
+
+
+
+
+Users can also choose whether failovering to async replica is allowed by using the following query:
+
+```
+SET COORDINATOR SETTING 'sync_failover_only' TO 'true'/'false' ;
+```
+
+By the default the value is true which means that only sync replicas are candidates in the election. When the value is set to false, async replica is also considered but
+there is then an additional risk of experiencing a data loss. However, failovering to async replica may be necessary when other sync replicas are down and you want to
+manually perform a failover.
+
+
 <Callout type="info">
 
 Consider the instance to be down only if several consecutive pings fail because a single ping can fail because of a large number of different reasons in distributed systems.


### PR DESCRIPTION
### Release note

Document changes related to the user option of failovering only to the sync replica.

### Related product PRs

PRs from product repo this doc page is related to: 
https://github.com/memgraph/memgraph/pull/2931

### Checklist:

- [x] Add appropriate milestone (current release cycle)
- [x] Add `bugfix` or `feature` label, based on the product PR type you're documenting
- [x] Make sure all relevant tech details are documented
    - [x] Update reference pages (e.g. [clauses](https://memgraph.com/docs/querying/clauses), [functions](https://memgraph.com/docs/querying/functions), [flags](https://memgraph.com/docs/database-management/configuration#list-of-configuration-flags), [experimental](https://memgraph.com/docs/database-management/experimental-features), [monitoring](https://memgraph.com/docs/database-management/monitoring), [Cypher differences](https://memgraph.com/docs/querying/differences-in-cypher-implementations))
    - [x] Search for the feature you are working on (mentions) and make updates if needed
    - [x] Provide a basic example of usage
    - [x] In case your feature is an Enterprise one, list it under [ME page](https://memgraph.com/docs/database-management/enabling-memgraph-enterprise) and mark its page with Enterprise ([example](https://memgraph.com/docs/database-management/authentication-and-authorization/role-based-access-control)).
- [x] Check all content with Grammarly
- [x] Perform a self-review of my code
- [x] The build passes locally
- [x] My changes generate no new warnings or errors