### PR TITLE
Add scalar_kind options to vector index

### DIFF
--- a/pages/querying/vector-search.mdx
+++ b/pages/querying/vector-search.mdx
@@ -56,6 +56,7 @@ Below is a list of all configuration options:
 - `metric: string (default=l2sq)` ➡ The metric used for the vector search. The default value is `l2sq` (squared Euclidean distance).
 - `resize_coefficient: int (default=2)` ➡ When the index reaches its capacity, it resizes by multiplying the current capacity by this coefficient, if sufficient memory is available. 
 If resizing fails due to memory limitations, an exception will be thrown. Default value is `2`.
+- `scalar_kind: string (default=f32)` ➡ The scalar type used to store each vector component. Smaller types reduce memory usage but may decrease precision.
 
 ## Run vector search
 
@@ -139,9 +140,29 @@ for the metric is `l2sq` (squared Euclidean distance).
 
 ### Scalar type
 
-Properties are stored as 64-bit values in the property store and as 32-bit values in the vector index.
-Scalar type define the data type of each vector element. Default type for the
-metric is `f32`.
+Properties are stored as 64-bit values in the property store, but for efficiency, vector elements in the vector index are stored using 32-bit values by default. 
+The scalar_kind setting defines the data type used for each vector element in the index. The default scalar type is `f32` (32-bit floating point), 
+which offers a good balance between precision and memory usage. Other available options, such as `f16` and `f64`, 
+allow you to trade precision for memory efficiency or vice versa.
+
+| Scalar    | Description                                                |
+|-----------|------------------------------------------------------------|
+| `b1x8`    | Binary format (1 bit per element, stored in 8-bit chunks). |
+| `u40`     | Unsigned 40-bit integer.                                   |
+| `uuid`    | Universally unique identifier (UUID).                      |
+| `bf16`    | 16-bit floating point (bfloat16).                          |
+| `f64`     | 64-bit floating point (double).                            |
+| `f32`     | 32-bit floating point (float).                             |
+| `f16`     | 16-bit floating point.                                     |
+| `f8`      | 8-bit floating point.                                      |
+| `u64`     | 64-bit unsigned integer.                                   |
+| `u32`     | 32-bit unsigned integer.                                   |
+| `u16`     | 16-bit unsigned integer.                                   |
+| `u8`      | 8-bit unsigned integer.                                    |
+| `i64`     | 64-bit signed integer.                                     |
+| `i32`     | 32-bit signed integer.                                     |
+| `i16`     | 16-bit signed integer.                                     |
+| `i8`      | 8-bit signed integer.                                      |
 
 ## Drop vector index
 

--- a/pages/querying/vector-search.mdx
+++ b/pages/querying/vector-search.mdx
@@ -141,10 +141,9 @@ for the metric is `l2sq` (squared Euclidean distance).
 
 ### Scalar type
 
-Properties are stored as 64-bit values in the property store, but for efficiency, vector elements in the vector index are stored using 32-bit values by default. 
-The scalar_kind setting defines the data type used for each vector element in the index. The default scalar type is `f32` (32-bit floating point), 
-which offers a good balance between precision and memory usage. Other available options, such as `f16` and `f64`, 
-allow you to trade precision for memory efficiency or vice versa.
+Properties are stored as 64-bit values in the property store. However, for efficiency, vector elements in the vector index are stored using 32-bit values by default. 
+The `scalar_kind` setting determines the data type used for each vector element in the index. By default, the scalar type is set to `f32` (32-bit floating point), 
+which provides a good balance between precision and memory usage. Alternative options, such as `f16` for lower memory usage or `f64` for higher precision, allow you to fine-tune this tradeoff based on your specific needs.
 
 | Scalar    | Description                                                |
 |-----------|------------------------------------------------------------|

--- a/pages/querying/vector-search.mdx
+++ b/pages/querying/vector-search.mdx
@@ -82,6 +82,7 @@ Additionally, the same information can be retrieved with the `SHOW VECTOR INDEX 
 - `capacity: int` ➡ The capacity of the vector index.
 - `metric: string` ➡ Metric used for vector search similarity.
 - `size: int` ➡ The number of entries in the vector index.
+- `scalar_kind: string` ➡ The scalar type used for each vector element.
 
 {<h3 className="custom-header"> Usage: </h3>}
 
@@ -200,7 +201,7 @@ After Memgraph MAGE and Lab have been started, head over to the Query execution
 tab in Memgraph Lab and run the following query to create vector index:
 
 ```cypher
