### PR TITLE
Add how to debug GDB under MG charts

### DIFF
--- a/pages/database-management/debugging.mdx
+++ b/pages/database-management/debugging.mdx
@@ -412,6 +412,8 @@ To enable core dumps, create a `values.yaml` file with at least the following se
 createCoreDumpsClaim: true
 ```
 
+Setting this value to true will also enable the use of GDB inside Memgraph containers when using our provided [charts](https://github.com/memgraph/helm-charts).
+
 <Callout type="info">
 Feel free to copy values file from the [helm-charts repository](https://github.com/memgraph/helm-charts) as a base, since additional required fields may be missing from a minimal config.
 </Callout>


### PR DESCRIPTION
### Release note

Explained that when coreDumpsPVC is set to true and relwithdebinfo image is used, GDB can used inside MG containers.

### Checklist:

- [x] Add appropriate milestone (current release cycle)
- [x] Add `bugfix` or `feature` label, based on the product PR type you're documenting
- [x] Make sure all relevant tech details are documented
    - [x] Update reference pages (e.g. [clauses](https://memgraph.com/docs/querying/clauses), [functions](https://memgraph.com/docs/querying/functions), [flags](https://memgraph.com/docs/database-management/configuration#list-of-configuration-flags), [experimental](https://memgraph.com/docs/database-management/experimental-features), [monitoring](https://memgraph.com/docs/database-management/monitoring), [Cypher differences](https://memgraph.com/docs/querying/differences-in-cypher-implementations))
    - [x] Search for the feature you are working on (mentions) and make updates if needed
    - [x] Provide a basic example of usage
    - [x] In case your feature is an Enterprise one, list it under [ME page](https://memgraph.com/docs/database-management/enabling-memgraph-enterprise) and mark its page with Enterprise ([example](https://memgraph.com/docs/database-management/authentication-and-authorization/role-based-access-control)).
- [x] Check all content with Grammarly
- [x] Perform a self-review of my code
- [x] The build passes locally
- [x] My changes generate no new warnings or errors