### PR TITLE
Clarify `datetime()` behaviour when fields are missing

### DIFF
--- a/pages/fundamentals/data-types.mdx
+++ b/pages/fundamentals/data-types.mdx
@@ -622,7 +622,12 @@ CREATE (:Flight {AIR123: datetime("2021-04-21T14:15:00Z")});
 
 Maps for constructing `ZonedDateTime` values may have the following fields:
 `year`, `month`, `day`, `hour`, `minute`, `second`, `millisecond`,
-`microsecond` and `timezone`.
+`microsecond` and `timezone`. If some numeric fields are omitted, they will
+assume the lowest value for that field, which is `0` for `year`, `hour`,
+`minute`, `second`, `millisecond`, and `microsecond`; and `1` for `month` and
+`day`. If the `timezone` is omitted, UTC will be assumed. If all numeric
+fields are omitted and only the `timezone` is specified, then a `datetime`
+representing the current clock time in the given timezone is created.
 
 There are two options for the `timezone` field:
 * string: timezone name from the

--- a/pages/fundamentals/data-types.mdx
+++ b/pages/fundamentals/data-types.mdx
@@ -622,12 +622,13 @@ CREATE (:Flight {AIR123: datetime("2021-04-21T14:15:00Z")});
 
 Maps for constructing `ZonedDateTime` values may have the following fields:
 `year`, `month`, `day`, `hour`, `minute`, `second`, `millisecond`,
-`microsecond` and `timezone`. If some numeric fields are omitted, they will
-assume the lowest value for that field, which is `0` for `year`, `hour`,
-`minute`, `second`, `millisecond`, and `microsecond`; and `1` for `month` and
-`day`. If the `timezone` is omitted, UTC will be assumed. If all numeric
-fields are omitted and only the `timezone` is specified, then a `datetime`
-representing the current clock time in the given timezone is created.
+`microsecond` and `timezone`. 
+- If some numeric fields are omitted, they default to the lowest value for that field:
+     - `0` for `year`, `hour`, `minute`, `second`, `millisecond`, and `microsecond`.
+     - `1` for `month` and `day`. 
+- If the `timezone` is omitted, it defaults to UTC. 
+- If all numeric fields are omitted and only the `timezone` is specified, then a `datetime`
+represents the **current time** in the that timezone.
 
 There are two options for the `timezone` field:
 * string: timezone name from the


### PR DESCRIPTION
### Release note

Clarifies what defaults are assumed when any numeric fields or the `timezone` is omitted when calling `datetime()`. 

### Related product PRs

https://github.com/memgraph/memgraph/pull/3339

### Checklist:

- [ ] Add appropriate milestone (current release cycle)
- [ ] Add `bugfix` or `feature` label, based on the product PR type you're documenting
- [x] Make sure all relevant tech details are documented
    - [ ] Update reference pages (e.g. [clauses](https://memgraph.com/docs/querying/clauses), [functions](https://memgraph.com/docs/querying/functions), [flags](https://memgraph.com/docs/database-management/configuration#list-of-configuration-flags), [experimental](https://memgraph.com/docs/database-management/experimental-features), [monitoring](https://memgraph.com/docs/database-management/monitoring), [Cypher differences](https://memgraph.com/docs/querying/differences-in-cypher-implementations))
    - [ ] Search for the feature you are working on (mentions) and make updates if needed
    - [ ] Provide a basic example of usage
    - [ ] In case your feature is an Enterprise one, list it under [ME page](https://memgraph.com/docs/database-management/enabling-memgraph-enterprise) and mark its page with Enterprise ([example](https://memgraph.com/docs/database-management/authentication-and-authorization/role-based-access-control)).
- [x] Check all content with Grammarly
- [x] Perform a self-review of my code
- [x] The build passes locally
- [x] My changes generate no new warnings or errors