### PR TITLE
Update for GraphQL 7.2.0 middleware support

### DIFF
--- a/pages/client-libraries/graphql.mdx
+++ b/pages/client-libraries/graphql.mdx
@@ -15,19 +15,18 @@ queries against it.
 
 ## Quickstart
 
-We'll be using a simple Node.js application using the Neo4j GraphQL Library to connect
-to a running Memgraph instance and execute GraphQL queries against the database.
+We'll be using a simple Node.js application using the Neo4j GraphQL Library to
+connect to a running Memgraph instance and execute GraphQL queries against the
+database.
 
 Necessary prerequisites that should be installed in your local environment are:
 
-- [The Neo4j GraphQL Library](https://neo4j.com/docs/graphql/current/).
 - The [npm](https://www.npmjs.com/) package manager.
 - The [Node.js](https://nodejs.org/en) runtime environment.
-- A utility that can be used to host the GraphQL schema, e.g. [Apollo Server](https://www.apollographql.com/docs/apollo-server/).
 
 <Steps>
 
-### Run Memgraph 
+### Run Memgraph
 
 If you're new to Memgraph or you're in a developing stage, we
 recommend using the Memgraph Platform. Besides the database, it also
@@ -58,7 +57,7 @@ communicate with the client using the exposed 7687 port. Memgraph Lab is a web
 application you can use to visualize the data. It's accessible at
 [http://localhost:3000](http://localhost:3000) if Memgraph Platform is running
 correctly. The 7444 port enables Memgraph Lab to access and preview the logs,
-which is why both of these ports need to be exposed. 
+which is why both of these ports need to be exposed.
 
 For more information visit the getting started guide on [how to run Memgraph
 with Docker](/getting-started/install-memgraph/docker).
@@ -66,7 +65,7 @@ with Docker](/getting-started/install-memgraph/docker).
 
 ### Create a work directory
 
-Next, create a directory for your project and positioning yourself in it:
+Next, create a directory for your project and position yourself in it:
 
 ```
 mkdir graphql-example
@@ -83,21 +82,83 @@ npm init es6 --yes
 
 ### Setup the Neo4j GraphQL Library
 
-Install the library and its dependencies by running the following command:
+Install the library, its dependencies, and a GraphQL server (such as [Apollo
+Server](https://www.apollographql.com/docs/apollo-server/)) by running the
+following command:
 
 ```
-npm install @neo4j/graphql graphql neo4j-driver @apollo/server
+npm install @neo4j/graphql@7.2.0 graphql neo4j-driver @apollo/server
 ```
+
+<Callout type="warning">
+Memgraph is currently compatible with `@neo4j/graphql@7.2.0`. Other versions of
+the GraphQL middleware may not generate Memgraph-compatible queries.
+</Callout>
+
+### Create the Schema
+
+GraphQL APIs need to be aware of the shape of the data they are working with,
+which is abstracted into the concept of GraphQL schemas. This must be explicitly
+specified in the Node.js application file. In terms of a property graph, the
+schema must contain the labels and properties of nodes and relationships.
+(Whilst the Neo4j GraphQL Library has support for automatic graph introspection,
+Memgraph currently does not support this feature.)
+
+More information on defining a GraphQL schema can be found in the
+[GraphQL documentation](https://graphql.org/learn/schema/).
+
+Given the following dataset:
+
+```cypher
+CREATE (u1:User {id: "user1", name: "Alice"})
+CREATE (u2:User {id: "user2", name: "Bob"})
+CREATE (p1:Post {id: "post1", content: "Alice's first post!"})
+CREATE (p2:Post {id: "post2", content: "Bob's great idea."})
+CREATE (p3:Post {id: "post3", content: "Another thought from Alice."})
+CREATE (u1)-[:HAS_POST]->(p1)
+CREATE (u2)-[:HAS_POST]->(p2)
+CREATE (u1)-[:HAS_POST]->(p3);
+```
+
+We could create the following schema, where `type Post @node` corresponds to a
+vertex with a `:Post` label, `content: String` to a `content` property on the
+vertex, and `:HAS_POST` edges are notated using the `@relationship` directive
+with type `HAS_POST`.
+
+```graphql
+type Post @node {
+    id: ID! @id
+    content: String!
+    creator: [User!]! @relationship(type: "HAS_POST", direction: IN)
+}
+
+type User @node {
+    id: ID! @id
+    name: String
+    posts: [Post!]! @relationship(type: "HAS_POST", direction: OUT)
+}
+```
+
+<Callout>
+Note that relationships in the schema must always be expressed as many-to-many
+(i.e, as array `[ ]` types), even if they model one-to-one, one-to-many, or
+many-to-one relationships. This is a restriction of the GraphQL middleware.
+</Callout>
 
 ### Create the application file
 
-The application file will be used to setup the Neo4j GraphQL Library and connect to the running Memgraph instance.
+The application file will be used to setup the Neo4j GraphQL Library and connect
+to the running Memgraph instance.
 
-Create the file and add the content below.
+Create the file:
 
 ```
 touch index.js
 ```
+
+Add the content below. Note that the schema we created above is used as a
+string literal for `typeDefs`:
+
 
 ```js
 import { Neo4jGraphQL } from "@neo4j/graphql";
@@ -105,14 +166,14 @@ import { ApolloServer } from '@apollo/server'
 import { startStandaloneServer } from '@apollo/server/standalone';
 import neo4j from 'neo4j-driver'
 
-const typeDefs = `#graphql
-type Post {
+const typeDefs = `
+type Post @node {
     id: ID! @id
     content: String!
-    creator: User! @relationship(type: "HAS_POST", direction: IN)
+    creator: [User!]! @relationship(type: "HAS_POST", direction: IN)
 }
 
-type User {
+type User @node {
     id: ID! @id
     name: String
     posts: [Post!]! @relationship(type: "HAS_POST", direction: OUT)
@@ -131,16 +192,24 @@ const server = new ApolloServer({
 });
 
 const { url } = await startStandaloneServer(server, {
-    context: async ({ req }) => ({ req, sessionConfig: {database: "memgraph"}}),
+    context: async ({ req }) => ({
+        req,
+        sessionConfig: { database: "memgraph" },
+        cypherQueryOptions: { addVersionPrefix: false }
+    }),
     listen: { port: 4000 },
 });
 
 console.log(`🚀 Server ready at ${url}`);
+
 ```
 
-The example above shows that the data schema must be explicitly defined. The GraphQL server can only process queries that operate on data conforming to the specified schemas. In this example, the schema defines a graph, where the nodes labeled as `User` or `Post` may be connected with a `HAS_POST` relationship. 
-
-To set up a GraphQL client against a running Memgraph instance, you have to specify the GraphQL schema, set up the used drivers, and specify Memgraph as the used database. Specifying the used database is especially important because the default database name in the `driverConfig` is not compatible with Memgraph.
+To set up a GraphQL client against a running Memgraph instance, you have to
+specify the GraphQL schema, set up the used drivers, and specify Memgraph as the
+used database. Specifying the used database is especially important because the
+default database name in the `driverConfig` is not compatible with Memgraph.
+You must also use `cypherQueryOptions: { addVersionPrefix: false }` to ensure
+that any Cypher queries are compatible with Memgraph.
 
 ### Run the application
 
@@ -152,27 +221,69 @@ node index.js
 
 ### Interact with Memgraph
 
-You are now ready to interact with Memgraph using GraphQL queries through **localhost(127.0.0.1):4000**.
+You are now ready to interact with Memgraph using GraphQL queries through the 
+GraphQL server on `localhost:4000` or `127.0.0.1:4000`.
+
+Running a GraphQL query  on the example dataset, such as:
+
+```graphql
+query Users {
+  users {
+    name
+    posts {
+      content
+    }
+  }
+}
+```
+
+will yield the following results:
+
+```json
+{
+  "data": {
+    "users": [
+      {
+        "name": "Alice",
+        "posts": [
+          {
+            "content": "Alice's first post!"
+          },
+          {
+            "content": "Another thought from Alice."
+          }
+        ]
+      },
+      {
+        "name": "Bob",
+        "posts": [
+          {
+            "content": "Bob's great idea."
+          }
+        ]
+      }
+    ]
+  }
+}
+```
 
 </Steps>
 
-## Current limitations
+## Features
 
-Memgraph currently supports CRUD operations using GraphQL. That means that the entities inside
-the database can be updated and basic traversals can be done, but more complicated operations
-are currently not supported through GraphQL.
+Memgraph support includes the following GraphQL features:
 
-GraphQL APIs need to be aware of the shape of data they are working with which is abstracted
-into the concept of GraphQL schemas. Currently this has to be specified in the Node.js
-application file explicitly. In terms of a property graph, this means the labels and properties
-of nodes and relationships. The Neo4j GraphQL Library has support for automatic graph
-introspection, Memgraph currently does not support this feature.
+- [Read queries based on a defined schema.](https://neo4j.com/docs/graphql/current/queries-aggregations/queries/)
+- [Aggregations on nodes and edges.](https://neo4j.com/docs/graphql/current/queries-aggregations/aggregations/)
+- [Sorting results on any object type defined in the schema.](https://neo4j.com/docs/graphql/current/queries-aggregations/sorting/)
+- [Offset and cursor based pagination.](https://neo4j.com/docs/graphql/current/queries-aggregations/pagination/)
+- [Create, update, and delete mutations.](https://neo4j.com/docs/graphql/current/mutations/)
+- [Custom Cypher statements with the `@cypher` directive.](https://neo4j.com/docs/graphql/current/directives/custom-logic/#_cypher)
 
 <Callout type="info">
 
 If you encounter serialization errors while using GraphQL client, we recommend
 referring to our [Serialization errors](/help-center/errors/serialization) page
-for detailed guidance on troubleshooting and best practices. 
-
+for detailed guidance on troubleshooting and best practices.
 
 </Callout>


### PR DESCRIPTION
### Release note

Update GraphQL documentation for compatibility with the currently supported `@neo4j/graphql` middleware version, which is `7.2.0`.

### Related product PRs

PRs from product repo this doc page is related to: 
- [#3027](https://github.com/memgraph/memgraph/pull/3027)

### Checklist:

- [x] Add appropriate milestone (current release cycle)
- [x] Add `bugfix` or `feature` label, based on the product PR type you're documenting
- [x] Make sure all relevant tech details are documented
    - [x] Update reference pages (e.g. [clauses](https://memgraph.com/docs/querying/clauses), [functions](https://memgraph.com/docs/querying/functions), [flags](https://memgraph.com/docs/database-management/configuration#list-of-configuration-flags), [experimental](https://memgraph.com/docs/database-management/experimental-features), [monitoring](https://memgraph.com/docs/database-management/monitoring), [Cypher differences](https://memgraph.com/docs/querying/differences-in-cypher-implementations))
    - [x] Search for the feature you are working on (mentions) and make updates if needed
    - [x] Provide a basic example of usage
    - [x] In case your feature is an Enterprise one, list it under [ME page](https://memgraph.com/docs/database-management/enabling-memgraph-enterprise) and mark its page with Enterprise ([example](https://memgraph.com/docs/database-management/authentication-and-authorization/role-based-access-control)).
- [x] Check all content with Grammarly
- [x] Perform a self-review of my code
- [x] The build passes locally
- [x] My changes generate no new warnings or errors