### PR TITLE
Add database UUID to show storage info

### DIFF
--- a/pages/database-management/backup-and-restore.mdx
+++ b/pages/database-management/backup-and-restore.mdx
@@ -268,8 +268,11 @@ storage.
 When running Memgraph with multi-tenancy, every database other than the default database
 (named `memgraph`) will have its own associated database UUID. Database UUID can be inspected
 by running the `SHOW STORAGE INFO` command and reading the value under the `database_uuid` key.
+The default database `memgraph` does not follow this directory structure and the data files are directly located under `/var/lib/memgraph`.
 
 The default data directory location for a specific database is `/var/lib/memgraph/<database_uuid>/`. 
+The default database `memgraph` does not follow this directory structure and the data files are directly located under `/var/lib/memgraph`.
+
 Manual snapshot backup flow should look like this:
 
 <Steps>

--- a/pages/database-management/backup-and-restore.mdx
+++ b/pages/database-management/backup-and-restore.mdx
@@ -263,13 +263,11 @@ keeps its own
 Memgraph persists the metadata used in the implementation of the on-disk
 storage. 
 
-## Backup in multi-tenancy (Enterprise)
+## Backup in multi-tenancy <sup style={{ fontSize: '0.6em', color: '#888' }}>Enterprise</sup>
 
 When running Memgraph with multi-tenancy, every database other than the default database
 (named `memgraph`) will have its own associated database UUID. Database UUID can be inspected
 by running the `SHOW STORAGE INFO` command and reading the value under the `database_uuid` key.
-The default database `memgraph` does not follow this directory structure and the data files are directly located under `/var/lib/memgraph`.
-
 The default data directory location for a specific database is `/var/lib/memgraph/<database_uuid>/`. 
 The default database `memgraph` does not follow this directory structure and the data files are directly located under `/var/lib/memgraph`.
 

