### PR TITLE
 feat: Support MT authentication with bolt+routing on the HA cluster

### DIFF
--- a/pages/clustering/high-availability.mdx
+++ b/pages/clustering/high-availability.mdx
@@ -104,16 +104,16 @@ This rule could also apply to CentOS and Fedora, but at the moment it's not test
 
 ## Authentication
 
-User accounts exist exclusively on data instances—coordinators do not manage user authentication. Therefore, coordinator instances prohibit:
-  - Environment variables MEMGRAPH_USER and MEMGRAPH_PASSWORD
-  - Authentication queries such as CREATE USER
+User accounts exist exclusively on data instances - coordinators do not manage user authentication. Therefore, coordinator instances prohibit:
+  - Environment variables `MEMGRAPH_USER` and `MEMGRAPH_PASSWORD`.
+  - Authentication queries such as `CREATE USER`.
 
-When using the bolt+routing protocol, provide credentials for users that exist on the data instances. The authentication flow works as follows:
+When using the **bolt+routing protocol**, provide credentials for users that exist on the data instances. The authentication flow works as follows:
 
-1. Client connects to a coordinator
-2. Coordinator responds with the routing table (without authenticating)
-3. Client connects to the designated data instance using the same credentials
-4. Data instance authenticates the user and processes the request
+1. Client connects to a **coordinator**.
+2. Coordinator responds with the **routing table** (without authenticating).
+3. Client connects to the **designated data instance** using the **same credentials**.
+4. Data instance **authenticates the user and processes the request**.
 
 This architecture separates routing coordination from the user management, ensuring that authentication occurs only where user data resides.
 

--- a/pages/clustering/high-availability.mdx
+++ b/pages/clustering/high-availability.mdx
@@ -104,23 +104,19 @@ This rule could also apply to CentOS and Fedora, but at the moment it's not test
 
 ## Authentication
 
-When using authentication features for high availability, there are a couple of
-things to consider first.
+User accounts exist exclusively on data instances—coordinators do not manage user authentication. Therefore, coordinator instances prohibit:
+  - Environment variables MEMGRAPH_USER and MEMGRAPH_PASSWORD
+  - Authentication queries such as CREATE USER
 
-Currently, it is not possible to create users with the query `CREATE USER` on
-**coordinators**. Instead, for the direct Bolt connection to coordinators to work as
-expected, create user by [setting environment
-variables](/database-management/configuration#environment-variables)
-`MEMGRAPH_USER` and `MEMGRAPH_PASSWORD`.
+When using the bolt+routing protocol, provide credentials for users that exist on the data instances. The authentication flow works as follows:
 
-On the other hand, users can be created using the `CREATE USER` query on the
-**main data instance**. Such user will be replicated to other replica data instances
-but coordinators won't know about this user. 
+1. Client connects to a coordinator
+2. Coordinator responds with the routing table (without authenticating)
+3. Client connects to the designated data instance using the same credentials
+4. Data instance authenticates the user and processes the request
 
-When using the **bolt+routing** type of connection, the drivers are using the same
-authentication arguments for connecting to coordinators and data instances.
-Because of that, for bolt+routing connections, the user created on data
-instances needs to exist on coordinators too. 
+This architecture separates routing coordination from the user management, ensuring that authentication occurs only where user data resides.
+
 
 ## Starting instances
 


### PR DESCRIPTION
### Release note

Support MT authentication in the HA environment. 

### Related product PRs

PRs from product repo this doc page is related to: 
https://github.com/memgraph/memgraph/pull/3278

### Checklist:

- [x] Add appropriate milestone (current release cycle)
- [x] Add `bugfix` or `feature` label, based on the product PR type you're documenting
- [x] Make sure all relevant tech details are documented
    - [x] Update reference pages (e.g. [clauses](https://memgraph.com/docs/querying/clauses), [functions](https://memgraph.com/docs/querying/functions), [flags](https://memgraph.com/docs/database-management/configuration#list-of-configuration-flags), [experimental](https://memgraph.com/docs/database-management/experimental-features), [monitoring](https://memgraph.com/docs/database-management/monitoring), [Cypher differences](https://memgraph.com/docs/querying/differences-in-cypher-implementations))
    - [x] Search for the feature you are working on (mentions) and make updates if needed
    - [x] Provide a basic example of usage
    - [x] In case your feature is an Enterprise one, list it under [ME page](https://memgraph.com/docs/database-management/enabling-memgraph-enterprise) and mark its page with Enterprise ([example](https://memgraph.com/docs/database-management/authentication-and-authorization/role-based-access-control)).
- [x] Check all content with Grammarly
- [x] Perform a self-review of my code
- [x] The build passes locally
- [x] My changes generate no new warnings or errors