### PR TITLE
Add config argument to `schema.node_type_properties` and `schema.rel_type_properties`

### DIFF
--- a/pages/advanced-algorithms/available-algorithms.mdx
+++ b/pages/advanced-algorithms/available-algorithms.mdx
@@ -158,6 +158,8 @@ This table shows the mapping between APOC functions/procedures and their Memgrap
 | apoc.map.removeKeys | Removes specified keys from a map | [map.remove_keys()](/advanced-algorithms/available-algorithms/map#remove_keys) |
 | apoc.map.merge | Merges multiple maps into one | [map.merge()](/advanced-algorithms/available-algorithms/map#merge) |
 | apoc.map.fromLists | Creates a map from two lists (keys and values) | [map.from_lists()](/advanced-algorithms/available-algorithms/map#from_lists) |
+| apoc.meta.nodeTypeProperties | Returns schema information about nodes and their properties | [schema.node_type_properties()](/querying/schema#node_type_properties) |
+| apoc.meta.relTypeProperties | Returns schema information about relationships and their properties | [schema.rel_type_properties()](/querying/schema#rel_type_properties) |
 | apoc.refactor.from | Redirects relationship to use a new start node | [refactor.from()](/advanced-algorithms/available-algorithms/refactor#from) |
 | apoc.refactor.to | Redirects relationship to use a new end node | [refactor.to()](/advanced-algorithms/available-algorithms/refactor#to) |
 | apoc.refactor.rename.label | Renames a label from old to new for all nodes | [refactor.rename_label()](/advanced-algorithms/available-algorithms/refactor#rename_label) |
@@ -181,3 +183,4 @@ This table shows the mapping between APOC functions/procedures and their Memgrap
 | apoc.text.regReplace | Replaces substrings matching regex with replacement | [text.regReplace()](/advanced-algorithms/available-algorithms/text#regreplace) |
 | apoc.util.md5 | Gets MD5 hash of concatenated string representations | [util_module.md5()](/advanced-algorithms/available-algorithms/util_module#md5) |
 | apoc.util.validatePredicate | Raises exception if predicate yields true with parameter interpolation | [mgps.validate_predicate()](/advanced-algorithms/available-algorithms/mgps#validate_predicate) |
+| apoc.version | Returns the Memgraph server version string | [mgps.version()](/advanced-algorithms/available-algorithms/mgps#version) |

--- a/pages/advanced-algorithms/available-algorithms/mgps.mdx
+++ b/pages/advanced-algorithms/available-algorithms/mgps.mdx
@@ -62,3 +62,22 @@ MATCH (n:User)
 WHERE mgps.validate_predicate(n.age < 0, "Invalid age: %i", [n.age])
 RETURN n;
 ```
+
+### `version()`
+
+Returns the Memgraph server version as a string. Provided as the Memgraph
+equivalent of `apoc.version` for compatibility with Neo4j-style clients.
+
+<Callout type="info">
+This function is equivalent to **apoc.version**.
+</Callout>
+
+{<h4 className="custom-header"> Output: </h4>}
+
+- `version: string` ➡ The Memgraph server version.
+
+{<h4 className="custom-header"> Usage: </h4>}
+
+```cypher
+RETURN mgps.version();
+```

--- a/pages/querying/schema.mdx
+++ b/pages/querying/schema.mdx
@@ -350,6 +350,28 @@ You can execute these procedures on [graph projections, subgraphs or portions of
 
 The `schema.node_type_properties()` procedure returns schema information about nodes and their properties in the graph.
 
+This procedure is also exposed as `apoc.meta.nodeTypeProperties` and
+`db.schema.nodeTypeProperties` for compatibility with Neo4j-style clients
+(such as the Neo4j ODBC BI Connector).
+
+{<h3 className="custom-header"> Input: </h3>}
+
+- `config: Map` (optional, default `{}`) ➡ A map of options that filter which
+  nodes are scanned and how the result is computed. Supported keys:
+  - `includeLabels: List[string]` ➡ Only nodes that have at least one of these
+    labels are included.
+  - `excludeLabels: List[string]` ➡ Nodes that have any of these labels are
+    skipped.
+  - `includeRels: List[string]` ➡ Only nodes that have at least one outgoing
+    relationship of one of these types are included.
+  - `excludeRels: List[string]` ➡ Nodes that have any outgoing relationship of
+    one of these types are skipped.
+  - `sample: integer` (default `1000`) ➡ Number of matching nodes per node type
+    to scan. Use `-1` to scan every node (full scan).
+  - `maxRels: integer` (default `100`) ➡ Maximum number of outgoing
+    relationships per node to inspect when applying `includeRels` /
+    `excludeRels` filters.
+
 {<h3 className="custom-header"> Output: </h3>}
 
 - `nodeType: string` ➡ Concatenated node labels separated by a `:`.
@@ -367,9 +389,36 @@ CALL schema.node_type_properties()
 YIELD nodeType, nodeLabels, mandatory, propertyName, propertyTypes;
 ```
 
+To restrict the scan to a subset of labels, pass a `config` map:
+
+```cypher
+CALL schema.node_type_properties({includeLabels: ["Dog"]})
+YIELD nodeType, nodeLabels, mandatory, propertyName, propertyTypes;
+```
+
 ### rel_type_properties()
 
 This `schema.rel_type_properties()` procedure returns schema information about relationships and their properties in the graph.
+
+This procedure is also exposed as `apoc.meta.relTypeProperties` and
+`db.schema.relTypeProperties` for compatibility with Neo4j-style clients
+(such as the Neo4j ODBC BI Connector).
+
+{<h3 className="custom-header"> Input: </h3>}
+
+- `config: Map` (optional, default `{}`) ➡ A map of options that filter which
+  relationships are scanned. Supported keys:
+  - `includeLabels: List[string]` ➡ Only relationships whose source node has
+    at least one of these labels are included.
+  - `excludeLabels: List[string]` ➡ Relationships whose source node has any
+    of these labels are skipped.
+  - `includeRels: List[string]` ➡ Only relationships of these types are
+    included.
+  - `excludeRels: List[string]` ➡ Relationships of these types are skipped.
+  - `sample: integer` (default `1000`) ➡ Number of source nodes to sample.
+    Use `-1` to scan every node (full scan).
+  - `maxRels: integer` (default `100`) ➡ Maximum number of outgoing
+    relationships per sampled source node to inspect.
 
 {<h3 className="custom-header"> Output: </h3>}
 
@@ -385,6 +434,13 @@ To get the information about relationships and properties, run the following que
 
 ```cypher
 CALL schema.rel_type_properties()
+YIELD relType, mandatory, propertyName, propertyTypes;
+```
+
+To restrict the scan to a subset of relationship types, pass a `config` map:
+
+```cypher
+CALL schema.rel_type_properties({includeRels: ["LOVES"]})
 YIELD relType, mandatory, propertyName, propertyTypes;
 ```
 


### PR DESCRIPTION
### Release note

Add node_type_properties and rel_type_properties config argument to match Neo4j specification.
Also, add apoc.version mapping.

The change is necessary for compatibility in the Neo4j ODBC BI connector.

### Related product PRs

PRs from product repo this doc page is related to: 
https://github.com/memgraph/memgraph/pull/4000

### Checklist:

- [x] Add appropriate milestone (current release cycle)
- [x] Add `bugfix` or `feature` label, based on the product PR type you're documenting
- [x] Make sure all relevant tech details are documented
    - [x] Update reference pages (e.g. [clauses](https://memgraph.com/docs/querying/clauses), [functions](https://memgraph.com/docs/querying/functions), [flags](https://memgraph.com/docs/database-management/configuration#list-of-configuration-flags), [experimental](https://memgraph.com/docs/database-management/experimental-features), [monitoring](https://memgraph.com/docs/database-management/monitoring), [Cypher differences](https://memgraph.com/docs/querying/differences-in-cypher-implementations))
    - [x] Search for the feature you are working on (mentions) and make updates if needed
    - [x] Provide a basic example of usage
    - [x] In case your feature is an Enterprise one, list it under [ME page](https://memgraph.com/docs/database-management/enabling-memgraph-enterprise) and mark its page with Enterprise ([example](https://memgraph.com/docs/database-management/authentication-and-authorization/role-based-access-control)).
- [x] Check all content with Grammarly
- [x] Perform a self-review of my code
- [x] The build passes locally
- [x] My changes generate no new warnings or errors