### PR TITLE
Add GDB debugging on K8s

### DIFF
--- a/pages/getting-started/install-memgraph/kubernetes.mdx
+++ b/pages/getting-started/install-memgraph/kubernetes.mdx
@@ -242,6 +242,7 @@ their default values.
 | `storageClass.fsType`                       | Filesystem type for the StorageClass                                                                                             | `""`                                   |
 | `storageClass.reclaimPolicy`                | Reclaim policy for the StorageClass                                                                                              | `Retain`                               |
 | `storageClass.volumeBindingMode`            | Volume binding mode for the StorageClass                                                                                         | `Immediate`                            |
+| `debugging.ptrace`                          | If set to true, ptrace_scope will be modified with the init container to allow GDB debugging.                                    | `false`                                |
 
 To change the default chart values, provide your own `values.yaml` file during
 the installation:
@@ -609,6 +610,7 @@ The following table lists the configurable parameters of the Memgraph HA chart a
 | `secrets.name`                                           | The name of the Kubernetes secret containing Memgraph credentials                                            | `memgraph-secrets`         |
 | `secrets.userKey`                                        | The key in the Kubernetes secret for the Memgraph user, the value is passed to the `MEMGRAPH_USER` env.      | `USER`                     |
 | `secrets.passwordKey`                                    | The key in the Kubernetes secret for the Memgraph password, the value is passed to the `MEMGRAPH_PASSWORD`.  | `PASSWORD`                 |
+| `debugging.ptrace`                                       | If set to true, ptrace_scope will be modified with the init container to allow GDB debugging.                | `false`                    |
 
 For the `data` and `coordinators` sections, each item in the list has the following parameters:
 


### PR DESCRIPTION
### Release note

With the usage of init container, it is possible to debug relwithdebinfo Memgraph container on K8s cluster.

### Related product PRs

PRs from product repo this doc page is related to: 
https://github.com/memgraph/helm-charts/pull/145

### Checklist:

- [x] Add appropriate milestone (current release cycle)
- [x] Add `bugfix` or `feature` label, based on the product PR type you're documenting
- [x] Make sure all relevant tech details are documented
    - [x] Update reference pages (e.g. [clauses](https://memgraph.com/docs/querying/clauses), [functions](https://memgraph.com/docs/querying/functions), [flags](https://memgraph.com/docs/database-management/configuration#list-of-configuration-flags), [experimental](https://memgraph.com/docs/database-management/experimental-features), [monitoring](https://memgraph.com/docs/database-management/monitoring), [Cypher differences](https://memgraph.com/docs/querying/differences-in-cypher-implementations))
    - [x] Search for the feature you are working on (mentions) and make updates if needed
    - [x] Provide a basic example of usage
    - [x] In case your feature is an Enterprise one, list it under [ME page](https://memgraph.com/docs/database-management/enabling-memgraph-enterprise) and mark its page with Enterprise ([example](https://memgraph.com/docs/database-management/authentication-and-authorization/role-based-access-control)).
- [x] Check all content with Grammarly
- [x] Perform a self-review of my code
- [x] The build passes locally
- [x] My changes generate no new warnings or errors