### PR TITLE
Remove query parametrization

### DIFF
--- a/pages/querying/best-practices.mdx
+++ b/pages/querying/best-practices.mdx
@@ -444,42 +444,6 @@ When searching for a longer chain in the graph, you should be aware of
 cyphermorphism and make sure you utilize it. You can achieve that by writing a
 query that matches the exact pattern you need within the same clause.
 
-### Query parametrization
-
-Multiple query plans will be generated for each query, but only a single plan is
-optimal. Query planning time can be significant for complex queries because the
-query planner will try to generate multiple versions of the query plan and
-choose the optimal one. 
-
-After the optimal query plan is generated, it is cached and reused for the same
-query. **To utilize the benefits of the query plan caching, use query parameters
-as much as possible**.
-
-Here is an example of a query without query parameters:
-```cypher
-CREATE (n:Node {id: 123}); 
-CREATE (n:Node {id: 154}); 
-CREATE (n:Node {id: 322}); 
-```
-
-Here is an example of a query with query parameters:
-
-```cypher
-CREATE (n:Node {id: $id}); 
-CREATE (n:Node {id: $id});
-CREATE (n:Node {id: $id});
-```
-
-Memgraph query engine will try to cache the query plan even without the
-parameters. Still, **to ensure the best performance, use the query parameters
-whenever you can**.
-
-<Cards>
-    <Cards.Card
-    title="Read more about query plan caching"
-    href="/querying/query-plan#query-plan-caching"
-    />
-</Cards>
 
 ### Reduce roundtrip
 


### PR DESCRIPTION
This PR removes query parametrization from Querying best practices.
[Context](https://memgraph.slack.com/archives/CSR01RS80/p1758632944963509)