### PR TITLE
Update debugging docs for heaptrack

### DIFF
--- a/pages/database-management/debugging.mdx
+++ b/pages/database-management/debugging.mdx
@@ -235,6 +235,69 @@ services:
 ```
 
 
+### Using `heaptrack` with Docker
+
+All `RelWithDebInfo` images come with `heaptrack` installed. You can use it to track the memory usage of Memgraph.
+
+Before starting the container, create a directory to store the heaptrack data:
+
+```bash
+mkdir -p /tmp/heaptrack
+chmod a+rwx /tmp/heaptrack
+```
+
+Then start the container with the following command:
+
+```bash
+docker run -d --rm \
+  --name memgraph \
+  -v /tmp/heaptrack:/data \
+  --entrypoint /usr/bin/heaptrack \
+  memgraph/memgraph:3.6.1-relwithdebinfo \
+  --output /data/heaptrack.memgraph \
+  -- \
+  /usr/lib/memgraph/memgraph
+```
+
+<Callout>
+  Running the MAGE container using this method will result in a segmentation fault due to the way 
+  that `heaptrack` interacts with Python, so memgraph should be launched by `heaptrack` using the `--use-inject` flag:
+
+  ```bash
+  docker run -d --rm \
+    --name memgraph \
+    -p 7687:7687 \
+    -v /tmp/heaptrack:/data \
+    --entrypoint /usr/bin/heaptrack \
+    memgraph/memgraph-mage:3.6.1-relwithdebinfo \
+    --output /data/heaptrack.memgraph \
+    --use-inject /usr/lib/memgraph/memgraph
+  ```
+</Callout>
+
+To stop `memgraph` gracefully:
+
+```bash
+docker exec memgraph bash -c "kill -SIGINT \$(pidof memgraph)"
+```
+
+Then the `heaptrack` GUI can be used to inspect the heaptrack data on the host machine:
+
+```bash
+heaptrack /tmp/heaptrack/heaptrack.memgraph.gz
+```
+
+<Callout>
+  The `heaptrack` GUI can be installed on the host machine by issuing the command (Debian/Ubuntu):
+  ```bash
+  sudo apt install heaptrack
+  ```
+  or by issuing the command (Fedora):
+  ```bash
+  sudo dnf install heaptrack
+  ```
+</Callout>
+
 ### Profiling with `perf`
 
 Perfing is the most common operation that is run when Memgraph is hanging or


### PR DESCRIPTION
### Release note

Added instructions on how to use `heaptrack` with Memgraph and MAGE Docker images.

### Related product PRs

PRs from product repo this doc page is related to: 
- https://github.com/memgraph/memgraph/pull/3346
- https://github.com/memgraph/mage/pull/681

### Checklist:

- [x] Add appropriate milestone (current release cycle)
- [x] Add `bugfix` or `feature` label, based on the product PR type you're documenting
- [ ] Make sure all relevant tech details are documented
    - [ ] Update reference pages (e.g. [clauses](https://memgraph.com/docs/querying/clauses), [functions](https://memgraph.com/docs/querying/functions), [flags](https://memgraph.com/docs/database-management/configuration#list-of-configuration-flags), [experimental](https://memgraph.com/docs/database-management/experimental-features), [monitoring](https://memgraph.com/docs/database-management/monitoring), [Cypher differences](https://memgraph.com/docs/querying/differences-in-cypher-implementations))
    - [ ] Search for the feature you are working on (mentions) and make updates if needed
    - [ ] Provide a basic example of usage
    - [ ] In case your feature is an Enterprise one, list it under [ME page](https://memgraph.com/docs/database-management/enabling-memgraph-enterprise) and mark its page with Enterprise ([example](https://memgraph.com/docs/database-management/authentication-and-authorization/role-based-access-control)).
- [ ] Check all content with Grammarly
- [ ] Perform a self-review of my code
- [x] The build passes locally
- [ ] My changes generate no new warnings or errors