### PR TITLE
Load JSON from string

### DIFF
--- a/pages/advanced-algorithms/available-algorithms/json_util.mdx
+++ b/pages/advanced-algorithms/available-algorithms/json_util.mdx
@@ -144,6 +144,28 @@ YIELD objects
 RETURN objects;
 ```
 
+### `load_from_str()`
+
+The procedure loads data from a JSON string.
+
+{<h4 className="custom-header"> Input: </h4>}
+
+- `json_str: string` ➡ JSON string that needs to be loaded.
+
+{<h4 className="custom-header"> Output: </h4>}
+
+- `objects: List[object]` ➡ A list of JSON objects from the string that is being loaded.
+
+{<h4 className="custom-header"> Usage: </h4>}
+
+Use the following query to load data from a JSON string:
+
+```cypher
+CALL json_util.load_from_str(json_str) 
+YIELD objects
+RETURN objects;
+```
+
 ## Examples
 
 ### Load JSON from path
@@ -216,6 +238,36 @@ Run the query to load the data from the file at the URL:
 
 ```cypher
 CALL json_util.load_from_url("https://download.memgraph.com/asset/mage/data.json") 
+YIELD objects
+UNWIND objects AS o
+RETURN o.first_name AS name, o.last_name AS surname;
+```
+
+Results:
+
+```plaintext
++------------------+-------------------+
+| name             | surname           |
++------------------+-------------------+
+| James            | Bond              |
++------------------+-------------------+
+```
+</Steps>
+
+### Load JSON from string
+
+<Steps>
+
+{<h3 className="custom-header"> Input string </h3>}
+
+The JSON string is `{"first_name": "James", "last_name": "Bond"}`.
+
+{<h3 className="custom-header"> Import data </h3>}
+
+Directly parse the JSON string:
+
+```cypher
+CALL json_util.load_from_str('{"first_name": "James", "last_name": "Bond"}')
 YIELD objects
 UNWIND objects AS o
 RETURN o.first_name AS name, o.last_name AS surname;


### PR DESCRIPTION
### Release note

Added `load_json_str()` procedure to the `json_util` query module.

### Related product PRs

PRs from product repo this doc page is related to: 
- https://github.com/memgraph/mage/pull/530

### Checklist:

- [x] Add appropriate milestone (current release cycle)
- [x] Add `bugfix` or `feature` label, based on the product PR type you're documenting
- [ ] Make sure all relevant tech details are documented
    - [ ] Update reference pages (e.g. [clauses](https://memgraph.com/docs/querying/clauses), [functions](https://memgraph.com/docs/querying/functions), [flags](https://memgraph.com/docs/database-management/configuration#list-of-configuration-flags), [experimental](https://memgraph.com/docs/database-management/experimental-features), [monitoring](https://memgraph.com/docs/database-management/monitoring), [Cypher differences](https://memgraph.com/docs/querying/differences-in-cypher-implementations))
    - [ ] Search for the feature you are working on (mentions) and make updates if needed
    - [x] Provide a basic example of usage
    - [ ] In case your feature is an Enterprise one, list it under [ME page](https://memgraph.com/docs/database-management/enabling-memgraph-enterprise) and mark its page with Enterprise ([example](https://memgraph.com/docs/database-management/authentication-and-authorization/role-based-access-control)).
- [ ] Check all content with Grammarly
- [x] Perform a self-review of my code
- [x] The build passes locally
- [x] My changes generate no new warnings or errors