### PR TITLE
Update vector edge index docs

### DIFF
--- a/pages/querying/vector-search.mdx
+++ b/pages/querying/vector-search.mdx
@@ -19,7 +19,7 @@ specifically operates at `READ_UNCOMMITTED`. This design maintains all
 transactional guarantees at the database level. Only the vector index
 operations use this relaxed isolation level, ensuring the database's ACID
 properties remain intact for all other operations.
-Memgraph supports vector indexes on both **nodes** and **edges**. Both use the same **single-store** pattern: the vector value is stored only in the vector index backend (USearch), and the property store keeps only a reference (a vector index ID). This avoids duplicating vector data between the property store and the index. The syntax and the procedures used to create, query and drop the index differ between the node and the edge variant.
+Memgraph supports vector indexes on both **nodes** and **edges**. Both use the same **single-store** pattern: the vector value is stored only in the vector index backend (USearch), and the property store keeps only a reference (a vector index ID). This avoids duplicating vector data between the property store and the index. The creation syntax (`CREATE VECTOR INDEX` vs. `CREATE VECTOR EDGE INDEX`) and the search procedure (`vector_search.search()` vs. `vector_search.search_edges()`) differ between the node and the edge variant; `DROP VECTOR INDEX` and `SHOW VECTOR INDEX INFO` work for both.
 
 <Callout type="warning">
 To configure vector search as described in the example, please use the latest Memgraph version.

--- a/pages/querying/vector-search.mdx
+++ b/pages/querying/vector-search.mdx
@@ -19,10 +19,7 @@ specifically operates at `READ_UNCOMMITTED`. This design maintains all
 transactional guarantees at the database level. Only the vector index
 operations use this relaxed isolation level, ensuring the database's ACID
 properties remain intact for all other operations.
-Memgraph supports two kinds of vector indexes:
-
-- **Single-store vector index on nodes**. The vector value is stored only in the vector index backend (USearch); the property store keeps only a reference (vector index ID). This avoids duplicating vector data between the property store and the index.
-- **Vector index on edges**. This uses a different storage model: the vector remains in the edge property store and is also indexed in USearch. Creating, querying, and dropping edge vector indexes is done with separate syntax and procedures from the single-store (node) index.
+Memgraph supports vector indexes on both **nodes** and **edges**. Both use the same **single-store** pattern: the vector value is stored only in the vector index backend (USearch), and the property store keeps only a reference (a vector index ID). This avoids duplicating vector data between the property store and the index. The syntax and the procedures used to create, query and drop the index differ between the node and the edge variant.
 
 <Callout type="warning">
 To configure vector search as described in the example, please use the latest Memgraph version.
@@ -36,11 +33,11 @@ systems to find entities based on semantic similarity rather than exact matches.
 
 ## Create vector index 
 
-To run vector search, first create a vector index. The syntax and storage behavior differ for nodes and edges.
+To run vector search, first create a vector index. The syntax differs for nodes and edges; the storage behavior is the same (single-store) for both.
 
-### Single-store vector index
+### Vector index on nodes
 
-Single-store vector indices are created with the `CREATE VECTOR INDEX` command. You need to:
+Vector indexes on nodes are created with the `CREATE VECTOR INDEX` command. You need to:
 
 1. Provide the index name
 2. Specify the label and property it applies to
@@ -64,7 +61,7 @@ CREATE VECTOR EDGE INDEX vector_index_name ON :EDGE_TYPE(embedding) WITH CONFIG 
 
 ### Configuration parameters
 
-The following options apply to both single-store vector indexes (nodes) and vector indexes on edges:
+The following options apply to vector indexes on both nodes and edges:
 
 - `dimension: int` ➡ The dimension of vectors in the index.
 - `capacity: int` ➡ Minimum capacity for the vector index, which prefers powers of two and is adjusted internally for optimal performance but will be at least the given value.
@@ -130,7 +127,7 @@ Additionally, the same information can be retrieved with the `SHOW VECTOR INDEX 
 - `metric: string` ➡ [Similarity metric](#similarity-metrics) used for vector search.
 - `size: int` ➡ The number of entries in the vector index.
 - `scalar_kind: string` ➡ The [scalar kind](#scalar-kind) used for each vector element.
-- `index_type: string` ➡ The type of the index. For a single-store vector index on nodes, the output is `label+property_vector`; for an index on edges, it is `edge-type+property_vector`.
+- `index_type: string` ➡ The type of the index. For a vector index on nodes, the output is `label+property_vector`; for a vector index on edges, it is `edge-type+property_vector`.
 
 {<h3 className="custom-header"> Usage: </h3>}
 
@@ -263,8 +260,8 @@ DROP VECTOR INDEX vector_index_name;
 ```
 
 <Callout type="warning">
