### PR TITLE
Add MCP to AI docs

### DIFF
--- a/pages/ai-ecosystem.mdx
+++ b/pages/ai-ecosystem.mdx
@@ -13,20 +13,21 @@ natural language processing (NLP) systems and beyond. These technologies
 frequently intersect, enabling the creation of powerful applications with
 Generative AI (GenAI), including advanced chatbots and agents.
 
-## What You'll Find Here
+## What you'll find here
 
 This section of Memgraph’s documentation is your guide to using Memgraph for AI:
 
-- [Building GenAI apps with GraphRAG](/ai-ecosystem/graph-rag): See how knowledge graphs enable more
-  efficient and scalable RAG systems.
-- [AI integrations with Memgraph](/ai-ecosystem/integrations): We have several integrations with popular
-  AI frameworks to help you customize and build your own GenAI application from
-  scratch. Some of the libraries that support Memgraph
-  include **LangChain** and **LlamaIndex**.
-- [GraphChat in Memgraph Lab](/ai-ecosystem/graphchat): Explore how natural language querying
-  (GraphChat) ties into the GraphRAG ecosystem, making complex graphs accessible
-  to everyone.
-- [Machine learning with Memgraph](/ai-ecosystem/machine-learning): Learn how Memgraph powers ML workflows
-  with graph-powered insights.
+- [Building GenAI apps with GraphRAG](/ai-ecosystem/graph-rag): See how
+  knowledge graphs enable more efficient and scalable RAG systems.
+- [AI integrations with Memgraph](/ai-ecosystem/integrations): We have several
+  integrations with popular AI frameworks to help you customize and build your
+  own GenAI application from scratch. Some of the libraries that support
+  Memgraph include **Model Context Protocol (MCP)**, **LangChain**
+  and **LlamaIndex**.
+- [GraphChat in Memgraph Lab](/ai-ecosystem/graphchat): Explore how natural
+  language querying (GraphChat) ties into the GraphRAG ecosystem, making complex
+  graphs accessible to everyone.
+- [Machine learning with Memgraph](/ai-ecosystem/machine-learning): Learn how
+  Memgraph powers ML workflows with graph-powered insights.
 
 <CommunityLinks/>


### PR DESCRIPTION
MCP was missing from the main AI ecosystem page