### PR TITLE
Add v3.2.1

### DIFF
--- a/pages/release-notes.mdx
+++ b/pages/release-notes.mdx
@@ -108,6 +108,9 @@ updated.
   correctness but with a smaller chance of something getting inconsistent.
   [#2937](https://github.com/memgraph/memgraph/pull/2937)
 
+
+## Previous releases
+
 ### Memgraph v3.2.0 - Apr 23rd, 2025
 
 {<h4 className="custom-header">⚠️ Breaking changes</h4>}
@@ -293,7 +296,6 @@ updated.
 
 <LabReleasesClient version="3.2.0" />
 
-## Previous releases
 
 ### Memgraph v3.1.1 - Mar 28th, 2025
 

--- a/pages/release-notes.mdx
+++ b/pages/release-notes.mdx
@@ -66,7 +66,7 @@ updated.
 
 ## 🚀 Latest release
 
-### Memgraph v3.2.0 - May 9th, 2025
+### Memgraph v3.2.1 - May 9th, 2025
 
 {<h4 className="custom-header">🛠️ Improvements</h4>}
 

--- a/pages/release-notes.mdx
+++ b/pages/release-notes.mdx
@@ -66,6 +66,10 @@ updated.
 
 ## 🚀 Latest release
 
+### Memgraph v3.2.0 - May 9th, 2025
+{<h4 className="custom-header">🛠️ Improvements</h4>}
+{<h4 className="custom-header">🐞 Bug fixes</h4>}
+
 ### Memgraph v3.2.0 - Apr 23rd, 2025
 
 {<h4 className="custom-header">⚠️ Breaking changes</h4>}

--- a/pages/release-notes.mdx
+++ b/pages/release-notes.mdx
@@ -91,9 +91,22 @@ updated.
   Creating deltas with large properties would correctly allocate memory, but
   cause an out-of-bounds write. Users shouldn't see segfaults on commits or GC
   runs anymore. [2950](https://github.com/memgraph/memgraph/pull/2950)
-- Fix CallProcedureCursor reset method. Query modules would sometimes cause a
+- Fixed CallProcedureCursor reset method. Query modules would sometimes cause a
   crash due to not being reset properly.
   [#2953](https://github.com/memgraph/memgraph/pull/2953)
+- Fixed impersonate user misalignment between interpreter and session. This
+  broke the permissions when using the impersonated user. User can now actually
+  use the feature and see the correct behavior.
+  [2938](https://github.com/memgraph/memgraph/pull/2938)
+- Fixed query type deduction giving the wrong answer in cases where subqueries
+  execute read procedures. Without the fix users could not execute certain
+  queries. Query type misalignment shouldn't occur anymore.
+  [2944](https://github.com/memgraph/memgraph/pull/2944)
+- Improved usages of read-modify-write pattern in the Raft code by using compare
+  exchange operations instead of blindly loading, modifying and then storing
+  again. Users should expect the same behaviour from the perspective of
+  correctness but with a smaller chance of something getting inconsistent.
+  [#2937](https://github.com/memgraph/memgraph/pull/2937)
 
 ### Memgraph v3.2.0 - Apr 23rd, 2025
 

--- a/pages/release-notes.mdx
+++ b/pages/release-notes.mdx
@@ -90,18 +90,18 @@ updated.
 - Fixed `PageSlabMemoryResource` large allocation returning wrong address.
   Creating deltas with large properties would correctly allocate memory, but
   cause an out-of-bounds write. Users shouldn't see segfaults on commits or GC
-  runs anymore. [2950](https://github.com/memgraph/memgraph/pull/2950)
+  runs anymore. [#2950](https://github.com/memgraph/memgraph/pull/2950)
 - Fixed CallProcedureCursor reset method. Query modules would sometimes cause a
   crash due to not being reset properly.
   [#2953](https://github.com/memgraph/memgraph/pull/2953)
 - Fixed impersonate user misalignment between interpreter and session. This
   broke the permissions when using the impersonated user. User can now actually
   use the feature and see the correct behavior.
-  [2938](https://github.com/memgraph/memgraph/pull/2938)
+  [#2938](https://github.com/memgraph/memgraph/pull/2938)
 - Fixed query type deduction giving the wrong answer in cases where subqueries
   execute read procedures. Without the fix users could not execute certain
   queries. Query type misalignment shouldn't occur anymore.
-  [2944](https://github.com/memgraph/memgraph/pull/2944)
+  [#2944](https://github.com/memgraph/memgraph/pull/2944)
 - Improved usages of read-modify-write pattern in the Raft code by using compare
   exchange operations instead of blindly loading, modifying and then storing
   again. Users should expect the same behaviour from the perspective of

--- a/pages/release-notes.mdx
+++ b/pages/release-notes.mdx
@@ -67,8 +67,33 @@ updated.
 ## 🚀 Latest release
 
 ### Memgraph v3.2.0 - May 9th, 2025
+
 {<h4 className="custom-header">🛠️ Improvements</h4>}
+
+- Modified the Docker image such that the `memgraph` user has the UID `101` to
+  match that used by `MAGE`. If the user has any volumes mounted on older
+  versions or memgraph (< 3.2.1), then they should `chown 101:101
+  /path/to/volume` to allow the `memgraph` user to read and write to them.
+  [#2947](https://github.com/memgraph/memgraph/pull/2947)
+- New `relwithdebinfo` Docker build for `arm64` to allow users to debug
+  Memgraph on ARM. Push `relwithdebinfo` DEB packages and Docker images to
+  download bucket during release, so they are available
+  [here](https://memgraph.com/download)
+  [#2952](https://github.com/memgraph/memgraph/pull/2952)
+- Improved the performance when writing to disk log stores' durable data using
+  batched writing. Users can expect the same behavior as before, with a
+  slightly better performance when using high availability.
+  [#2946](https://github.com/memgraph/memgraph/pull/2946)
+
 {<h4 className="custom-header">🐞 Bug fixes</h4>}
+
+- Fixed `PageSlabMemoryResource` large allocation returning wrong address.
+  Creating deltas with large properties would correctly allocate memory, but
+  cause an out-of-bounds write. Users shouldn't see segfaults on commits or GC
+  runs anymore. [2950](https://github.com/memgraph/memgraph/pull/2950)
+- Fix CallProcedureCursor reset method. Query modules would sometimes cause a
+  crash due to not being reset properly.
+  [#2953](https://github.com/memgraph/memgraph/pull/2953)
 
 ### Memgraph v3.2.0 - Apr 23rd, 2025
 


### PR DESCRIPTION
NOTE: Mage is just skipped intentionally because only the Memgraph version changed there.

### Changelog

- [x] https://github.com/memgraph/memgraph/pull/2947 @mattkjames7 
- [x] https://github.com/memgraph/memgraph/pull/2950 @andrejtonev 
- [x] https://github.com/memgraph/memgraph/pull/2952 @mattkjames7 
- [x] https://github.com/memgraph/memgraph/pull/2953 @imilinovic 
- [x] https://github.com/memgraph/memgraph/pull/2946 @as51340 
- [x] https://github.com/memgraph/memgraph/pull/2938 @andrejtonev 
- [x] https://github.com/memgraph/memgraph/pull/2944 @andrejtonev 
- [x] https://github.com/memgraph/memgraph/pull/2937 @as51340 