### PR TITLE
feat: Add optional init containers to HA chart

### DIFF
--- a/pages/getting-started/install-memgraph/kubernetes.mdx
+++ b/pages/getting-started/install-memgraph/kubernetes.mdx
@@ -556,13 +556,6 @@ kubectl create secret generic memgraph-secrets --from-literal=USER=memgraph --fr
 
 The same user will then be created on all coordinator and data instances through Memgraph's environment variables.
 
-### Monitoring
-
-HA chart supports monitoring through Prometheus. The basic configuration template is provided in `values.yaml` file which allows you to specify whether or not you
-want to use Prometheus and through which type of service you want your Prometheus server to be exposed. We use `prometheus-community` [chart](https://github.com/prometheus-community/helm-charts)
-as a dependency set-up through Chart.yaml file.
-
-
 ### Setting up the cluster
 
 Although there are many configuration options you can use to set up HA cluster (especially for networking), the set-up process
@@ -775,6 +768,8 @@ The following table lists the configurable parameters of the Memgraph HA chart a
 | `labels.coordinators.statefulSetLabels`                    | Enables you to set labels on a stateful set level.                                                           | `{}`                           |
 | `labels.coordinators.serviceLabels`                        | Enables you to set labels on a service level.                                                                | `{}`                           |
 | `updateStrategy.type`                                      | Update strategy for StatefulSets. Possible values are `RollingUpdate` and `OnDelete`                         | `RollingUpdate`                | 
+| `initContainers.data`                                      | Init containers that users can define that will be applied to data instances.                                | `[]`                           | 
+| `initContainers.coordinators`                              | Init containers that users can define that will be applied to coordinators.                                  | `[]`                           | 
 
 
 For the `data` and `coordinators` sections, each item in the list has the following parameters:


### PR DESCRIPTION
### Release note

Documented optional init containers in the HA chart.

### Related product PRs

PRs from product repo this doc page is related to: 
https://github.com/memgraph/helm-charts/pull/165

### Checklist:

- [x] Add appropriate milestone (current release cycle)
- [x] Add `bugfix` or `feature` label, based on the product PR type you're documenting
- [x] Make sure all relevant tech details are documented
    - [x] Update reference pages (e.g. [clauses](https://memgraph.com/docs/querying/clauses), [functions](https://memgraph.com/docs/querying/functions), [flags](https://memgraph.com/docs/database-management/configuration#list-of-configuration-flags), [experimental](https://memgraph.com/docs/database-management/experimental-features), [monitoring](https://memgraph.com/docs/database-management/monitoring), [Cypher differences](https://memgraph.com/docs/querying/differences-in-cypher-implementations))
    - [x] Search for the feature you are working on (mentions) and make updates if needed
    - [x] Provide a basic example of usage
    - [x] In case your feature is an Enterprise one, list it under [ME page](https://memgraph.com/docs/database-management/enabling-memgraph-enterprise) and mark its page with Enterprise ([example](https://memgraph.com/docs/database-management/authentication-and-authorization/role-based-access-control)).
- [x] Check all content with Grammarly
- [x] Perform a self-review of my code
- [x] The build passes locally
- [x] My changes generate no new warnings or errors