### PR TITLE
Add `where` after `yield` syntax

### DIFF
--- a/pages/advanced-algorithms/run-algorithms.mdx
+++ b/pages/advanced-algorithms/run-algorithms.mdx
@@ -70,6 +70,17 @@ using the `AS` sub-clause:
 ```cypher
 MATCH (result) CALL module.procedure(42) YIELD result AS procedure_result RETURN *;
 ```
+
+### Filtering YIELD results with WHERE
+
+The `YIELD` clause can be followed directly by a `WHERE` clause to filter
+the records returned by the procedure inline, without wrapping the call in
+a separate `WITH … WHERE` step:
+
+```cypher
+CALL mg.procedures() YIELD * WHERE name = 'mg.procedures' RETURN name;
+```
+
 ## Managing query modules from Memgraph Lab
 
 You can inspect query modules in [Memgraph Lab](/memgraph-lab/features/query-modules) (v2.0 and

--- a/pages/custom-query-modules/manage-query-modules.mdx
+++ b/pages/custom-query-modules/manage-query-modules.mdx
@@ -344,6 +344,16 @@ using the `AS` sub-clause:
 MATCH (result) CALL module.procedure(42) YIELD result AS procedure_result RETURN *;
 ```
 
+### Filtering YIELD results with WHERE
+
+The `YIELD` clause can be followed directly by a `WHERE` clause to filter
+the records returned by the procedure inline, without wrapping the call in
+a separate `WITH … WHERE` step:
+
+```cypher
+CALL mg.procedures() YIELD * WHERE name = 'mg.procedures' RETURN name;
+```
+
 ### Mapping custom procedure names to existing query procedures
 
 If you want to replace procedure names your application calls without changing


### PR DESCRIPTION
### Release note

Implement `WHERE` after `YIELD` syntax.

Example:
```
CALL mg.procedures() YIELD * WHERE name = 'mg.procedures'
RETURN name
```

### Related product PRs

PRs from product repo this doc page is related to: 
https://github.com/memgraph/memgraph/pull/4010

### Checklist:

- [x] Add appropriate milestone (current release cycle)
- [x] Add `bugfix` or `feature` label, based on the product PR type you're documenting
- [x] Make sure all relevant tech details are documented
    - [x] Update reference pages (e.g. [clauses](https://memgraph.com/docs/querying/clauses), [functions](https://memgraph.com/docs/querying/functions), [flags](https://memgraph.com/docs/database-management/configuration#list-of-configuration-flags), [experimental](https://memgraph.com/docs/database-management/experimental-features), [monitoring](https://memgraph.com/docs/database-management/monitoring), [Cypher differences](https://memgraph.com/docs/querying/differences-in-cypher-implementations))
    - [x] Search for the feature you are working on (mentions) and make updates if needed
    - [x] Provide a basic example of usage
    - [x] In case your feature is an Enterprise one, list it under [ME page](https://memgraph.com/docs/database-management/enabling-memgraph-enterprise) and mark its page with Enterprise ([example](https://memgraph.com/docs/database-management/authentication-and-authorization/role-based-access-control)).
- [x] Check all content with Grammarly
- [x] Perform a self-review of my code
- [x] The build passes locally
- [x] My changes generate no new warnings or errors