### PR TITLE
Remove experimental features section of the docs

### DIFF
--- a/pages/database-management.mdx
+++ b/pages/database-management.mdx
@@ -31,11 +31,11 @@ needs.
 ## [Enabling Memgraph Enterprise](/database-management/enabling-memgraph-enterprise) 
 
 Check how to enable Memgraph Enterprise to get access to advanced features. 
-
+{/*
 ## [Experimental features](/database-management/experimental-features) 
 
 Experimental features in Memgraph represent the forefront of our innovation, offering cutting-edge functionality as we continuously enhance our product. Learn how to try them out.
-
+*/}
 ## [Logs](/database-management/logs)
 
 Check how to access logs and change log tracking level. Learn about query audit logging in Memgraph Enterprise.

--- a/pages/database-management/_meta.ts
+++ b/pages/database-management/_meta.ts
@@ -4,7 +4,7 @@ export default {
   "configuration": "Configuration",
   "debugging": "Debugging",
   "enabling-memgraph-enterprise": "Enabling Memgraph Enterprise",
-  "experimental-features": "Experimental features",
+  "experimental-features": { display: "hidden" },
   "logs": "Logs",
   "monitoring": "Monitoring",
   "multi-tenancy": "Multi-tenancy",

--- a/pages/database-management/configuration.mdx
+++ b/pages/database-management/configuration.mdx
@@ -394,6 +394,7 @@ workers simultaneously.
 
 </Callout>
 
+{/*
 ### Experimental features
 
 This section contains the list of flags that are used to configure [experimental features](/database-management/experimental-features) in Memgraph.
@@ -401,7 +402,7 @@ This section contains the list of flags that are used to configure [experimental
 | Flag                                          | Description                                                                                                                                                    |
 |-----------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `--experimental-enabled`                        | Enables experimental capabilities within Memgraph. Currently, `text-search` is allowed value.                                                                  |
-
+*/}
 
 ### High availability
 


### PR DESCRIPTION
Since we currently don't have any experimental features in Memgraph, this PR removes all mentions of it from the documentation.