--- a/pages/database-management/backup-and-restore.mdx
+++ b/pages/database-management/backup-and-restore.mdx
@@ -262,3 +262,49 @@ keeps its own
 [WAL](https://github.com/facebook/rocksdb/wiki/Write-Ahead-Log-%28WAL%29) files.
 Memgraph persists the metadata used in the implementation of the on-disk
 storage. 
+
+## Backup in multi-tenancy (Enterprise)
+
+When running Memgraph with multi-tenancy, every database other than the default database
+(named `memgraph`) will have its own associated database UUID. Database UUID can be inspected
+by running the `SHOW STORAGE INFO` command and reading the value under the `database_uuid` key.
+
+The default data directory location for a specific database is `/var/lib/memgraph/<database_uuid>/`. 
+Manual snapshot backup flow should look like this:
+
+<Steps>
+
+{<h3 className="custom-header">Create snapshots inside Memgraph</h3>}
+
+Create snapshot for every database (or let it create automatically with periodic snapshot execution inside Memgraph)
+
+{<h3 className="custom-header">Perform backup</h3>}
+
+Backup the snapshot for every database into a 3rd party location. Currently, you're encouraged to perform the backup mechanisms by 
+yourself with tools such as [rclone](https://rclone.org/).
+
+{<h3 className="custom-header">When performing recovery, copy the snapshot to Memgraph</h3>}
+
+When recovering a specific database, copy the snapshot to any data location
+  - if the data directory the snapshot is being copied to is a location that's outside the database directory, ensure the snapshot
+    has the permissions to be copied to the database data directory
+  - if the data directory the snapshot is being copied to is a location that's inside the database directory, there should be no issues
+    with permissions as there is no copying being performed from source to target directory location
+
+{<h3 className="custom-header">Position to specific database</h3>}
+
+Position the database driver interacting with Memgraph into the database using `USE DATABASE <database_name>` 
+
+{<h3 className="custom-header">Recover the snapshot</h3>}
+
+Execute `RECOVER SNAPSHOT <path_to_snapshot> FORCE`
+
+</Steps>
+
+
+## Best practices
+
+Memgraph can optimize restoring of snapshots in a multi-threaded manner. To enable multi-threaded restoration of a snapshot, you need to ensure
+the following flags are present:
+- `--storage-parallel-schema-recovery=true`
+- `--storage-recovery-thread-count=<number_of_cores>` where `number_of_cores` is the amount of CPU cores to parallelize the restoration process

--- a/pages/database-management/multi-tenancy.md
+++ b/pages/database-management/multi-tenancy.md
@@ -16,7 +16,7 @@ Instead, global limitations are imposed on Memgraph as a whole.
 
 ## Default database
 
-A default database named 'memgraph' is automatically created during startup. New
+A default database named `memgraph` is automatically created during startup. New
 users are granted access only to this default database. The default
 database name cannot be altered.
 
@@ -26,6 +26,9 @@ Isolated databases within Memgraph function as distinct single-database Memgraph
 instances. Queries executed on a specific database should operate as if it were
 the sole database in the system, preventing cross-database contamination. Users
 interact with individual databases, and cross-database queries are prohibited.
+
+Every database has its own database UUID, which can be read by running the `SHOW STORAGE INFO`
+query on a particular database.
 
 ## Database configuration and data directory
 

--- a/pages/database-management/server-stats.md
+++ b/pages/database-management/server-stats.md
@@ -30,6 +30,7 @@ The result will contain the following fields:
 | Field                        | Description                                                                                                                                                                                   |
 |------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | name                         | Name of the current database.                    |
+| database_uuid                | Unique UUID of the database.                     |
 | vertex_count                 | The number of stored nodes (vertices).                                                                                                                                                        |
 | edge_count                   | The number of stored relationships (edges).                                                                                                                                                   |
 | average_degree               | The average number of relationships of a single node.                                                                                                                                         |

--- a/pages/fundamentals/storage-memory-usage.mdx
+++ b/pages/fundamentals/storage-memory-usage.mdx
@@ -761,6 +761,7 @@ SHOW STORAGE INFO;
 | storage info                   | value                          |
 +--------------------------------+--------------------------------+
 | "name"                         | "memgraph"                     |
+| "database_uuid"                | "memgraph"                     |
 | "vertex_count"                 | 0                              |
 | "edge_count"                   | 0                              |
 | "average_degree"               | 0                              |

--- a/pages/fundamentals/storage-memory-usage.mdx
+++ b/pages/fundamentals/storage-memory-usage.mdx
@@ -757,26 +757,26 @@ SHOW STORAGE INFO;
 ```
 
 ```copy=false
-+--------------------------------+--------------------------------+
-| storage info                   | value                          |
-+--------------------------------+--------------------------------+
-| "name"                         | "memgraph"                     |
-| "database_uuid"                | "memgraph"                     |
-| "vertex_count"                 | 0                              |
-| "edge_count"                   | 0                              |
-| "average_degree"               | 0                              |
-| "vm_max_map_count"             | 453125                         |
-| "memory_res"                   | "43.16MiB"                     |
-| "peak_memory_res"              | "43.16MiB"                     |
-| "unreleased_delta_objects"     | 0                              |
-| "disk_usage"                   | "104.46KiB"                    |
-| "memory_tracked"               | "8.52MiB"                      |
-| "allocation_limit"             | "58.55GiB"                     |
-| "global_isolation_level"       | "SNAPSHOT_ISOLATION"           |
-| "session_isolation_level"      | ""                             |
-| "next_session_isolation_level" | ""                             |
-| "storage_mode"                 | "IN_MEMORY_TRANSACTIONAL"      |
-+--------------------------------+--------------------------------+
++--------------------------------+----------------------------------------+
+| storage info                   | value                                  |
++--------------------------------+----------------------------------------+
+| "name"                         | "memgraph"                             |
+| "database_uuid"                | "99f743e8-5b98-4b78-8384-f96862b7f01b" |
+| "vertex_count"                 | 0                                      |
+| "edge_count"                   | 0                                      |
+| "average_degree"               | 0                                      |
+| "vm_max_map_count"             | 453125                                 |
+| "memory_res"                   | "43.16MiB"                             |
+| "peak_memory_res"              | "43.16MiB"                             |
+| "unreleased_delta_objects"     | 0                                      |
+| "disk_usage"                   | "104.46KiB"                            |
+| "memory_tracked"               | "8.52MiB"                              |
+| "allocation_limit"             | "58.55GiB"                             |
+| "global_isolation_level"       | "SNAPSHOT_ISOLATION"                   |
+| "session_isolation_level"      | ""                                     |
+| "next_session_isolation_level" | ""                                     |
+| "storage_mode"                 | "IN_MEMORY_TRANSACTIONAL"              |
++--------------------------------+----------------------------------------+
 ```
 
 Find out more about `SHOW STORAGE INFO` query on [Server


### PR DESCRIPTION
### Release note

Added `database_uuid` parameter to `SHOW STORAGE INFO`

### Related product PRs

[PRs from product repo this doc page is related to: 
[(paste the links to the PRs)](https://github.com/memgraph/memgraph/pull/3111)](https://github.com/memgraph/memgraph/pull/3111)

### Checklist:

- [x] Add appropriate milestone (current release cycle)
- [x] Add `bugfix` or `feature` label, based on the product PR type you're documenting
- [x] Make sure all relevant tech details are documented
    - [x] Update reference pages (e.g. [clauses](https://memgraph.com/docs/querying/clauses), [functions](https://memgraph.com/docs/querying/functions), [flags](https://memgraph.com/docs/database-management/configuration#list-of-configuration-flags), [experimental](https://memgraph.com/docs/database-management/experimental-features), [monitoring](https://memgraph.com/docs/database-management/monitoring), [Cypher differences](https://memgraph.com/docs/querying/differences-in-cypher-implementations))
    - [x] Search for the feature you are working on (mentions) and make updates if needed
    - [x] Provide a basic example of usage
    - [x] In case your feature is an Enterprise one, list it under [ME page](https://memgraph.com/docs/database-management/enabling-memgraph-enterprise) and mark its page with Enterprise ([example](https://memgraph.com/docs/database-management/authentication-and-authorization/role-based-access-control)).
- [x] Check all content with Grammarly
- [x] Perform a self-review of my code
- [x] The build passes locally
- [x] My changes generate no new warnings or errors