### PR TITLE
Add Rust overview page

### DIFF
--- a/pages/custom-query-modules/rust.mdx
+++ b/pages/custom-query-modules/rust.mdx
@@ -1,0 +1,62 @@
+---
+title: How to create a query module in Rust
+description: Enhance your graph data analysis by integrating the Rust programming language with Memgraph.
+---
+
+import { Callout } from 'nextra/components'
+import {CommunityLinks} from '/components/social-card/CommunityLinks'
+
+# How to create a query module in Rust
+
+To create a query module in Rust for Memgraph, you need to compile your code
+into a shared library (`.so` file) that Memgraph can load dynamically at
+runtime.
+
+## Development environment options 
+
+You have two main ways to set up your Rust
+development environment:
+
+1. **Using your own environment** <br/>
+You can compile Rust query modules on your local machine or server, but you’ll
+need to manually install Rust tooling and any necessary dependencies (like
+`cargo` and system libraries).
+
+2. **Using the MAGE environment** <br/>
+The Memgraph MAGE development Docker image (with the `-dev` tag) contains all
+required dependencies and provides an isolated environment ideal for
+development. 
+
+See the [quickstart to custom query
+module](/custom-query-modules/rust/rust-example) in Rust for a full guide.
+
+## How the Rust API works 
+
+The Rust API is a wrapper around Memgraph’s C API, providing a more ergonomic
+and memory-safe interface while maintaining high performance. Query modules
+written in Rust are compiled to shared libraries and loaded by Memgraph at
+startup.
+
+- The API includes wrappers for working with graph data, procedures, results,
+errors, and more.
+- You can define custom procedures using macros like `init_module!`,
+`define_procedure!`, and `close_module!`.
+- Exception handling in Rust (with `Result` types) ensures better stability, but
+unhandled `panic!` calls can still crash Memgraph.
+
+Full reference: [Rust API documentation](/custom-query-modules/rust/rust-api).
+
+## Quickstart summary 
+
+To get started quickly:
+1. Run Memgraph using the MAGE development Docker image.
+2. Install `cargo` inside the container.
+3. Copy the query module boilerplate and adjust `Cargo.toml` and `lib.rs`.
+4. Build your module using `python3 setup build -p
+   /usr/lib/memgraph/query_modules/`.
+5. Load the module in Memgraph with `CALL mg.load_all();`.
+
+Follow the [quickstart guide](/custom-query-modules/rust/rust-example) for
+detailed instructions.
+
+<CommunityLinks/>


### PR DESCRIPTION
Added an overview page for Rust to fit the rest of the docs structure

Closes: https://github.com/memgraph/documentation/issues/887