### PR TITLE
docs: Disable starting HA cluster when --storage-wal-enabled=false for IN_MEMORY_TRANSACTIONAL storage 

### DIFF
--- a/pages/clustering/high-availability.mdx
+++ b/pages/clustering/high-availability.mdx
@@ -125,14 +125,15 @@ instances needs to exist on coordinators too.
 ## Starting instances
 
 You can start the data and coordinator instances using environment flags or configuration flags.
-The main difference between data instance and coordinator is that data instances have `--management-port`, whereas coordinators must have `--coordinator-id` and `--coordinator-port`. 
+The main difference between data instance and coordinator is that data instances have `--management-port`,
+whereas coordinators must have `--coordinator-id` and `--coordinator-port`. 
 
 ### Configuration Flags
 
 #### Data instance
 
 Memgraph data instance must use flag `--management-port=<port>`. This flag is tied to the high availability feature, enables the coordinator to connect to the data instance, 
-and allows the Memgraph data instance to use the high availability feature.
+and allows the Memgraph data instance to use the high availability feature. The flag `--storage-wal-enabled` must be enabled, otherwise data instance won't be started. 
 
 ```
 docker run --name instance1 -p 7687:7687 -p 7444:7444 memgraph/memgraph-mage

--- a/pages/fundamentals/data-durability.mdx
+++ b/pages/fundamentals/data-durability.mdx
@@ -18,6 +18,9 @@ These mechanisms generate **durability files** and save them in the respective
 `wal` and `snapshots` folders in the **data directory**. Data directory stores
 permanent data on disk. 
 
+Memgraph cannot be used with only WAL files enabled. You can either have only snapshots 
+or snapshots and WAL files.
+
 The default data directory path is `/var/lib/memgraph` but the path can be
 changed by modifying the `--data-directory` configuration flag. To learn how to
 modify configuration flags, head over to the
@@ -86,6 +89,11 @@ are created periodically based on the value defined with the
 on the value of the `--storage-snapshot-on-exit` configuration flag.  When a
 snapshot creation is triggered, the entire data storage is written to the drive.
 Nodes and relationships are divided into groups called batches.
+
+
+<Callout type="info">
+If both flags `--storage-snapshot-interval` and `--storage-snapshot-interval-sec` are defined, the flag `--storage-snapshot-interval` will be used.
+</Callout>
 
 Snapshot creation can be made faster by using **multiple threads**. See [Parallelized execution](#parallelized-execution) for more information.
 

--- a/pages/release-notes.mdx
+++ b/pages/release-notes.mdx
@@ -46,6 +46,14 @@ troubleshoot in production.
 
 ## 🚀 Latest release
 
+### Memgraph v3.6.0 - October 8th, 2025
+
+### MAGE v3.6.0 - October 8th, 2025
+
+### Lab v3.6.0 - October 8th, 2025
+
+## Previous releases
+
 ### Memgraph v3.5.0 - August 27th, 2025
 
 {<h4 className="custom-header">⚠️ Breaking changes</h4>}
@@ -268,7 +276,6 @@ troubleshoot in production.
 
 <LabReleasesClient version="3.5.0" />
 
-## Previous releases
 
 ### Memgraph v3.4.0 - July 10th, 2025
 


### PR DESCRIPTION
### Release note

Described new behaviour of snapshot flags. Explained that HA data instance won't be started if wal is disabled.

### Related product PRs

PRs from product repo this doc page is related to: 
https://github.com/memgraph/memgraph/pull/3259

### Checklist:

- [x] Add appropriate milestone (current release cycle)
- [x] Add `bugfix` or `feature` label, based on the product PR type you're documenting
- [x] Make sure all relevant tech details are documented
    - [x] Update reference pages (e.g. [clauses](https://memgraph.com/docs/querying/clauses), [functions](https://memgraph.com/docs/querying/functions), [flags](https://memgraph.com/docs/database-management/configuration#list-of-configuration-flags), [experimental](https://memgraph.com/docs/database-management/experimental-features), [monitoring](https://memgraph.com/docs/database-management/monitoring), [Cypher differences](https://memgraph.com/docs/querying/differences-in-cypher-implementations))
    - [x] Search for the feature you are working on (mentions) and make updates if needed
    - [x] Provide a basic example of usage
    - [x] In case your feature is an Enterprise one, list it under [ME page](https://memgraph.com/docs/database-management/enabling-memgraph-enterprise) and mark its page with Enterprise ([example](https://memgraph.com/docs/database-management/authentication-and-authorization/role-based-access-control)).
- [x] Check all content with Grammarly
- [x] Perform a self-review of my code
- [x] The build passes locally
- [x] My changes generate no new warnings or errors