### PR TITLE
Update changelog for v3.6.2 release

### DIFF
--- a/pages/release-notes.mdx
+++ b/pages/release-notes.mdx
@@ -59,7 +59,6 @@ troubleshoot in production.
 
 - Added `text()` function to embed lists of strings directly. 
   [#686](https://github.com/memgraph/mage/pull/686)
-
 - Added `model_info()` function to return a `Map` of information about the model 
   being used. [#686](https://github.com/memgraph/mage/pull/686)
 
@@ -69,7 +68,6 @@ troubleshoot in production.
   list of embeddings are returned. `node_sentence()` now returns `dimension` - 
   the length of the output of the embedding model. 
   [#686](https://github.com/memgraph/mage/pull/686)
-
 - Fixed default `device` such that CPU-only containers fallback to CPU compute 
   without having to specify that `device="cpu"`.
   [#686](https://github.com/memgraph/mage/pull/686)


### PR DESCRIPTION
### Release note

Update changelog for v3.6.2 release

### Related product PRs

No milestone for Memgraph v3.6.2.

MAGE milestone: https://github.com/memgraph/mage/milestone/27

- https://github.com/memgraph/documentation/pull/1450 -> https://github.com/memgraph/mage/pull/686


