### PR TITLE
Add ISSU docs

### DIFF
--- a/pages/clustering/high-availability.mdx
+++ b/pages/clustering/high-availability.mdx
@@ -16,7 +16,7 @@ relies on replication. The cluster consists of:
 - REPLICA instances that can only respond to read queries
 - COORDINATOR instances that manage the cluster state.
 
-Depending on how configuration flags are set, Memgraph can run as a data instance or coordinator instance. 
+Depending on how configuration flags are set, Memgraph can run as a data instance or as a coordinator instance. 
 The coordinator instance is a new addition to enable the high availability feature and orchestrates data instances to ensure that there is always one MAIN instance in the cluster.
 
 ## Cluster management


### PR DESCRIPTION
Memgraph's HA charts support ISSU. There are several steps you should do in order to be able to perform no-downtime upgrade. 
The assumption is that you are running HA chart with updateStrategy.type set to `OnDelete`.

Although the upgrade process should always finish successfully, unexpected things can always happen. Therefore we are strongly recommending that for the 1st step you perform a backup of your lib directory on all of your `StatefulSets.` Depending on the
infrastructe on which you are running your cluster, details will differ a bit. Here I will present how to perform the upgrade on Azure AKS cluster. If performing an upgrade using `minikube`, it is important to make sure that the snapshot resides on the same node
on which the `StatefulSet` is installed, otherwise it won't be able to restore `StatefulSet's` attached PVC from the `VolumeSnapshot`.

If you are using AWS cluster, refer to the documentation on this [page](https://docs.aws.amazon.com/eks/latest/userguide/csi-snapshot-controller.html) to check how to enable taking volume snapshots on your K8s deployment.


1. Create `VolumeSnapshotClass`

```
apiVersion: snapshot.storage.k8s.io/v1
kind: VolumeSnapshotClass
metadata:
  name: csi-azure-disk-snapclass
driver: disk.csi.azure.com
deletionPolicy: Delete
```

`kubectl apply -f azure_class.yaml`

If using GKE, the default CSI driver is `pd.csi.storage.gke.io` so make sure to change the driver field.


2. Create a `VolumeSnapshot` of the lib directory for each `StatefulSet` in the cluster

```
apiVersion: snapshot.storage.k8s.io/v1
kind: VolumeSnapshot
metadata:
  name: coord-3-snap  # Modify name when taking snapshot for the other instance
  namespace: default
spec:
  volumeSnapshotClassName: csi-azure-disk-snapclass
  source:
    persistentVolumeClaimName: memgraph-coordinator-3-lib-storage-memgraph-coordinator-3-0  # This is the lib directory of the coordinator 3. Change persistentVolumeClaimName to take a snapshot for the other instance in the cluster.
```


`kubectl apply -f azure_snapshot.yaml` (Do it for all instances)


3. Open values.yaml file and update `image.tag` to the version to which you want to upgrade your cluster.

4. Run  `helm upgrade <release> <chart> -f <path_to_values.yaml>`
In this step, pods won't be restarted, here we only prepare pods for the upgrade process

5. Run `SHOW INSTANCES` on any coordinator
This query will show you which pod behaves as replica, which pod as main and which pods are coordinators.

6. Each pod will get upgraded by deleting it. Start by deleting replica pod:
```
kubectl delete pod memgraph-data-1-0`

```

It is important to wait until all pods are in ready state before starting the upgrade of the next pod. Otherwise you may end up in state with some data lost.
```
kubectl wait --for=condition=ready pod --all
```


7. Delete main pod:
Right before the moment of starting the upgrade of main pod, you should run query `SHOW REPLICATION LAG` to check whether replicas are behind MAIN. If case they are,
your upgrade will be prone to data loss. To achieve data-loss free no-downtime upgrade your replicas should be running in `STRICT_SYNC` mode which will effectively
disable writes while upgrading any `STRICT_SYNC` instance.


```
kubectl delete pod memgraph-data-0-0
kubectl wait --for=condition=ready pod --all
```


8. Do the same for all coordinators. Start by deleting followers and finish by deleting the leader pod. NOTE: You could have leader running on different pod that's why
it is important to run `SHOW INSTANCES` before starting the upgrade procedure.

```
kubectl delete pod memgraph-coordinator-3-0
kubectl wait --for=condition=ready pod --all
kubectl delete pod memgraph-coordinator-2-0
kubectl wait --for=condition=ready pod --all
kubectl delete pod memgraph-coordinator-1-0
kubectl wait --for=condition=ready pod --all
```


9. Check that your cluster was successfully upgraded by running `SHOW VERSION`

10. (OPTIONAL) If while deleting one of your pods, you figured out that an error happened or even after upgrading all of your pods, something doesn't work as expected you can safely downgrade your cluster to the last stable version from `VolumeSnapshots` you took.
In order to do so, first run `helm uninstall <release>`. Open `values.yaml` and set `restoreDataFromSnapshot` for all instances to `true`. Make sure to set correct name of the snapshot you will use to recover your instances. 
Run `helm install` -> your cluster should be stable as before.














### Release note

Please briefly explain the changes you made which will be added to the changelog.

### Related product PRs

PRs from product repo this doc page is related to: 
(paste the links to the PRs)

### Checklist:

- [ ] Add appropriate milestone (current release cycle)
- [ ] Add `bugfix` or `feature` label, based on the product PR type you're documenting
- [ ] Make sure all relevant tech details are documented
    - [ ] Update reference pages (e.g. [clauses](https://memgraph.com/docs/querying/clauses), [functions](https://memgraph.com/docs/querying/functions), [flags](https://memgraph.com/docs/database-management/configuration#list-of-configuration-flags), [experimental](https://memgraph.com/docs/database-management/experimental-features), [monitoring](https://memgraph.com/docs/database-management/monitoring), [Cypher differences](https://memgraph.com/docs/querying/differences-in-cypher-implementations))
    - [ ] Search for the feature you are working on (mentions) and make updates if needed
    - [ ] Provide a basic example of usage
    - [ ] In case your feature is an Enterprise one, list it under [ME page](https://memgraph.com/docs/database-management/enabling-memgraph-enterprise) and mark its page with Enterprise ([example](https://memgraph.com/docs/database-management/authentication-and-authorization/role-based-access-control)).
- [ ] Check all content with Grammarly
- [ ] Perform a self-review of my code
- [ ] The build passes locally
- [ ] My changes generate no new warnings or errors