### PR TITLE
Update remove_labels example

### DIFF
--- a/pages/advanced-algorithms/available-algorithms/create.mdx
+++ b/pages/advanced-algorithms/available-algorithms/create.mdx
@@ -387,8 +387,8 @@ nodes:
 ```cypher
 CREATE (:Person:Student:Programmer {name: "Ana"});
 MATCH (p:Person) CALL create.remove_labels(p, ["Student", "Engineer"])
-YIELD nodes
-RETURN nodes;
+YIELD node
+RETURN node;
 ```
 
 ```plaintext


### PR DESCRIPTION
This PR fixes a typo in the example under [create.remove_labels](https://memgraph.com/docs/advanced-algorithms/available-algorithms/create#remove_labels) page