### PR TITLE
Improve drop index docs

### DIFF
--- a/pages/fundamentals/indexes.mdx
+++ b/pages/fundamentals/indexes.mdx
@@ -96,6 +96,11 @@ Creating an index will optimize the following type of queries:
 MATCH (n:Person) RETURN n;
 ```
 
+To drop the label index use:
+```cypher
+DROP INDEX ON :Label;
+```
+
 ### Label-property index
 
 To optimize queries that fetch nodes with a certain label and property
@@ -133,6 +138,11 @@ Be aware that since the filter inside `WHERE` can contain any kind of an
 expression, the expression can be so complicated that the index doesn't get used.
 If there is any suspicion that an index isn't used, we recommend writing
 labels and properties inside the `MATCH` pattern.
+
+To drop the label-property index use:
+```cypher
+DROP INDEX ON :Label(property);
+```
 
 ### Label-property composite index
 
@@ -257,6 +267,11 @@ generally put the property with the highest cardinality (most unique values)
 first. Alternatively, if queries on property `a` alone are more common than
 those on `b` alone, prefer `(a, b)` over `(b, a)`.
 
+To drop the label-property composite index use:
+```cypher
+DROP INDEX ON :Label(property1, property2);
+```
+
 ### Edge-type index
 
 To optimize queries that fetch only the edges by specific edge-types, you need
@@ -280,6 +295,12 @@ If you need to access nodes of found edges, you can use the `startNode(r)` and `
 Named parameters are not supported for edge-type indexes.
 
 </Callout>
+
+
+To drop the edge-type index use:
+```cypher
+DROP EDGE INDEX ON :EDGE_TYPE;
+```
 
 ### Edge-type property index
 
@@ -306,6 +327,11 @@ Named parameters are not supported for edge-type property indexes.
 
 </Callout>
 
+To drop the edge-type property index use:
+```cypher
+DROP EDGE INDEX ON :EDGE_TYPE(property_name);
+```
+
 ### Global edge property index
 
 Since edges can have only one edge type, Memgraph provides a way to index all the edges that contain
@@ -329,6 +355,11 @@ If you need to access nodes of found edges, you can use the `startNode(r)` and `
 Named parameters are not supported for edge-type property indexes.
 
 </Callout>
+
+To drop the global edge property index use:
+```cypher
+DROP GLOBAL EDGE INDEX ON :(property_name);
+```
 
 ### Point index
 
@@ -479,13 +510,17 @@ DROP EDGE INDEX ON :EDGE_TYPE(property_name);
 DROP GLOBAL EDGE INDEX ON :(property_name);
 ```
 
+```cypher
+DROP POINT INDEX ON :Label(property);
+```
+
 These queries instruct all active transactions to abort as soon as possible.
 Once all transactions have finished, the index will be deleted.
 
 ### Delete all node indexes
 
 <Callout type="warning">
-The `schema.assert()` procedure will not drop edge-type and point indexes. 
+The `schema.assert()` procedure will not drop edge and point indexes. 
 Our plan is to update it, and you can track the progress on our [GitHub](https://github.com/memgraph/memgraph/issues/2462). 
 </Callout>
 


### PR DESCRIPTION
Added point index to the list of drop indexes commands and added each drop index command under index, so it's easier to find all the important Cypher queries for certain type of index (although it's under create). 