### PR TITLE
User-role mapping clarification

### DIFF
--- a/pages/database-management/authentication-and-authorization/multiple-roles.mdx
+++ b/pages/database-management/authentication-and-authorization/multiple-roles.mdx
@@ -13,6 +13,12 @@ users to have different roles assigned to them for specific databases. This
 feature enables proper tenant isolation and fine-grained access control in
 multi-tenant environments.
 
+<Callout type="warning">
+
+User-role mappings are simple maps located in the user. Deleting or renaming the database will not update this information. The admin needs to make sure the correct access is maintained at all times.
+
+</Callout>
+
 ## Privileges with multiple roles
 
 When a user has multiple roles, their privileges are combined according to the
@@ -215,7 +221,7 @@ specification, even in multi-tenant environments. It will show all roles
 assigned to the user across all databases.
 
 ```cypher
--- Show all roles for a user (works in all environments)
+-- Show all roles for a user (works in all environments)  
 SHOW ROLE FOR user_name;
 SHOW ROLES FOR user_name;
 ```

--- a/pages/database-management/authentication-and-authorization/role-based-access-control.mdx
+++ b/pages/database-management/authentication-and-authorization/role-based-access-control.mdx
@@ -114,6 +114,12 @@ SHOW ROLE FOR user_name ON CURRENT;
 SHOW ROLE FOR user_name ON DATABASE database_name;
 ```
 
+<Callout type="warning">
+
+User-role mappings are simple maps located in the user. Deleting or renaming the database will not update this information. The admin needs to make sure the correct access is maintained at all times.
+
+</Callout>
+
 These commands return the aggregated roles for the user in the specified
 database context. The `ON MAIN` option shows roles for the user's main database,
 `ON CURRENT` shows roles for whatever database is currently active, and `ON

--- a/pages/database-management/multi-tenancy.md
+++ b/pages/database-management/multi-tenancy.md
@@ -148,6 +148,12 @@ unified source of truth. A single user can access multiple databases with a
 global set of privileges, but currently, per-database privileges cannot be
 granted.
 
+<Callout type="warning">
+
+User-role mappings are simple maps located in the user. Deleting or renaming the database will not update this information. The admin needs to make sure the correct access is maintained at all times.
+
+</Callout>
+
 Access to all databases can be granted or revoked using wildcards:
 `GRANT DATABASE * TO user;`, `DENY DATABASE * TO user;` or 
 `REVOKE DATABASE * FROM user;`.


### PR DESCRIPTION
### Release note

Please briefly explain the changes you made which will be added to the changelog.
User-role mapping is not updated after a database is dropped. This was a conscious choice, but was not communicated. 
NOTE: This will  be changed for 3.7 after some customer complaints (mappings and access will be updated after db drops and renamings).

### Related product PRs

PRs from product repo this doc page is related to: 
(paste the links to the PRs)

### Checklist:

- [x] Add appropriate milestone (current release cycle)
- [x] Add `bugfix` or `feature` label, based on the product PR type you're documenting
- [x] Make sure all relevant tech details are documented
    - [x] Update reference pages (e.g. [clauses](https://memgraph.com/docs/querying/clauses), [functions](https://memgraph.com/docs/querying/functions), [flags](https://memgraph.com/docs/database-management/configuration#list-of-configuration-flags), [experimental](https://memgraph.com/docs/database-management/experimental-features), [monitoring](https://memgraph.com/docs/database-management/monitoring), [Cypher differences](https://memgraph.com/docs/querying/differences-in-cypher-implementations))
    - [x] Search for the feature you are working on (mentions) and make updates if needed
    - [x] Provide a basic example of usage
    - [x] In case your feature is an Enterprise one, list it under [ME page](https://memgraph.com/docs/database-management/enabling-memgraph-enterprise) and mark its page with Enterprise ([example](https://memgraph.com/docs/database-management/authentication-and-authorization/role-based-access-control)).
- [x] Check all content with Grammarly
- [x] Perform a self-review of my code
- [ ] The build passes locally
- [ ] My changes generate no new warnings or errors