### PR TITLE
Allow parametrized config docs

### DIFF
--- a/pages/querying/vector-search.mdx
+++ b/pages/querying/vector-search.mdx
@@ -105,6 +105,26 @@ CREATE VECTOR INDEX idx ON :Label(embedding) WITH CONFIG vector_index_config.con
 
 The function is evaluated at index-creation time. Both the node and edge index variants support this syntax.
 
+### Using parameters for configuration
+
+The `WITH CONFIG` map accepts query parameters, both for the whole map and for individual values. This lets a client supply the configuration at query time without rebuilding the Cypher string.
+
+Pass the entire config as a parameter:
+
+```cypher
+CREATE VECTOR INDEX idx ON :Label(embedding) WITH CONFIG $config;
+```
+
+with `$config` bound by the client to a map such as `{dimension: 128, capacity: 1000, metric: "cos"}`.
+
+Or parameterize individual values:
+
+```cypher
+CREATE VECTOR INDEX idx ON :Label(embedding) WITH CONFIG {"dimension": $dim, "capacity": $cap};
+```
+
+Both forms work for `CREATE VECTOR INDEX` and `CREATE VECTOR EDGE INDEX`.
+
 ## Run vector search
 
 To run vector search, call the `vector_search` query module: use `vector_search.search()` for a vector index on nodes and `vector_search.search_edges()` for a vector index on edges.

--- a/pages/querying/vector-search.mdx
+++ b/pages/querying/vector-search.mdx
@@ -73,6 +73,27 @@ The following options apply to both single-store vector indexes (nodes) and vect
 If resizing fails due to memory limitations, an exception will be thrown. Default value is `2`.
 - `scalar_kind: string (default=f32)` ➡ The [scalar kind](#scalar-kind) used to store each vector component. Smaller types reduce memory usage but may decrease precision.
 
+
+### Using parameters for configuration
+
+The `WITH CONFIG` map accepts query parameters, both for the whole map and for individual values. This lets a client supply the configuration at query time without rebuilding the Cypher string.
+
+Pass the entire config as a parameter:
+
+```cypher
+CREATE VECTOR INDEX idx ON :Label(embedding) WITH CONFIG $config;
+```
+
+with `$config` bound by the client to a map such as `{dimension: 128, capacity: 1000, metric: "cos"}`.
+
+Or parameterize individual values:
+
+```cypher
+CREATE VECTOR INDEX idx ON :Label(embedding) WITH CONFIG {"dimension": $dim, "capacity": $cap};
+```
+
+Both forms work for `CREATE VECTOR INDEX` and `CREATE VECTOR EDGE INDEX`.
+
 ### Using a function for configuration
 
 Instead of a static map literal, you can pass a **query module function** that returns the configuration map. This lets you centralize index configurations and reuse them across queries.
@@ -104,26 +125,6 @@ CREATE VECTOR INDEX idx ON :Label(embedding) WITH CONFIG vector_index_config.con
 ```
 
 The function is evaluated at index-creation time. Both the node and edge index variants support this syntax.
-
-### Using parameters for configuration
-
-The `WITH CONFIG` map accepts query parameters, both for the whole map and for individual values. This lets a client supply the configuration at query time without rebuilding the Cypher string.
-
-Pass the entire config as a parameter:
-
-```cypher
-CREATE VECTOR INDEX idx ON :Label(embedding) WITH CONFIG $config;
-```
-
-with `$config` bound by the client to a map such as `{dimension: 128, capacity: 1000, metric: "cos"}`.
-
-Or parameterize individual values:
-
-```cypher
-CREATE VECTOR INDEX idx ON :Label(embedding) WITH CONFIG {"dimension": $dim, "capacity": $cap};
-```
-
-Both forms work for `CREATE VECTOR INDEX` and `CREATE VECTOR EDGE INDEX`.
 
 ## Run vector search
 


### PR DESCRIPTION
### Release note
Vector index creation now accepts the whole config map as a query parameter (`WITH CONFIG $config`) or individual values (`WITH CONFIG {"dimension": $dim, "capacity": $cap}`), for both `CREATE VECTOR INDEX` and `CREATE VECTOR EDGE INDEX`.

### Related product PRs

PRs from product repo this doc page is related to: 
https://github.com/memgraph/memgraph/pull/3959

### Checklist:

- [ ] Add appropriate milestone (current release cycle)
- [ ] Add `bugfix` or `feature` label, based on the product PR type you're documenting
- [ ] Make sure all relevant tech details are documented
    - [ ] Update reference pages (e.g. [clauses](https://memgraph.com/docs/querying/clauses), [functions](https://memgraph.com/docs/querying/functions), [flags](https://memgraph.com/docs/database-management/configuration#list-of-configuration-flags), [experimental](https://memgraph.com/docs/database-management/experimental-features), [monitoring](https://memgraph.com/docs/database-management/monitoring), [Cypher differences](https://memgraph.com/docs/querying/differences-in-cypher-implementations))
    - [ ] Search for the feature you are working on (mentions) and make updates if needed
    - [ ] Provide a basic example of usage
    - [ ] In case your feature is an Enterprise one, list it under [ME page](https://memgraph.com/docs/database-management/enabling-memgraph-enterprise) and mark its page with Enterprise ([example](https://memgraph.com/docs/database-management/authentication-and-authorization/role-based-access-control)).
- [ ] Check all content with Grammarly
- [ ] Perform a self-review of my code
- [ ] The build passes locally
- [ ] My changes generate no new warnings or errors