-**Single-store vector index (nodes only):** When you drop a single-store vector index, Memgraph must move all vector data from USearch back into the property store. Every affected node's property is rewritten from a vector index ID to the full vector. This can be **slow** (one write per indexed node) and **memory costly** (vectors are stored in the property store as 64-bit values, increasing property store size). 
-The same effect occurs when you **remove a label** from a node that had a vector index on that label: if no other vector index references that property, the vector is restored from USearch to the property store. Plan accordingly when dropping indexes or changing labels on large datasets.
+**Drop cost (nodes and edges):** When you drop a vector index, Memgraph must move all vector data from USearch back into the property store. Every affected node's or edge's property is rewritten from a vector index ID to the full vector. This can be **slow** (one write per indexed entry) and **memory costly** (vectors are stored in the property store as 64-bit values, increasing property store size).
+The same effect occurs when you **remove a label** from a node that had a vector index on that label: if no other vector index references that property, the vector is restored from USearch to the property store. (Edges have no analogous label-removal — only `DROP VECTOR INDEX` triggers the restore for edge vector indexes.) Plan accordingly when dropping indexes or changing labels on large datasets.
 </Callout>
 
 ## Example

--- a/pages/querying/vector-search.mdx
+++ b/pages/querying/vector-search.mdx
@@ -33,8 +33,7 @@ systems to find entities based on semantic similarity rather than exact matches.
 
 ## Create vector index 
 
-To run vector search, first create a vector index. The syntax differs for nodes and edges; the storage behavior is the same (single-store) for both.
-
+To run vector search, first create a vector index.
 ### Vector index on nodes
 
 Vector indexes on nodes are created with the `CREATE VECTOR INDEX` command. You need to:
@@ -260,8 +259,8 @@ DROP VECTOR INDEX vector_index_name;
 ```
 
 <Callout type="warning">
-**Drop cost (nodes and edges):** When you drop a vector index, Memgraph must move all vector data from USearch back into the property store. Every affected node's or edge's property is rewritten from a vector index ID to the full vector. This can be **slow** (one write per indexed entry) and **memory costly** (vectors are stored in the property store as 64-bit values, increasing property store size).
-The same effect occurs when you **remove a label** from a node that had a vector index on that label: if no other vector index references that property, the vector is restored from USearch to the property store. (Edges have no analogous label-removal — only `DROP VECTOR INDEX` triggers the restore for edge vector indexes.) Plan accordingly when dropping indexes or changing labels on large datasets.
+**Drop cost:** When you drop a vector index, Memgraph must move all vector data from USearch back into the property store. Every affected node's or edge's property is rewritten from a vector index ID to the full vector. This can be **slow** (one write per indexed entry) and **memory costly** (float components are stored in the property store at the precision set by `--storage-floating-point-resolution-bits`, default 64-bit, increasing property store size).
+The same effect occurs when you **remove a label** from a node that had a vector index on that label: if no other vector index references that property, the vector is restored from USearch to the property store. Plan accordingly when dropping indexes or changing labels on large datasets.
 </Callout>
 
 ## Example


### PR DESCRIPTION
### Release note

Vector edge indexes now use the same single-store pattern as node indexe. Drops the dual-store framing for edges, unifies the intro, and extends the DROP-cost warning to cover both nodes and edges.

### Related product PRs

PRs from product repo this doc page is related to: 
https://github.com/memgraph/memgraph/pull/3929

### Checklist:

- [x] Add appropriate milestone (current release cycle)
- [x] Add `bugfix` or `feature` label, based on the product PR type you're documenting
- [x] Make sure all relevant tech details are documented
    - [x] Update reference pages (e.g. [clauses](https://memgraph.com/docs/querying/clauses), [functions](https://memgraph.com/docs/querying/functions), [flags](https://memgraph.com/docs/database-management/configuration#list-of-configuration-flags), [experimental](https://memgraph.com/docs/database-management/experimental-features), [monitoring](https://memgraph.com/docs/database-management/monitoring), [Cypher differences](https://memgraph.com/docs/querying/differences-in-cypher-implementations))
    - [x] Search for the feature you are working on (mentions) and make updates if needed
    - [x] Provide a basic example of usage
    - [x] In case your feature is an Enterprise one, list it under [ME page](https://memgraph.com/docs/database-management/enabling-memgraph-enterprise) and mark its page with Enterprise ([example](https://memgraph.com/docs/database-management/authentication-and-authorization/role-based-access-control)).
- [x] Check all content with Grammarly
- [x] Perform a self-review of my code
- [x] The build passes locally
- [x] My changes generate no new warnings or errors