-CREATE VECTOR INDEX index_name ON :Node(vector) WITH CONFIG {"dimension": 2, "capacity": 1000, "metric": "cos","resize_coefficient": 2};
+CREATE VECTOR INDEX index_name ON :Node(vector) WITH CONFIG {"dimension": 2, "capacity": 1000, "metric": "cos", "resize_coefficient": 2, "scalar_kind": "f16"};
 ```
 
 Then, run the following query to inspect vector index:
@@ -217,11 +218,11 @@ SHOW VECTOR INDEX INFO;
 The above query will result with:
 
 ```
-+--------------+--------------+--------------+--------------+--------------+--------------+
-| capacity     | dimension    | index_name   | label        | property     | size         |
-+--------------+--------------+--------------+--------------+--------------+--------------+
-| 2048         | 2            | "index_name" | "Node"       | "vector"     | 0            |
-+--------------+--------------+--------------+--------------+--------------+--------------+
++--------------+--------------+--------------+--------------+--------------+--------+--------------+
+| capacity     | dimension    | index_name   | label        | property     | size   | scalar_kind  |
++--------------+--------------+--------------+--------------+--------------+--------+--------------+
+| 2048         | 2            | "index_name" | "Node"       | "vector"     | 0      | "f16"        |
++--------------+--------------+--------------+--------------+--------------+--------+--------------+
 ```
 
 {<h3 className="custom-header"> Create a node </h3>}
@@ -242,11 +243,11 @@ CALL vector_search.show_index_info() YIELD * RETURN *;
 The above query results in:
 
 ```
-+--------------+--------------+--------------+--------------+--------------+--------------+
-| capacity     | dimension    | index_name   | label        | property     | size         |
-+--------------+--------------+--------------+--------------+--------------+--------------+
-| 2048         | 2            | "index_name" | "Node"       | "vector"     | 1            |
-+--------------+--------------+--------------+--------------+--------------+--------------+
++--------------+--------------+--------------+--------------+--------------+--------+--------------+
+| capacity     | dimension    | index_name   | label        | property     | size   | scalar_kind  |
++--------------+--------------+--------------+--------------+--------------+--------+--------------+
+| 2048         | 2            | "index_name" | "Node"       | "vector"     | 1      | "f16"        |
++--------------+--------------+--------------+--------------+--------------+--------+--------------+
 ```
 
 We can see the size of the index changed, due to one new node.
@@ -290,11 +291,11 @@ CALL vector_search.show_index_info() YIELD * RETURN *;
 
 The size is now 5, due to 4 additional nodes:
 ```
-+--------------+--------------+--------------+--------------+--------------+--------------+
-| capacity     | dimension    | index_name   | label        | property     | size         |
-+--------------+--------------+--------------+--------------+--------------+--------------+
-| 2048         | 2            | "index_name" | "Node"       | "vector"     | 5            |
-+--------------+--------------+--------------+--------------+--------------+--------------+
++--------------+--------------+--------------+--------------+--------------+--------+--------------+
+| capacity     | dimension    | index_name   | label        | property     | size   | scalar_kind  |
++--------------+--------------+--------------+--------------+--------------+--------+--------------+
+| 2048         | 2            | "index_name" | "Node"       | "vector"     | 5      | "f16"        |
++--------------+--------------+--------------+--------------+--------------+--------+--------------+
 ```
 
 Let's again search for the top five similar nodes to the vector [2.0, 2.0] (to compare it to all nodes we have):


### PR DESCRIPTION
### Release note

Extended docs with options for `scalar_kind`.

### Related product PRs

PRs from product repo this doc page is related to: 
https://github.com/memgraph/memgraph/pull/3037

### Checklist:

- [x] Add appropriate milestone (current release cycle)
- [x] Add `bugfix` or `feature` label, based on the product PR type you're documenting
- [x] Make sure all relevant tech details are documented
    - [x] Update reference pages (e.g. [clauses](https://memgraph.com/docs/querying/clauses), [functions](https://memgraph.com/docs/querying/functions), [flags](https://memgraph.com/docs/database-management/configuration#list-of-configuration-flags), [experimental](https://memgraph.com/docs/database-management/experimental-features), [monitoring](https://memgraph.com/docs/database-management/monitoring), [Cypher differences](https://memgraph.com/docs/querying/differences-in-cypher-implementations))
    - [x] Search for the feature you are working on (mentions) and make updates if needed
    - [x] Provide a basic example of usage
    - [x] In case your feature is an Enterprise one, list it under [ME page](https://memgraph.com/docs/database-management/enabling-memgraph-enterprise) and mark its page with Enterprise ([example](https://memgraph.com/docs/database-management/authentication-and-authorization/role-based-access-control)).
- [x] Check all content with Grammarly
- [x] Perform a self-review of my code
- [x] The build passes locally
- [x] My changes generate no new warnings or errors