### PR TITLE
Add API reference for ZonedDateTime

### DIFF
--- a/pages/custom-query-modules/c/c-api.mdx
+++ b/pages/custom-query-modules/c/c-api.mdx
@@ -41,6 +41,7 @@ Memgraph in order to use them.
 | **[mgp_local_time_parameters](#mgp_local_time_parameters)** |   |
 | **[mgp_local_date_time_parameters](#mgp_local_date_time_parameters)** |   |
 | **[mgp_duration_parameters](#mgp_duration_parameters)** |   |
+| **[mgp_zoned_date_time_parameters](#mgp_zoned_date_time_parameters)** |   |
 | **[mgp_execution_headers](#mgp_execution_headers)** | Headers of the query that's executed through the API. |
 | **[mgp_execution_result](#mgp_execution_result)** | Type handling the pulling logic of the query executing through the API. |
 
@@ -49,7 +50,7 @@ Memgraph in order to use them.
 
 |                | Name           |
 | -------------- | -------------- |
-| enum| **[mgp_value_type](#enum-mgp-value-type)** &#123;MGP_VALUE_TYPE_NULL, MGP_VALUE_TYPE_BOOL, MGP_VALUE_TYPE_INT, MGP_VALUE_TYPE_DOUBLE, MGP_VALUE_TYPE_STRING, MGP_VALUE_TYPE_LIST, MGP_VALUE_TYPE_MAP, MGP_VALUE_TYPE_VERTEX, MGP_VALUE_TYPE_EDGE, MGP_VALUE_TYPE_PATH, MGP_VALUE_TYPE_DATE, MGP_VALUE_TYPE_LOCAL_TIME, MGP_VALUE_TYPE_LOCAL_DATE_TIME, MGP_VALUE_TYPE_DURATION&#125;<br />All available types that can be stored in a mgp_value.  |
+| enum| **[mgp_value_type](#enum-mgp-value-type)** &#123;MGP_VALUE_TYPE_NULL, MGP_VALUE_TYPE_BOOL, MGP_VALUE_TYPE_INT, MGP_VALUE_TYPE_DOUBLE, MGP_VALUE_TYPE_STRING, MGP_VALUE_TYPE_LIST, MGP_VALUE_TYPE_MAP, MGP_VALUE_TYPE_VERTEX, MGP_VALUE_TYPE_EDGE, MGP_VALUE_TYPE_PATH, MGP_VALUE_TYPE_DATE, MGP_VALUE_TYPE_LOCAL_TIME, MGP_VALUE_TYPE_LOCAL_DATE_TIME, MGP_VALUE_TYPE_DURATION, MGP_VALUE_TYPE_ZONED_DATE_TIME&#125;<br />All available types that can be stored in a mgp_value.  |
 | typedef void(*)(struct mgp_list *, struct mgp_graph *, struct mgp_result *, struct mgp_memory *) | **[mgp_proc_cb](#typedef-mgp-proc-cb)** <br />Entry-point for a query module read procedure, invoked through openCypher.  |
 | typedef void(*)(struct mgp_list *, struct mgp_graph *, struct mgp_memory *) | **[mgp_proc_initializer](#typedef-mgp-proc-initializer)** <br />Initialization point for a query module read procedure, invoked before procedure.  |
 | typedef void(*)() | **[mgp_proc_cleanup](#typedef-mgp-proc-cleanup)** <br />Cleanup for a query module read procedure  |
@@ -80,6 +81,7 @@ Memgraph in order to use them.
 | enum [mgp_error](#variable-mgp-error) | **[mgp_value_make_local_time](#function-mgp-value-make-local-time)**(struct mgp_local_time * val, struct mgp_value ** result)<br />Create a mgp_value storing a mgp_local_time.  |
 | enum [mgp_error](#variable-mgp-error) | **[mgp_value_make_local_date_time](#function-mgp-value-make-local-date-time)**(struct mgp_local_date_time * val, struct mgp_value ** result)<br />Create a mgp_value storing a mgp_local_date_time.  |
 | enum [mgp_error](#variable-mgp-error) | **[mgp_value_make_duration](#function-mgp-value-make-duration)**(struct mgp_duration * val, struct mgp_value ** result)<br />Create a mgp_value storing a mgp_duration.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_value_make_zoned_date_time](#function-mgp-value-make-zoned-date-time)**(struct mgp_zoned_date_time * val, struct mgp_value ** result)<br />Create a mgp_value storing a mgp_zoned_date_time.  |
 | enum [mgp_error](#variable-mgp-error) | **[mgp_value_get_type](#function-mgp-value-get-type)**(struct mgp_value * val, enum [mgp_value_type](#enum-mgp-value-type) * result)<br />Get the type of the value contained in mgp_value.  |
 | enum [mgp_error](#variable-mgp-error) | **[mgp_value_is_null](#function-mgp-value-is-null)**(struct mgp_value * val, int * result)<br />Result is non-zero if the given mgp_value represents `null`.  |
 | enum [mgp_error](#variable-mgp-error) | **[mgp_value_is_bool](#function-mgp-value-is-bool)**(struct mgp_value * val, int * result)<br />Result is non-zero if the given mgp_value stores a boolean.  |
@@ -95,6 +97,7 @@ Memgraph in order to use them.
 | enum [mgp_error](#variable-mgp-error) | **[mgp_value_is_local_time](#function-mgp-value-is-local-time)**(struct mgp_value * val, int * result)<br />Result is non-zero if the given mgp_value stores a local time.  |
 | enum [mgp_error](#variable-mgp-error) | **[mgp_value_is_local_date_time](#function-mgp-value-is-local-date-time)**(struct mgp_value * val, int * result)<br />Result is non-zero if the given mgp_value stores a local date-time.  |
 | enum [mgp_error](#variable-mgp-error) | **[mgp_value_is_duration](#function-mgp-value-is-duration)**(struct mgp_value * val, int * result)<br />Result is non-zero if the given mgp_value stores a duration.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_value_is_zoned_date_time](#function-mgp-value-is-zoned-date-time)**(struct mgp_value * val, int * result)<br />Result is non-zero if the given mgp_value stores a zoned date-time.  |
 | enum [mgp_error](#variable-mgp-error) | **[mgp_value_get_bool](#function-mgp-value-get-bool)**(struct mgp_value * val, int * result)<br />Get the contained boolean value.  |
 | enum [mgp_error](#variable-mgp-error) | **[mgp_value_get_int](#function-mgp-value-get-int)**(struct mgp_value * val, int64_t * result)<br />Get the contained integer.  |
 | enum [mgp_error](#variable-mgp-error) | **[mgp_value_get_double](#function-mgp-value-get-double)**(struct mgp_value * val, double * result)<br />Get the contained double floating-point.  |
@@ -108,6 +111,7 @@ Memgraph in order to use them.
 | enum [mgp_error](#variable-mgp-error) | **[mgp_value_get_local_time](#function-mgp-value-get-local-time)**(struct mgp_value * val, struct mgp_local_time ** result)<br />Get the contained local time.  |
 | enum [mgp_error](#variable-mgp-error) | **[mgp_value_get_local_date_time](#function-mgp-value-get-local-date-time)**(struct mgp_value * val, struct mgp_local_date_time ** result)<br />Get the contained local date-time.  |
 | enum [mgp_error](#variable-mgp-error) | **[mgp_value_get_duration](#function-mgp-value-get-duration)**(struct mgp_value * val, struct mgp_duration ** result)<br />Get the contained duration.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_value_get_zoned_date_time](#function-mgp-value-get-zoned-date-time)**(struct mgp_value * val, struct mgp_zoned_date_time ** result)<br />Get the contained zoned date-time.  |
 | enum [mgp_error](#variable-mgp-error) | **[mgp_list_make_empty](#function-mgp-list-make-empty)**(size_t capacity, struct mgp_memory * memory, struct mgp_list ** result)<br />Create an empty list with given capacity.  |
 | void | **[mgp_list_destroy](#function-mgp-list-destroy)**(struct mgp_list * list)<br />Free the memory used by the given mgp_list and contained elements.  |
 | enum [mgp_error](#variable-mgp-error) | **[mgp_list_contains_deleted](#function-mgp-list-contains-deleted)**(struct mgp_list * list, int * result)<br />Result is non-zero if the given list contains any deleted values, otherwise 0.  |
@@ -244,13 +248,33 @@ Memgraph in order to use them.
 | enum [mgp_error](#variable-mgp-error) | **[mgp_local_date_time_get_hour](#function-mgp-local-date-time-get-hour)**(struct mgp_local_date_time * local_date_time, int * hour)<br />Get the hour property of the local date-time.  |
 | enum [mgp_error](#variable-mgp-error) | **[mgp_local_date_time_get_minute](#function-mgp-local-date-time-get-minute)**(struct mgp_local_date_time * local_date_time, int * minute)<br />Get the minute property of the local date-time.  |
 | enum [mgp_error](#variable-mgp-error) | **[mgp_local_date_time_get_second](#function-mgp-local-date-time-get-second)**(struct mgp_local_date_time * local_date_time, int * second)<br />Get the second property of the local date-time.  |
-| enum [mgp_error](#variable-mgp-error) | **[mgp_local_date_time_get_millisecond](#function-mgp-local-date-time-get-millisecond)**(struct mgp_local_date_time * local_date_time, int * millisecond)<br />Get the milisecond property of the local date-time.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_local_date_time_get_millisecond](#function-mgp-local-date-time-get-millisecond)**(struct mgp_local_date_time * local_date_time, int * millisecond)<br />Get the millisecond property of the local date-time.  |
 | enum [mgp_error](#variable-mgp-error) | **[mgp_local_date_time_get_microsecond](#function-mgp-local-date-time-get-microsecond)**(struct mgp_local_date_time * local_date_time, int * microsecond)<br />Get the microsecond property of the local date-time.  |
 | enum [mgp_error](#variable-mgp-error) | **[mgp_local_date_time_timestamp](#function-mgp-local-date-time-timestamp)**(struct mgp_local_date_time * local_date_time, int64_t * timestamp)<br />Get the local date-time as microseconds from Unix epoch.  |
 | enum [mgp_error](#variable-mgp-error) | **[mgp_local_date_time_now](#function-mgp-local-date-time-now)**(struct mgp_memory * memory, struct mgp_local_date_time ** local_date_time)<br />Get the local date-time representing current date and time.  |
 | enum [mgp_error](#variable-mgp-error) | **[mgp_local_date_time_add_duration](#function-mgp-local-date-time-add-duration)**(struct mgp_local_date_time * local_date_time, struct mgp_duration * dur, struct mgp_memory * memory, struct mgp_local_date_time ** result)<br />Add a duration to the local date-time.  |
 | enum [mgp_error](#variable-mgp-error) | **[mgp_local_date_time_sub_duration](#function-mgp-local-date-time-sub-duration)**(struct mgp_local_date_time * local_date_time, struct mgp_duration * dur, struct mgp_memory * memory, struct mgp_local_date_time ** result)<br />Subtract a duration from the local date-time.  |
 | enum [mgp_error](#variable-mgp-error) | **[mgp_local_date_time_diff](#function-mgp-local-date-time-diff)**(struct mgp_local_date_time * first, struct mgp_local_date_time * second, struct mgp_memory * memory, struct mgp_duration ** result)<br />Get a duration between two local date-times.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_zoned_date_time_from_string](#function-mgp-zoned-date-time-from-string)**(const char * string, struct mgp_memory * memory, struct mgp_zoned_date_time ** zoned_date_time)<br />Create a zoned date-time from a string following the ISO 8601 format. Supports timezone offsets and named timezones.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_zoned_date_time_from_parameters](#function-mgp-zoned-date-time-from-parameters)**(struct [mgp_zoned_date_time_parameters](#mgp_zoned_date_time_parameters) * parameters, struct mgp_memory * memory, struct mgp_zoned_date_time ** zoned_date_time)<br />Create a zoned date-time from [mgp_zoned_date_time_parameters](#mgp_zoned_date_time_parameters).  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_zoned_date_time_copy](#function-mgp-zoned-date-time-copy)**(struct mgp_zoned_date_time * zoned_date_time, struct mgp_memory * memory, struct mgp_zoned_date_time ** result)<br />Copy a mgp_zoned_date_time.  |
+| void | **[mgp_zoned_date_time_destroy](#function-mgp-zoned-date-time-destroy)**(struct mgp_zoned_date_time * zoned_date_time)<br />Free the memory used by a mgp_zoned_date_time.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_zoned_date_time_equal](#function-mgp-zoned-date-time-equal)**(struct mgp_zoned_date_time * first, struct mgp_zoned_date_time * second, int * result)<br />Result is non-zero if given zoned date-times are equal, otherwise 0.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_zoned_date_time_get_year](#function-mgp-zoned-date-time-get-year)**(struct mgp_zoned_date_time * zoned_date_time, int * year)<br />Get the year property of the zoned date-time.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_zoned_date_time_get_month](#function-mgp-zoned-date-time-get-month)**(struct mgp_zoned_date_time * zoned_date_time, int * month)<br />Get the month property of the zoned date-time.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_zoned_date_time_get_day](#function-mgp-zoned-date-time-get-day)**(struct mgp_zoned_date_time * zoned_date_time, int * day)<br />Get the day property of the zoned date-time.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_zoned_date_time_get_hour](#function-mgp-zoned-date-time-get-hour)**(struct mgp_zoned_date_time * zoned_date_time, int * hour)<br />Get the hour property of the zoned date-time.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_zoned_date_time_get_minute](#function-mgp-zoned-date-time-get-minute)**(struct mgp_zoned_date_time * zoned_date_time, int * minute)<br />Get the minute property of the zoned date-time.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_zoned_date_time_get_second](#function-mgp-zoned-date-time-get-second)**(struct mgp_zoned_date_time * zoned_date_time, int * second)<br />Get the second property of the zoned date-time.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_zoned_date_time_get_millisecond](#function-mgp-zoned-date-time-get-millisecond)**(struct mgp_zoned_date_time * zoned_date_time, int * millisecond)<br />Get the millisecond property of the zoned date-time.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_zoned_date_time_get_microsecond](#function-mgp-zoned-date-time-get-microsecond)**(struct mgp_zoned_date_time * zoned_date_time, int * microsecond)<br />Get the microsecond property of the zoned date-time.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_zoned_date_time_get_timezone](#function-mgp-zoned-date-time-get-timezone)**(struct mgp_zoned_date_time * zoned_date_time, char const ** timezone)<br />Get the timezone property of the zoned date-time.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_zoned_date_time_get_offset](#function-mgp-zoned-date-time-get-offset)**(struct mgp_zoned_date_time * zoned_date_time, int * offset)<br />Get the offset of the zoned date-time.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_zoned_date_time_timestamp](#function-mgp-zoned-date-time-timestamp)**(struct mgp_zoned_date_time * zoned_date_time, int64_t * timestamp)<br />Get the zoned date-time as microseconds from Unix epoch.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_zoned_date_time_add_duration](#function-mgp-zoned-date-time-add-duration)**(struct mgp_zoned_date_time * zoned_date_time, struct mgp_duration * dur, struct mgp_memory * memory, struct mgp_zoned_date_time ** result)<br />Add a duration to the zoned date-time.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_zoned_date_time_sub_duration](#function-mgp-zoned-date-time-sub-duration)**(struct mgp_zoned_date_time * zoned_date_time, struct mgp_duration * dur, struct mgp_memory * memory, struct mgp_zoned_date_time ** result)<br />Subtract a duration from the zoned date-time.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_zoned_date_time_diff](#function-mgp-zoned-date-time-diff)**(struct mgp_zoned_date_time * first, struct mgp_zoned_date_time * second, struct mgp_memory * memory, struct mgp_duration ** result)<br />Get a duration between two zoned date-times.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_zoned_date_time_now](#function-mgp-zoned-date-time-now)**(struct mgp_memory * memory, struct mgp_zoned_date_time ** zoned_date_time)<br />Get the zoned date-time representing current date and time.  |
 | enum [mgp_error](#variable-mgp-error) | **[mgp_duration_from_string](#function-mgp-duration-from-string)**(const char * string, struct mgp_memory * memory, struct mgp_duration ** duration)<br />Create a duration from a string following the ISO 8601 format.  |
 | enum [mgp_error](#variable-mgp-error) | **[mgp_duration_from_parameters](#function-mgp-duration-from-parameters)**(struct [mgp_duration_parameters](#mgp_duration_parameters) * parameters, struct mgp_memory * memory, struct mgp_duration ** duration)<br />Create a duration from [mgp_duration_parameters](#mgp_duration_parameters).  |
 | enum [mgp_error](#variable-mgp-error) | **[mgp_duration_from_microseconds](#function-mgp-duration-from-microseconds)**(int64_t microseconds, struct mgp_memory * memory, struct mgp_duration ** duration)<br />Create a duration from microseconds.  |
@@ -503,6 +527,37 @@ struct mgp_date_parameters * date_parameters;
 struct mgp_local_time_parameters * local_time_parameters;
 ```
 
+### mgp_zoned_date_time_parameters
+
+#### Public Attributes
+
+| Type           | Name           |
+| -------------- | -------------- |
+| struct mgp_date_parameters * | **[date_parameters](#variable-date-parameters-zoned)**  |
+| struct mgp_local_time_parameters * | **[local_time_parameters](#variable-local-time-parameters-zoned)**  |
+| union | **[timezone_info](#variable-timezone-info)**  |
+| int | **[is_named_timezone](#variable-is-named-timezone)**  |
+
+#### variable date_parameters [#variable-date-parameters-zoned]
+```cpp
+struct mgp_date_parameters * date_parameters;
+```
+#### variable local_time_parameters [#variable-local-time-parameters-zoned]
+```cpp
+struct mgp_local_time_parameters * local_time_parameters;
+```
+#### variable timezone_info [#variable-timezone-info]
+```cpp
+union {
+    int32_t offset_in_minutes;
+    const char *timezone_name;
+} timezone_info;
+```
+#### variable is_named_timezone [#variable-is-named-timezone]
+```cpp
+int is_named_timezone;
+```
+
 ### mgp_duration_parameters
 
 #### Public Attributes
@@ -568,6 +623,7 @@ All available types that can be stored in a mgp_value.
 | MGP_VALUE_TYPE_LOCAL_TIME |
 | MGP_VALUE_TYPE_LOCAL_DATE_TIME |
 | MGP_VALUE_TYPE_DURATION |
+| MGP_VALUE_TYPE_ZONED_DATE_TIME |
 
 ### typedef mgp_proc_cb [#typedef-mgp-proc-cb]### typedef mgp_proc_initializer [#typedef-mgp-proc-initializer]### typedef mgp_proc_cleanup [#typedef-mgp-proc-cleanup]
 ```cpp
@@ -867,6 +923,23 @@ Create a mgp_value storing a mgp_duration.
 
 You need to free the instance through mgp_value_destroy. The ownership of the duration is transferred to the created mgp_value and destroying the mgp_value will destroy the mgp_duration. Therefore, if a mgp_value is successfully created you must not call mgp_duration_destroy on the given duration. MGP_ERROR_UNABLE_TO_ALLOCATE is returned if unable to allocate a mgp_value.
 
+### mgp_value_make_zoned_date_time [#function-mgp-value-make-zoned-date-time]
+```cpp
+enum mgp_error mgp_value_make_zoned_date_time(
+    struct mgp_zoned_date_time * val,
+    struct mgp_value ** result
+)
+```
+
+Create a mgp_value storing a mgp_zoned_date_time.
+
+You need to free the instance through mgp_value_destroy. The ownership of the
+zoned date-time is transferred to the created mgp_value and destroying the
+mgp_value will destroy the mgp_zoned_date_time. Therefore, if a mgp_value is
+successfully created you must not call mgp_zoned_date_time_destroy on the given
+zoned date-time. MGP_ERROR_UNABLE_TO_ALLOCATE is returned if unable to allocate
+a mgp_value.
+
 
 ### mgp_value_get_type [#function-mgp-value-get-type]
 ```cpp
@@ -1063,6 +1136,18 @@ Result is non-zero if the given mgp_value stores a duration.
 Current implementation always returns without errors.
 
 
+### mgp_value_is_zoned_date_time [#function-mgp-value-is-zoned-date-time]
+```cpp
+enum mgp_error mgp_value_is_zoned_date_time(
+    struct mgp_value * val,
+    int * result
+)
+```
+Result is non-zero if the given mgp_value stores a zoned date-time.
+
+Current implementation always returns without errors.
+
+
 ### mgp_value_get_bool [#function-mgp-value-get-bool]
 ```cpp
 enum mgp_error mgp_value_get_bool(
@@ -1228,6 +1313,19 @@ enum mgp_error mgp_value_get_duration(
 ```
 
 Get the contained duration.
+
+Result is undefined if mgp_value does not contain the expected type. Current implementation always returns without errors.
+
+
+### mgp_value_get_zoned_date_time [#function-mgp-value-get-zoned-date-time]
+```cpp
+enum mgp_error mgp_value_get_zoned_date_time(
+    struct mgp_value * val,
+    struct mgp_zoned_date_time ** result
+)
+```
+
+Get the contained zoned date-time.
 
 Result is undefined if mgp_value does not contain the expected type. Current implementation always returns without errors.
 
@@ -2968,7 +3066,7 @@ enum mgp_error mgp_local_date_time_get_millisecond(
 )
 ```
 
-Get the milisecond property of the local date-time.
+Get the millisecond property of the local date-time.
 
 ### mgp_local_date_time_get_microsecond [#function-mgp-local-date-time-get-microsecond]
 ```cpp
@@ -3046,6 +3144,262 @@ enum mgp_error mgp_local_date_time_diff(
 Get a duration between two local date-times.
 
 Resulting duration must be freed with mgp_duration_destroy. Return MGP_ERROR_UNABLE_TO_ALLOCATE if unable to allocate a mgp_local_date_time.
+
+
+### mgp_zoned_date_time_from_string [#function-mgp-zoned-date-time-from-string]
+```cpp
+enum mgp_error mgp_zoned_date_time_from_string(
+    const char * string,
+    struct mgp_memory * memory,
+    struct mgp_zoned_date_time ** zoned_date_time
+)
+```
+
+Create a zoned date-time from a string following the ISO 8601 format. The string can also include timezone information as a numeric offset (`+HH:MM` or `-HH:MM`) or a named timezone identifier (`[America/New_York]`).
+
+Resulting zoned date-time must be freed with mgp_zoned_date_time_destroy. Return
+MGP_ERROR_INVALID_ARGUMENT if the string cannot be parsed correctly. Return
+MGP_ERROR_UNABLE_TO_ALLOCATE if unable to allocate a mgp_zoned_date_time.
+
+
+### mgp_zoned_date_time_from_parameters [#function-mgp-zoned-date-time-from-parameters]
+```cpp
+enum mgp_error mgp_zoned_date_time_from_parameters(
+    struct mgp_zoned_date_time_parameters * parameters,
+    struct mgp_memory * memory,
+    struct mgp_zoned_date_time ** zoned_date_time
+)
+```
+
+Create a zoned date-time from [mgp_zoned_date_time_parameters](#mgp_zoned_date_time_parameters).
+
+Resulting zoned date-time must be freed with mgp_zoned_date_time_destroy. Return
+MGP_ERROR_INVALID_ARGUMENT if the parameters cannot be parsed correctly. Return
+MGP_ERROR_UNABLE_TO_ALLOCATE if unable to allocate a mgp_zoned_date_time.
+
+
+### mgp_zoned_date_time_copy [#function-mgp-zoned-date-time-copy]
+```cpp
+enum mgp_error mgp_zoned_date_time_copy(
+    struct mgp_zoned_date_time * zoned_date_time,
+    struct mgp_memory * memory,
+    struct mgp_zoned_date_time ** result
+)
+```
+
+Copy a mgp_zoned_date_time.
+
+Resulting pointer must be freed with mgp_zoned_date_time_destroy. Return
+MGP_ERROR_UNABLE_TO_ALLOCATE if unable to allocate a mgp_zoned_date_time.
+
+
+### mgp_zoned_date_time_destroy [#function-mgp-zoned-date-time-destroy]
+```cpp
+void mgp_zoned_date_time_destroy(
+    struct mgp_zoned_date_time * zoned_date_time
+)
+```
+
+Free the memory used by a mgp_zoned_date_time.
+
+
+### mgp_zoned_date_time_equal [#function-mgp-zoned-date-time-equal]
+```cpp
+enum mgp_error mgp_zoned_date_time_equal(
+    struct mgp_zoned_date_time * first,
+    struct mgp_zoned_date_time * second,
+    int * result
+)
+```
+
+Result is non-zero if given zoned date-times are equal, otherwise 0.
+
+
+### mgp_zoned_date_time_get_year [#function-mgp-zoned-date-time-get-year]
+```cpp
+enum mgp_error mgp_zoned_date_time_get_year(
+    struct mgp_zoned_date_time * zoned_date_time,
+    int * year
+)
+```
+
+Get the year property of the zoned date-time.
+
+
+### mgp_zoned_date_time_get_month [#function-mgp-zoned-date-time-get-month]
+```cpp
+enum mgp_error mgp_zoned_date_time_get_month(
+    struct mgp_zoned_date_time * zoned_date_time,
+    int * month
+)
+```
+
+Get the month property of the zoned date-time.
+
+
+### mgp_zoned_date_time_get_day [#function-mgp-zoned-date-time-get-day]
+```cpp
+enum mgp_error mgp_zoned_date_time_get_day(
+    struct mgp_zoned_date_time * zoned_date_time,
+    int * day
+)
+```
+
+Get the day property of the zoned date-time.
+
+
+### mgp_zoned_date_time_get_hour [#function-mgp-zoned-date-time-get-hour]
+```cpp
+enum mgp_error mgp_zoned_date_time_get_hour(
+    struct mgp_zoned_date_time * zoned_date_time,
+    int * hour
+)
+```
+
+Get the hour property of the zoned date-time.
+
+
+### mgp_zoned_date_time_get_minute [#function-mgp-zoned-date-time-get-minute]
+```cpp
+enum mgp_error mgp_zoned_date_time_get_minute(
+    struct mgp_zoned_date_time * zoned_date_time,
+    int * minute
+)
+```
+
+Get the minute property of the zoned date-time.
+
+
+### mgp_zoned_date_time_get_second [#function-mgp-zoned-date-time-get-second]
+```cpp
+enum mgp_error mgp_zoned_date_time_get_second(
+    struct mgp_zoned_date_time * zoned_date_time,
+    int * second
+)
+```
+
+Get the second property of the zoned date-time.
+
+
+### mgp_zoned_date_time_get_millisecond [#function-mgp-zoned-date-time-get-millisecond]
+```cpp
+enum mgp_error mgp_zoned_date_time_get_millisecond(
+    struct mgp_zoned_date_time * zoned_date_time,
+    int * millisecond
+)
+```
+
+Get the millisecond property of the zoned date-time.
+
+
+### mgp_zoned_date_time_get_microsecond [#function-mgp-zoned-date-time-get-microsecond]
+```cpp
+enum mgp_error mgp_zoned_date_time_get_microsecond(
+    struct mgp_zoned_date_time * zoned_date_time,
+    int * microsecond
+)
+```
+
+Get the microsecond property of the zoned date-time.
+
+
+### mgp_zoned_date_time_get_timezone [#function-mgp-zoned-date-time-get-timezone]
+```cpp
+enum mgp_error mgp_zoned_date_time_get_timezone(
+    struct mgp_zoned_date_time * zoned_date_time,
+    char const ** timezone
+)
+```
+
+Get the timezone property of the zoned date-time.
+
+
+### mgp_zoned_date_time_get_offset [#function-mgp-zoned-date-time-get-offset]
+```cpp
+enum mgp_error mgp_zoned_date_time_get_offset(
+    struct mgp_zoned_date_time * zoned_date_time,
+    int * offset
+)
+```
+
+Get the offset of the zoned date-time.
+
+
+### mgp_zoned_date_time_timestamp [#function-mgp-zoned-date-time-timestamp]
+```cpp
+enum mgp_error mgp_zoned_date_time_timestamp(
+    struct mgp_zoned_date_time * zoned_date_time,
+    int64_t * timestamp
+)
+```
+
+Get the zoned date-time as microseconds from Unix epoch.
+
+
+### mgp_zoned_date_time_add_duration [#function-mgp-zoned-date-time-add-duration]
+```cpp
+enum mgp_error mgp_zoned_date_time_add_duration(
+    struct mgp_zoned_date_time * zoned_date_time,
+    struct mgp_duration * dur,
+    struct mgp_memory * memory,
+    struct mgp_zoned_date_time ** result
+)
+```
+
+Add a duration to the zoned date-time.
+
+Resulting zoned date-time must be freed with mgp_zoned_date_time_destroy. Return
+MGP_ERROR_INVALID_ARGUMENT if the operation results in an invalid zoned
+date-time. Return MGP_ERROR_UNABLE_TO_ALLOCATE if unable to allocate a
+mgp_zoned_date_time.
+
+
+### mgp_zoned_date_time_sub_duration [#function-mgp-zoned-date-time-sub-duration]
+```cpp
+enum mgp_error mgp_zoned_date_time_sub_duration(
+    struct mgp_zoned_date_time * zoned_date_time,
+    struct mgp_duration * dur,
+    struct mgp_memory * memory,
+    struct mgp_zoned_date_time ** result
+)
+```
+
+Subtract a duration from the zoned date-time.
+
+Resulting zoned date-time must be freed with mgp_zoned_date_time_destroy. Return
+MGP_ERROR_INVALID_ARGUMENT if the operation results in an invalid zoned
+date-time. Return MGP_ERROR_UNABLE_TO_ALLOCATE if unable to allocate a
+mgp_zoned_date_time.
+
+
+### mgp_zoned_date_time_diff [#function-mgp-zoned-date-time-diff]
+```cpp
+enum mgp_error mgp_zoned_date_time_diff(
+    struct mgp_zoned_date_time * first,
+    struct mgp_zoned_date_time * second,
+    struct mgp_memory * memory,
+    struct mgp_duration ** result
+)
+```
+
+Get a duration between two zoned date-times.
+
+Resulting duration must be freed with mgp_duration_destroy. Return
+MGP_ERROR_UNABLE_TO_ALLOCATE if unable to allocate a mgp_duration.
+
+
+### mgp_zoned_date_time_now [#function-mgp-zoned-date-time-now]
+```cpp
+enum mgp_error mgp_zoned_date_time_now(
+    struct mgp_memory * memory,
+    struct mgp_zoned_date_time ** zoned_date_time
+)
+```
+
+Get the zoned date-time representing current date and time.
+
+Resulting zoned date-time must be freed with mgp_zoned_date_time_destroy. Return
+MGP_ERROR_UNABLE_TO_ALLOCATE if unable to allocate a mgp_zoned_date_time.
 
 
 ### mgp_duration_from_string [#function-mgp-duration-from-string]
@@ -3886,6 +4240,7 @@ enum mgp_value_type {
   MGP_VALUE_TYPE_LOCAL_TIME,
   MGP_VALUE_TYPE_LOCAL_DATE_TIME,
   MGP_VALUE_TYPE_DURATION,
+  MGP_VALUE_TYPE_ZONED_DATE_TIME
 };
 
 void mgp_value_destroy(struct mgp_value *val);
@@ -3918,6 +4273,8 @@ enum mgp_error mgp_value_make_local_date_time(struct mgp_local_date_time *val, s
 
 enum mgp_error mgp_value_make_duration(struct mgp_duration *val, struct mgp_value **result);
 
+enum mgp_error mgp_value_make_zoned_date_time(struct mgp_zoned_date_time *val, struct mgp_value **result);
+
 enum mgp_error mgp_value_get_type(struct mgp_value *val, enum mgp_value_type *result);
 
 enum mgp_error mgp_value_is_null(struct mgp_value *val, int *result);
@@ -3948,6 +4305,8 @@ enum mgp_error mgp_value_is_local_date_time(struct mgp_value *val, int *result);
 
 enum mgp_error mgp_value_is_duration(struct mgp_value *val, int *result);
 
+enum mgp_error mgp_value_is_zoned_date_time(struct mgp_value *val, int *result);
+
 enum mgp_error mgp_value_get_bool(struct mgp_value *val, int *result);
 
 enum mgp_error mgp_value_get_int(struct mgp_value *val, int64_t *result);
@@ -3973,6 +4332,8 @@ enum mgp_error mgp_value_get_local_time(struct mgp_value *val, struct mgp_local_
 enum mgp_error mgp_value_get_local_date_time(struct mgp_value *val, struct mgp_local_date_time **result);
 
 enum mgp_error mgp_value_get_duration(struct mgp_value *val, struct mgp_duration **result);
+
+enum mgp_error mgp_value_get_zoned_date_time(struct mgp_value *val, struct mgp_zoned_date_time **result);
 
 enum mgp_error mgp_list_make_empty(size_t capacity, struct mgp_memory *memory, struct mgp_list **result);
 
@@ -4359,6 +4720,45 @@ enum mgp_error mgp_local_date_time_sub_duration(struct mgp_local_date_time *loca
 
 enum mgp_error mgp_local_date_time_diff(struct mgp_local_date_time *first, struct mgp_local_date_time *second,
                                         struct mgp_memory *memory, struct mgp_duration **result);
+
+enum mgp_error mgp_zoned_date_time_from_string(const char *string, struct mgp_memory *memory,
+                                               struct mgp_zoned_date_time **zoned_date_time);
+enum mgp_error mgp_zoned_date_time_from_parameters(struct mgp_zoned_date_time_parameters *parameters,
+                                                   struct mgp_memory *memory,
+                                                   struct mgp_zoned_date_time **zoned_date_time);
+enum mgp_error mgp_zoned_date_time_copy(struct mgp_zoned_date_time *zoned_date_time, struct mgp_memory *memory,
+                                        struct mgp_zoned_date_time **result);
+void mgp_zoned_date_time_destroy(struct mgp_zoned_date_time *zoned_date_time);
+enum mgp_error mgp_zoned_date_time_equal(struct mgp_zoned_date_time *first, struct mgp_zoned_date_time *second,
+                                         int *result);
+enum mgp_error mgp_zoned_date_time_get_year(struct mgp_zoned_date_time *zoned_date_time, int *year);
+enum mgp_error mgp_zoned_date_time_get_month(struct mgp_zoned_date_time *zoned_date_time, int *month);
+enum mgp_error mgp_zoned_date_time_get_day(struct mgp_zoned_date_time *zoned_date_time, int *day);
+enum mgp_error mgp_zoned_date_time_get_hour(struct mgp_zoned_date_time *zoned_date_time, int *hour);
+enum mgp_error mgp_zoned_date_time_get_minute(struct mgp_zoned_date_time *zoned_date_time, int *minute);
+enum mgp_error mgp_zoned_date_time_get_second(struct mgp_zoned_date_time *zoned_date_time, int *second);
+enum mgp_error mgp_zoned_date_time_get_millisecond(struct mgp_zoned_date_time *zoned_date_time, int *millisecond);
+enum mgp_error mgp_zoned_date_time_get_microsecond(struct mgp_zoned_date_time *zoned_date_time, int *microsecond);
+enum mgp_error mgp_zoned_date_time_timestamp(struct mgp_zoned_date_time *zoned_date_time, int64_t *timestamp);
+enum mgp_error mgp_zoned_date_time_get_timezone(struct mgp_zoned_date_time *zoned_date_time, char const **timezone);
+enum mgp_error mgp_zoned_date_time_get_offset(struct mgp_zoned_date_time *zoned_date_time, int *offset);
+enum mgp_error mgp_zoned_date_time_add_duration(struct mgp_zoned_date_time *zoned_date_time, struct mgp_duration *dur,
+                                                struct mgp_memory *memory, struct mgp_zoned_date_time **result);
+enum mgp_error mgp_zoned_date_time_sub_duration(struct mgp_zoned_date_time *zoned_date_time, struct mgp_duration *dur,
+                                                struct mgp_memory *memory, struct mgp_zoned_date_time **result);
+enum mgp_error mgp_zoned_date_time_diff(struct mgp_zoned_date_time *first, struct mgp_zoned_date_time *second,
+                                        struct mgp_memory *memory, struct mgp_duration **result);
+enum mgp_error mgp_zoned_date_time_now(struct mgp_memory *memory, struct mgp_zoned_date_time **zoned_date_time);
+
+struct mgp_zoned_date_time_parameters {
+  struct mgp_date_parameters *date_parameters;
+  struct mgp_local_time_parameters *local_time_parameters;
+  union {
+    int32_t offset_in_minutes;
+    const char *timezone_name;
+  } timezone_info;
+  int is_named_timezone;
+};
 
 struct mgp_duration_parameters {
   double day;

--- a/pages/custom-query-modules/c/c-api.mdx
+++ b/pages/custom-query-modules/c/c-api.mdx
@@ -931,14 +931,14 @@ enum mgp_error mgp_value_make_zoned_date_time(
 )
 ```
 
-Create a mgp_value storing a mgp_zoned_date_time.
+Create a `mgp_value` storing a `mgp_zoned_date_time`.
 
-You need to free the instance through mgp_value_destroy. The ownership of the
-zoned date-time is transferred to the created mgp_value and destroying the
-mgp_value will destroy the mgp_zoned_date_time. Therefore, if a mgp_value is
-successfully created you must not call mgp_zoned_date_time_destroy on the given
-zoned date-time. MGP_ERROR_UNABLE_TO_ALLOCATE is returned if unable to allocate
-a mgp_value.
+You need to free the instance through `mgp_value_destroy`. The ownership of the
+zoned date-time is transferred to the created `mgp_value` and destroying the
+`mgp_value` will destroy the `mgp_zoned_date_time`. Therefore, if a `mgp_value` is
+successfully created you must not call `mgp_zoned_date_time_destroy` on the given
+zoned date-time. `MGP_ERROR_UNABLE_TO_ALLOCATE` is returned if unable to allocate
+a `mgp_value`.
 
 
 ### mgp_value_get_type [#function-mgp-value-get-type]
@@ -1143,7 +1143,7 @@ enum mgp_error mgp_value_is_zoned_date_time(
     int * result
 )
 ```
-Result is non-zero if the given mgp_value stores a zoned date-time.
+Result is non-zero if the given `mgp_value` stores a zoned date-time.
 
 Current implementation always returns without errors.
 
@@ -1327,7 +1327,7 @@ enum mgp_error mgp_value_get_zoned_date_time(
 
 Get the contained zoned date-time.
 
-Result is undefined if mgp_value does not contain the expected type. Current implementation always returns without errors.
+Result is undefined if `mgp_value` does not contain the expected type. Current implementation always returns without errors.
 
 
 ### mgp_list_make_empty [#function-mgp-list-make-empty]
@@ -3157,9 +3157,9 @@ enum mgp_error mgp_zoned_date_time_from_string(
 
 Create a zoned date-time from a string following the ISO 8601 format. The string can also include timezone information as a numeric offset (`+HH:MM` or `-HH:MM`) or a named timezone identifier (`[America/New_York]`).
 
-Resulting zoned date-time must be freed with mgp_zoned_date_time_destroy. Return
-MGP_ERROR_INVALID_ARGUMENT if the string cannot be parsed correctly. Return
-MGP_ERROR_UNABLE_TO_ALLOCATE if unable to allocate a mgp_zoned_date_time.
+Resulting zoned date-time must be freed with `mgp_zoned_date_time_destroy`. Return
+`MGP_ERROR_INVALID_ARGUMENT` if the string cannot be parsed correctly. Return
+`MGP_ERROR_UNABLE_TO_ALLOCATE` if unable to allocate a `mgp_zoned_date_time`.
 
 
 ### mgp_zoned_date_time_from_parameters [#function-mgp-zoned-date-time-from-parameters]
@@ -3173,9 +3173,9 @@ enum mgp_error mgp_zoned_date_time_from_parameters(
 
 Create a zoned date-time from [mgp_zoned_date_time_parameters](#mgp_zoned_date_time_parameters).
 
-Resulting zoned date-time must be freed with mgp_zoned_date_time_destroy. Return
-MGP_ERROR_INVALID_ARGUMENT if the parameters cannot be parsed correctly. Return
-MGP_ERROR_UNABLE_TO_ALLOCATE if unable to allocate a mgp_zoned_date_time.
+Resulting zoned date-time must be freed with `mgp_zoned_date_time_destroy`. Return
+`MGP_ERROR_INVALID_ARGUMENT` if the parameters cannot be parsed correctly. Return
+`MGP_ERROR_UNABLE_TO_ALLOCATE` if unable to allocate a `mgp_zoned_date_time`.
 
 
 ### mgp_zoned_date_time_copy [#function-mgp-zoned-date-time-copy]
@@ -3187,10 +3187,10 @@ enum mgp_error mgp_zoned_date_time_copy(
 )
 ```
 
-Copy a mgp_zoned_date_time.
+Copy a `mgp_zoned_date_time`.
 
-Resulting pointer must be freed with mgp_zoned_date_time_destroy. Return
-MGP_ERROR_UNABLE_TO_ALLOCATE if unable to allocate a mgp_zoned_date_time.
+Resulting pointer must be freed with `mgp_zoned_date_time_destroy`. Return
+`MGP_ERROR_UNABLE_TO_ALLOCATE` if unable to allocate a `mgp_zoned_date_time`.
 
 
 ### mgp_zoned_date_time_destroy [#function-mgp-zoned-date-time-destroy]
@@ -3200,7 +3200,7 @@ void mgp_zoned_date_time_destroy(
 )
 ```
 
-Free the memory used by a mgp_zoned_date_time.
+Free the memory used by a `mgp_zoned_date_time`.
 
 
 ### mgp_zoned_date_time_equal [#function-mgp-zoned-date-time-equal]
@@ -3348,10 +3348,10 @@ enum mgp_error mgp_zoned_date_time_add_duration(
 
 Add a duration to the zoned date-time.
 
-Resulting zoned date-time must be freed with mgp_zoned_date_time_destroy. Return
-MGP_ERROR_INVALID_ARGUMENT if the operation results in an invalid zoned
-date-time. Return MGP_ERROR_UNABLE_TO_ALLOCATE if unable to allocate a
-mgp_zoned_date_time.
+Resulting zoned date-time must be freed with `mgp_zoned_date_time_destroy`. Return
+`MGP_ERROR_INVALID_ARGUMENT` if the operation results in an invalid zoned
+date-time. Return `MGP_ERROR_UNABLE_TO_ALLOCATE` if unable to allocate a
+`mgp_zoned_date_time`.
 
 
 ### mgp_zoned_date_time_sub_duration [#function-mgp-zoned-date-time-sub-duration]
@@ -3366,10 +3366,10 @@ enum mgp_error mgp_zoned_date_time_sub_duration(
 
 Subtract a duration from the zoned date-time.
 
-Resulting zoned date-time must be freed with mgp_zoned_date_time_destroy. Return
-MGP_ERROR_INVALID_ARGUMENT if the operation results in an invalid zoned
-date-time. Return MGP_ERROR_UNABLE_TO_ALLOCATE if unable to allocate a
-mgp_zoned_date_time.
+Resulting zoned date-time must be freed with `mgp_zoned_date_time_destroy`. Return
+`MGP_ERROR_INVALID_ARGUMENT` if the operation results in an invalid zoned
+date-time. Return `MGP_ERROR_UNABLE_TO_ALLOCATE` if unable to allocate a
+`mgp_zoned_date_time`.
 
 
 ### mgp_zoned_date_time_diff [#function-mgp-zoned-date-time-diff]
@@ -3384,8 +3384,8 @@ enum mgp_error mgp_zoned_date_time_diff(
 
 Get a duration between two zoned date-times.
 
-Resulting duration must be freed with mgp_duration_destroy. Return
-MGP_ERROR_UNABLE_TO_ALLOCATE if unable to allocate a mgp_duration.
+Resulting duration must be freed with `mgp_duration_destroy`. Return
+`MGP_ERROR_UNABLE_TO_ALLOCATE` if unable to allocate a `mgp_duration`.
 
 
 ### mgp_zoned_date_time_now [#function-mgp-zoned-date-time-now]
@@ -3398,8 +3398,8 @@ enum mgp_error mgp_zoned_date_time_now(
 
 Get the zoned date-time representing current date and time.
 
-Resulting zoned date-time must be freed with mgp_zoned_date_time_destroy. Return
-MGP_ERROR_UNABLE_TO_ALLOCATE if unable to allocate a mgp_zoned_date_time.
+Resulting zoned date-time must be freed with `mgp_zoned_date_time_destroy`. Return
+`MGP_ERROR_UNABLE_TO_ALLOCATE` if unable to allocate a `mgp_zoned_date_time`.
 
 
 ### mgp_duration_from_string [#function-mgp-duration-from-string]

--- a/pages/custom-query-modules/cpp/cpp-api.md
+++ b/pages/custom-query-modules/cpp/cpp-api.md
@@ -331,6 +331,10 @@ Inserts a value of given type under field `field_name`.
 ```
 
 ```cpp
+  void Insert(const char *field_name, const ZonedDateTime value)
+```
+
+```cpp
   void Insert(const char *field_name, const Duration value)
 ```
 
@@ -417,6 +421,10 @@ Sets a return value of given type.
 
 ```cpp
   void SetValue(const LocalDateTime &value)
+```
+
+```cpp
+  void SetValue(const ZonedDateTime &value)
 ```
 
 ```cpp
@@ -1533,6 +1541,179 @@ Object is hashable using
 std::hash<mgp::LocalDateTime>
 ```
 
+### ZonedDateTime
+Temporal type representing a date-time with timezone information.
+#### Constructors
+Creates a ZonedDateTime object from the copy of the given `mgp_zoned_date_time`.
+```cpp
+explicit ZonedDateTime(mgp_zoned_date_time *ptr)
+explicit ZonedDateTime(const mgp_zoned_date_time *const_ptr)
+```
+Creates a ZonedDateTime object from the given string representing a date in the ISO 8601 format
+(`YYYY-MM-DDThh:mm:ss`, `YYYY-MM-DDThh:mm`, `YYYYMMDDThhmmss`, `YYYYMMDDThhmm`, or `YYYYMMDDThh`).
+The string can also include timezone information as a numeric offset (`+HH:MM` or `-HH:MM`) or
+a named timezone identifier (`[America/New_York]`).
+```cpp
+explicit ZonedDateTime(std::string_view string)
+```
+Creates a ZonedDateTime object with the given `year`, `month`, `day`, `hour`, `minute`, `second`,
+`millisecond`, `microsecond`, and `offset_in_minutes` properties.
+```cpp
+ZonedDateTime(int year, int month, int day, int hour, int minute, int second, int millisecond, int microsecond,
+              int offset_in_minutes)
+```
+Creates a ZonedDateTime object with the given `year`, `month`, `day`, `hour`, `minute`, `second`,
+`millisecond`, `microsecond`, and `timezone_name` properties.
+```cpp
+ZonedDateTime(int year, int month, int day, int hour, int minute, int second, int millisecond, int microsecond,
+              std::string_view timezone_name)
+```
+```cpp
+ZonedDateTime(const ZonedDateTime &other)
+ZonedDateTime(ZonedDateTime &&other) noexcept
+```
+#### Member functions
+
+| Name                     | Description                                                       |
+| ------------------------ | ----------------------------------------------------------------- |
+| `Now`                    | Returns the current `ZonedDateTime`.                              |
+| `Year`                   | Returns the object's `year` property.                             |
+| `Month`                  | Returns the object's `month` property.                            |
+| `Day`                    | Returns the object's `day` property.                              |
+| `Hour`                   | Returns the object's `hour` property.                             |
+| `Minute`                 | Returns the object's `minute` property.                           |
+| `Second`                 | Returns the object's `second` property.                           |
+| `Millisecond`            | Returns the object's `millisecond` property.                      |
+| `Microsecond`            | Returns the object's `microsecond` property.                      |
+| `Offset`                 | Returns the object's timezone offset in minutes.                  |
+| `Timezone`               | Returns the object's timezone name.                               |
+| `Timestamp`              | Returns the object's timestamp (microseconds since Unix epoch).   |
+| `ToString`               | Returns the object's string representation.                       |
+
+##### Now
+
+Returns the current `ZonedDateTime`.
+
+```cpp
+static ZonedDateTime Now()
+```
+
+##### Year
+
+Returns the object's `year` property.
+
+```cpp
+int Year() const
+```
+
+##### Month
+
+Returns the object's `month` property.
+
+```cpp
+int Month() const
+```
+
+##### Day
+
+Returns the object's `day` property.
+
+```cpp
+int Day() const
+```
+
+##### Hour
+
+Returns the object's `hour` property.
+
+```cpp
+int Hour() const
+```
+##### Minute
+
+Returns the object's `minute` property.
+
+```cpp
+int Minute() const
+```
+
+##### Second
+
+Returns the object's `second` property.
+
+```cpp
+int Second() const
+```
+
+##### Millisecond
+
+Returns the object's `millisecond` property.
+
+```cpp
+int Millisecond() const
+```
+
+##### Microsecond
+
+Returns the object's `microsecond` property.
+
+```cpp
+int Microsecond() const
+```
+##### Timezone
+
+Returns the object's `timezone` string property.
+
+```cpp
+char const *Timezone() const
+```
+
+##### Offset
+
+Returns the object's `offset` property.
+
+```cpp
+int Offset() const
+```
+
+##### Timestamp
+
+Returns the object's timestamp (microseconds from Unix epoch).
+
+```cpp
+int64_t Timestamp() const
+```
+
+##### ToString
+
+Returns the object's string representation.
+
+```cpp
+std::string ToString() const
+```
+
+#### Operators
+
+| Name                         | Description          |
+| ---------------------------- | -------------------- |
+| `operator+`<br/>`operator-`  | arithmetic operators |
+| `operator==`<br/>`operator<` | comparison operators |
+
+##### operator-
+
+```cpp
+ZonedDateTime operator-(const Duration &dur) const
+```
+
+```cpp
+Duration operator-(const ZonedDateTime &other) const
+```
+Object is hashable using
+
+```cpp
+std::hash<mgp::ZonedDateTime>
+```
+
 ### Duration
 
 Represents a period of time in Memgraph.
@@ -2125,6 +2306,8 @@ explicit Value(const LocalTime &value)
 explicit Value(LocalTime &&value)
 explicit Value(const LocalDateTime &value)
 explicit Value(LocalDateTime &&value)
+explicit Value(const ZonedDateTime &value)
+explicit Value(ZonedDateTime &&value)
 explicit Value(const Duration &value)
 explicit Value(Duration &&value)
 ```
@@ -2235,6 +2418,11 @@ LocalDateTime ValueLocalDateTime()
 ```
 
 ```cpp
+ZonedDateTime ValueZonedDateTime() const
+ZonedDateTime ValueZonedDateTime()
+```
+
+```cpp
 Duration ValueDuration() const
 Duration ValueDuration()
 ```
@@ -2300,6 +2488,10 @@ bool IsLocalDateTime() const
 ```
 
 ```cpp
+bool IsZonedDateTime() const
+```
+
+```cpp
 bool IsDuration() const
 ```
 
@@ -2321,6 +2513,7 @@ Returns the value's string representation. It does this by finding the type of t
 | `Date`          | Returns `Date.ToString()`.                                           |
 | `LocalTime`     | Returns `LocalTime.ToString()`.                                      |
 | `LocalDateTime` | Returns `LocalDateTime.ToString()`.                                  |
+| `ZonedDateTime` | Returns `ZonedDateTime.ToString()`.                                  |
 | `Duration`      | Returns `Duration.ToString()`.                                       |
 
 ```cpp
@@ -2372,6 +2565,7 @@ The types are listed and described [in the reference guide](/fundamentals/data-t
 - `Type::Date`
 - `Type::LocalTime`
 - `Type::LocalDateTime`
+- `Type::ZonedDateTime`
 - `Type::Duration`
 
 Additionally, operator<< is overloaded for Type enum, and usage of this operator will print the type represented by mgp::Type enum.

--- a/pages/custom-query-modules/cpp/cpp-api.md
+++ b/pages/custom-query-modules/cpp/cpp-api.md
@@ -1543,26 +1543,27 @@ std::hash<mgp::LocalDateTime>
 
 ### ZonedDateTime
 Temporal type representing a date-time with timezone information.
+
 #### Constructors
-Creates a ZonedDateTime object from the copy of the given `mgp_zoned_date_time`.
+Creates a `ZonedDateTime` object from the copy of the given `mgp_zoned_date_time`.
 ```cpp
 explicit ZonedDateTime(mgp_zoned_date_time *ptr)
 explicit ZonedDateTime(const mgp_zoned_date_time *const_ptr)
 ```
-Creates a ZonedDateTime object from the given string representing a date in the ISO 8601 format
+Creates a `ZonedDateTime` object from the given string representing a date in the ISO 8601 format
 (`YYYY-MM-DDThh:mm:ss`, `YYYY-MM-DDThh:mm`, `YYYYMMDDThhmmss`, `YYYYMMDDThhmm`, or `YYYYMMDDThh`).
 The string can also include timezone information as a numeric offset (`+HH:MM` or `-HH:MM`) or
 a named timezone identifier (`[America/New_York]`).
 ```cpp
 explicit ZonedDateTime(std::string_view string)
 ```
-Creates a ZonedDateTime object with the given `year`, `month`, `day`, `hour`, `minute`, `second`,
+Creates a `ZonedDateTime` object with the given `year`, `month`, `day`, `hour`, `minute`, `second`,
 `millisecond`, `microsecond`, and `offset_in_minutes` properties.
 ```cpp
 ZonedDateTime(int year, int month, int day, int hour, int minute, int second, int millisecond, int microsecond,
               int offset_in_minutes)
 ```
-Creates a ZonedDateTime object with the given `year`, `month`, `day`, `hour`, `minute`, `second`,
+Creates a `ZonedDateTime` object with the given `year`, `month`, `day`, `hour`, `minute`, `second`,
 `millisecond`, `microsecond`, and `timezone_name` properties.
 ```cpp
 ZonedDateTime(int year, int month, int day, int hour, int minute, int second, int millisecond, int microsecond,


### PR DESCRIPTION
### Release note

Add documentation for `ZonedDateTime` to C and C++ API pages.

### Related product PRs

https://github.com/memgraph/memgraph/pull/3121

### Checklist:

- [x] Add appropriate milestone (current release cycle)
- [x] Add `bugfix` or `feature` label, based on the product PR type you're documenting
- [x] Make sure all relevant tech details are documented
    - [x] Update reference pages (e.g. [clauses](https://memgraph.com/docs/querying/clauses), [functions](https://memgraph.com/docs/querying/functions), [flags](https://memgraph.com/docs/database-management/configuration#list-of-configuration-flags), [experimental](https://memgraph.com/docs/database-management/experimental-features), [monitoring](https://memgraph.com/docs/database-management/monitoring), [Cypher differences](https://memgraph.com/docs/querying/differences-in-cypher-implementations))
    - [x] Search for the feature you are working on (mentions) and make updates if needed
    - [ ] Provide a basic example of usage
    - [ ] In case your feature is an Enterprise one, list it under [ME page](https://memgraph.com/docs/database-management/enabling-memgraph-enterprise) and mark its page with Enterprise ([example](https://memgraph.com/docs/database-management/authentication-and-authorization/role-based-access-control)).
- [x] Check all content with Grammarly
- [x] Perform a self-review of my code
- [x] The build passes locally
- [x] My changes generate no new warnings or errors