### PR TITLE
Update direct download links

### DIFF
--- a/pages/getting-started/install-memgraph/direct-download-links.mdx
+++ b/pages/getting-started/install-memgraph/direct-download-links.mdx
@@ -11,32 +11,32 @@ Download Hub](https://memgraph.com/download/). If you need direct links for the
 latest version of Memgraph database, take a look at the list below.
 
 ## Docker
-- [https://download.memgraph.com/memgraph/v3.5.0/docker/memgraph-3.5.0-docker.tar.gz](https://download.memgraph.com/memgraph/v3.5.0/docker/memgraph-3.5.0-docker.tar.gz)
-- [https://download.memgraph.com/memgraph/v3.5.0/docker-aarch64/memgraph-3.5.0-docker.tar.gz](https://download.memgraph.com/memgraph/v3.5.0/docker-aarch64/memgraph-3.5.0-docker.tar.gz)
-- [https://download.memgraph.com/memgraph/v3.5.0/docker-relwithdebinfo/memgraph-3.5.0-relwithdebinfo-docker.tar.gz](https://download.memgraph.com/memgraph/v3.5.0/docker-relwithdebinfo/memgraph-3.5.0-relwithdebinfo-docker.tar.gz)
-- [https://download.memgraph.com/memgraph/v3.5.0/docker-aarch64-relwithdebinfo/memgraph-3.5.0-relwithdebinfo-docker.tar.gz](https://download.memgraph.com/memgraph/v3.5.0/docker-aarch64-relwithdebinfo/memgraph-3.5.0-relwithdebinfo-docker.tar.gz)
+- [https://download.memgraph.com/memgraph/v3.6.0/docker/memgraph-3.6.0-docker.tar.gz](https://download.memgraph.com/memgraph/v3.6.0/docker/memgraph-3.6.0-docker.tar.gz)
+- [https://download.memgraph.com/memgraph/v3.6.0/docker-aarch64/memgraph-3.6.0-docker.tar.gz](https://download.memgraph.com/memgraph/v3.6.0/docker-aarch64/memgraph-3.6.0-docker.tar.gz)
+- [https://download.memgraph.com/memgraph/v3.6.0/docker-relwithdebinfo/memgraph-3.6.0-relwithdebinfo-docker.tar.gz](https://download.memgraph.com/memgraph/v3.6.0/docker-relwithdebinfo/memgraph-3.6.0-relwithdebinfo-docker.tar.gz)
+- [https://download.memgraph.com/memgraph/v3.6.0/docker-aarch64-relwithdebinfo/memgraph-3.6.0-relwithdebinfo-docker.tar.gz](https://download.memgraph.com/memgraph/v3.6.0/docker-aarch64-relwithdebinfo/memgraph-3.6.0-relwithdebinfo-docker.tar.gz)
 
 ## Linux
 
 Memgraph can be run on the Linux distributions listed below.
 
 ### CentOS
-- [https://download.memgraph.com/memgraph/v3.5.0/centos-9/memgraph-3.5.0_1-1.x86_64.rpm](https://download.memgraph.com/memgraph/v3.5.0/centos-9/memgraph-3.5.0_1-1.x86_64.rpm)
-- [https://download.memgraph.com/memgraph/v3.5.0/centos-10/memgraph-3.5.0_1-1.x86_64.rpm](https://download.memgraph.com/memgraph/v3.5.0/centos-10/memgraph-3.5.0_1-1.x86_64.rpm)
+- [https://download.memgraph.com/memgraph/v3.6.0/centos-9/memgraph-3.6.0_1-1.x86_64.rpm](https://download.memgraph.com/memgraph/v3.6.0/centos-9/memgraph-3.6.0_1-1.x86_64.rpm)
+- [https://download.memgraph.com/memgraph/v3.6.0/centos-10/memgraph-3.6.0_1-1.x86_64.rpm](https://download.memgraph.com/memgraph/v3.6.0/centos-10/memgraph-3.6.0_1-1.x86_64.rpm)
 
 ### Debian
-- [https://download.memgraph.com/memgraph/v3.5.0/debian-11/memgraph_3.5.0-1_amd64.deb](https://download.memgraph.com/memgraph/v3.5.0/debian-11/memgraph_3.5.0-1_amd64.deb)
-- [https://download.memgraph.com/memgraph/v3.5.0/debian-12/memgraph_3.5.0-1_amd64.deb](https://download.memgraph.com/memgraph/v3.5.0/debian-12/memgraph_3.5.0-1_amd64.deb)
+- [https://download.memgraph.com/memgraph/v3.6.0/debian-11/memgraph_3.6.0-1_amd64.deb](https://download.memgraph.com/memgraph/v3.6.0/debian-11/memgraph_3.6.0-1_amd64.deb)
+- [https://download.memgraph.com/memgraph/v3.6.0/debian-12/memgraph_3.6.0-1_amd64.deb](https://download.memgraph.com/memgraph/v3.6.0/debian-12/memgraph_3.6.0-1_amd64.deb)
 
 ### Fedora
-- [https://download.memgraph.com/memgraph/v3.5.0/fedora-41/memgraph-3.5.0_1-1.x86_64.rpm](https://download.memgraph.com/memgraph/v3.5.0/fedora-41/memgraph-3.5.0_1-1.x86_64.rpm)
+- [https://download.memgraph.com/memgraph/v3.6.0/fedora-41/memgraph-3.6.0_1-1.x86_64.rpm](https://download.memgraph.com/memgraph/v3.6.0/fedora-41/memgraph-3.6.0_1-1.x86_64.rpm)
 
 ### Red Hat
-- [https://download.memgraph.com/memgraph/v3.5.0/centos-9/memgraph-3.5.0_1-1.x86_64.rpm](https://download.memgraph.com/memgraph/v3.5.0/centos-9/memgraph-3.5.0_1-1.x86_64.rpm)
+- [https://download.memgraph.com/memgraph/v3.6.0/centos-9/memgraph-3.6.0_1-1.x86_64.rpm](https://download.memgraph.com/memgraph/v3.6.0/centos-9/memgraph-3.6.0_1-1.x86_64.rpm)
 
 ### Ubuntu
-- [https://download.memgraph.com/memgraph/v3.5.0/ubuntu-22.04/memgraph_3.5.0-1_amd64.deb](https://download.memgraph.com/memgraph/v3.5.0/ubuntu-22.04/memgraph_3.5.0-1_amd64.deb)
-- [https://download.memgraph.com/memgraph/v3.5.0/ubuntu-24.04/memgraph_3.5.0-1_amd64.deb](https://download.memgraph.com/memgraph/v3.5.0/ubuntu-24.04/memgraph_3.5.0-1_amd64.deb)
-- [https://download.memgraph.com/memgraph/v3.5.0/ubuntu-24.04-relwithdebinfo/memgraph_3.5.0-1_amd64.deb](https://download.memgraph.com/memgraph/v3.5.0/ubuntu-24.04-relwithdebinfo/memgraph_3.5.0-1_amd64.deb)
-- [https://download.memgraph.com/memgraph/v3.5.0/ubuntu-24.04-aarch64/memgraph_3.5.0-1_arm64.deb](https://download.memgraph.com/memgraph/v3.5.0/ubuntu-24.04-aarch64/memgraph_3.5.0-1_arm64.deb)
-- [https://download.memgraph.com/memgraph/v3.5.0/ubuntu-24.04-aarch64-relwithdebinfo/memgraph_3.5.0-1_arm64.deb](https://download.memgraph.com/memgraph/v3.5.0/ubuntu-24.04-aarch64-relwithdebinfo/memgraph_3.5.0-1_arm64.deb)
+- [https://download.memgraph.com/memgraph/v3.6.0/ubuntu-22.04/memgraph_3.6.0-1_amd64.deb](https://download.memgraph.com/memgraph/v3.6.0/ubuntu-22.04/memgraph_3.6.0-1_amd64.deb)
+- [https://download.memgraph.com/memgraph/v3.6.0/ubuntu-24.04/memgraph_3.6.0-1_amd64.deb](https://download.memgraph.com/memgraph/v3.6.0/ubuntu-24.04/memgraph_3.6.0-1_amd64.deb)
+- [https://download.memgraph.com/memgraph/v3.6.0/ubuntu-24.04-relwithdebinfo/memgraph_3.6.0-1_amd64.deb](https://download.memgraph.com/memgraph/v3.6.0/ubuntu-24.04-relwithdebinfo/memgraph_3.6.0-1_amd64.deb)
+- [https://download.memgraph.com/memgraph/v3.6.0/ubuntu-24.04-aarch64/memgraph_3.6.0-1_arm64.deb](https://download.memgraph.com/memgraph/v3.6.0/ubuntu-24.04-aarch64/memgraph_3.6.0-1_arm64.deb)
+- [https://download.memgraph.com/memgraph/v3.6.0/ubuntu-24.04-aarch64-relwithdebinfo/memgraph_3.6.0-1_arm64.deb](https://download.memgraph.com/memgraph/v3.6.0/ubuntu-24.04-aarch64-relwithdebinfo/memgraph_3.6.0-1_arm64.deb)


### PR DESCRIPTION
This PR updates direct download links with the new 3.6 version of Memgraph.