### PR TITLE
Add boolean flag syntax warning and --strict-flag-check docs

### DIFF
--- a/pages/database-management/configuration.mdx
+++ b/pages/database-management/configuration.mdx
@@ -19,6 +19,15 @@ and key-value pairs that can be modified to suit your specific needs.
 
 Each configuration setting is in the form: `--setting-name=value`.
 
+<Callout type="warning">
+
+Boolean flags **must** use `=` syntax: `--flag=true` or `--flag=false`. Writing
+`--flag false` (space-separated) does **not** work as expected — it sets the flag
+to `true` and treats `false` as an unrecognized argument. You can also use
+`--flag` to enable or `--noflag` to disable.
+
+</Callout>
+
 You can check the current configuration by using the following query:
 
 ```opencypher
@@ -532,6 +541,7 @@ This section contains the list of all other relevant flags used within Memgraph.
 | `--replication-replica-check-frequency-sec`     | The time duration in seconds between two replica checks/pings. If < 1, replicas will not be checked at all and the replica will never be recovered. The MAIN instance allocates a new thread for each REPLICA.                                                                                                                                               | `[uint64]` |
 | `--replication-restore-state-on-startup=true`   | Set to `true` when initializing an instance to restore the replication role and configuration upon restart.                                                                                                                                                                                                                                                  | `[bool]`   |
 | `--schema-info-enabled=false`                   | Set to `true` to enable run-time schema info tracking.                                                                                                                                                                                                                                                                                                       | `[bool]`   |
+| `--strict-flag-check=false`                     | If `true`, Memgraph will error and exit when suspicious positional arguments are detected (e.g. `--bool-flag false` instead of `--bool-flag=false`). If `false`, a warning is logged instead.                                                                                                                                                                | `[bool]`   |
 | `--telemetry-enabled=true`                      | Set to true to enable telemetry. We collect information about the running system (CPU and memory information), information about the database runtime (vertex and edge counts and resource usage), and aggregated statistics about some features of the database (e.g. how many times a feature is used) to allow for an easier improvement of the product.  | `[bool]`   |
 
 ### Environment variables


### PR DESCRIPTION
### Release note

Added new warning for incorrect flag usage, along with --strict-flag-check to force memgraph error if command line flags were incorrect.

### Related product PRs

PRs from product repo this doc page is related to: 
https://github.com/memgraph/memgraph/pull/4009

### Checklist:

- [x] Add appropriate milestone (current release cycle)
- [x] Add `bugfix` or `feature` label, based on the product PR type you're documenting
- [ ] Make sure all relevant tech details are documented
    - [ ] Update reference pages (e.g. [clauses](https://memgraph.com/docs/querying/clauses), [functions](https://memgraph.com/docs/querying/functions), [flags](https://memgraph.com/docs/database-management/configuration#list-of-configuration-flags), [experimental](https://memgraph.com/docs/database-management/experimental-features), [monitoring](https://memgraph.com/docs/database-management/monitoring), [Cypher differences](https://memgraph.com/docs/querying/differences-in-cypher-implementations))
    - [ ] Search for the feature you are working on (mentions) and make updates if needed
    - [ ] Provide a basic example of usage
    - [ ] In case your feature is an Enterprise one, list it under [ME page](https://memgraph.com/docs/database-management/enabling-memgraph-enterprise) and mark its page with Enterprise ([example](https://memgraph.com/docs/database-management/authentication-and-authorization/role-based-access-control)).
- [ ] Check all content with Grammarly
- [ ] Perform a self-review of my code
- [ ] The build passes locally
- [ ] My changes generate no new warnings or errors