### PR TITLE
Fix query typo in the indexes docs

### DIFF
--- a/pages/fundamentals/indexes.mdx
+++ b/pages/fundamentals/indexes.mdx
@@ -204,7 +204,7 @@ Instead, you should use a `WHERE` clause to specify just the indexed property,
 which is the only scenario in which a nested index can be used:
 
 ```cypher
-MATCH (proj:Project) WHERE x.delivery.status.due_date = date('2025-06-04') RETURN *;
+MATCH (proj:Project) WHERE proj.delivery.status.due_date = date('2025-06-04') RETURN *;
 ```
 
 ```


### PR DESCRIPTION
This PR fixes a typo in a query in the indexes docs