### PR TITLE
Remove init script from Memgraph's build process

### DIFF
--- a/pages/getting-started/build-memgraph-from-source.mdx
+++ b/pages/getting-started/build-memgraph-from-source.mdx
@@ -219,17 +219,6 @@ conan remote add memgraph-recipes "$(pwd)/conan_recipes" -t local-recipes-index 
     without manual `conan export`.
 </Callout>
 
-<h3 className="custom-header">Run the init script to fetch other libs required for the build</h3>
-
-```bash
-./init
-```
-
-<Callout>
-    The `init` script fetches other libraries required for the build which are not yet provided
-    by `conan` (gflags, rocksdb, nuraft, protobuf, pulsar, usearch).
-</Callout>
-
 <h3 className="custom-header">Install conan dependencies</h3>
 
 ```bash
@@ -375,19 +364,16 @@ When build errors occur, there are some common issues that can be resolved by th
 
 1. Remove the `build` directory and run the build again.
 
-2. Re-run `./init`: Sometimes libraries that are configures by this script will be 
-upgraded/added/removed in the `master` branch, potentially causing future build errors.
-
-3. Re-run `conan install`: for simlar reasons as the previous step - libraries used in the build may
+2. Re-run `conan install`: for simlar reasons as the previous step - libraries used in the build may
 have been changed in `conanfile.py`. Unexpected linking errors can be caused by this.
 
-4. Reinstall `conan_config`. As list of supported Linux distributions and architectures evolves, 
+3. Reinstall `conan_config`. As list of supported Linux distributions and architectures evolves, 
 and the libraries used in the build may change, the configuration may need to be updated to account
 for specific build issues on some platforms.
 
-5. Reinstall host dependencies, as these may sometimes change.
+4. Reinstall host dependencies, as these may sometimes change.
 
-6. Renaming or removing the conan cache directory (usually `~/.conan2`) in order to rebuild the 
+5. Renaming or removing the conan cache directory (usually `~/.conan2`) in order to rebuild the 
 libraries and build tools from scratch can help to resolve build issues.
 
-7. Open an issue on our [GitHub repository](https://github.com/memgraph/memgraph/issues) with the error message.
+6. Open an issue on our [GitHub repository](https://github.com/memgraph/memgraph/issues) with the error message.


### PR DESCRIPTION
### Release note

The `init` script is no longer needed, so I'm removing that step from the docs.

### Related product PRs

PRs from product repo this doc page is related to: 
https://github.com/memgraph/memgraph/pull/4023

### Checklist:

- [x] Add appropriate milestone (current release cycle)
- [x] Add `bugfix` or `feature` label, based on the product PR type you're documenting
- [x] Make sure all relevant tech details are documented
    - [ ] Update reference pages (e.g. [clauses](https://memgraph.com/docs/querying/clauses), [functions](https://memgraph.com/docs/querying/functions), [flags](https://memgraph.com/docs/database-management/configuration#list-of-configuration-flags), [experimental](https://memgraph.com/docs/database-management/experimental-features), [monitoring](https://memgraph.com/docs/database-management/monitoring), [Cypher differences](https://memgraph.com/docs/querying/differences-in-cypher-implementations))
    - [ ] Search for the feature you are working on (mentions) and make updates if needed
    - [ ] Provide a basic example of usage
    - [ ] In case your feature is an Enterprise one, list it under [ME page](https://memgraph.com/docs/database-management/enabling-memgraph-enterprise) and mark its page with Enterprise ([example](https://memgraph.com/docs/database-management/authentication-and-authorization/role-based-access-control)).
- [ ] Check all content with Grammarly
- [x] Perform a self-review of my code
- [x] The build passes locally
- [x] My changes generate no new warnings or errors