### PR TITLE
Add `SHOW QUERY CALLABLE MAPPINGS`

### DIFF
--- a/pages/advanced-algorithms/available-algorithms.mdx
+++ b/pages/advanced-algorithms/available-algorithms.mdx
@@ -132,9 +132,13 @@ If you want to know more and learn how this affects you, read our [announcement]
 
 ## APOC mappings
 
-These aliases serve as a drop-in replacement for APOC and GDS queries, so you can migrate from Neo4j to Memgraph without changing your application code.
+When switching from Neo4j to Memgraph, application code that calls `apoc.*` or `gds.*`
+procedures and functions would otherwise break, since Memgraph exposes the same
+functionality under different names. The aliases below serve as a drop-in replacement for
+those APOC and GDS calls, so you can migrate without changing your application code.
 
-This table shows the mapping between APOC functions/procedures and their Memgraph equivalents. Use these mappings if you're familiar with Neo4j's APOC library.
+This table shows the mapping between APOC functions/procedures and their Memgraph equivalents.
+Use these mappings if you're familiar with Neo4j's APOC library.
 
 ### Inspecting configured mappings
 

--- a/pages/advanced-algorithms/available-algorithms.mdx
+++ b/pages/advanced-algorithms/available-algorithms.mdx
@@ -132,6 +132,8 @@ If you want to know more and learn how this affects you, read our [announcement]
 
 ## APOC mappings
 
+These aliases serve as a drop-in replacement for APOC and GDS queries, so you can migrate from Neo4j to Memgraph without changing your application code.
+
 This table shows the mapping between APOC functions/procedures and their Memgraph equivalents. Use these mappings if you're familiar with Neo4j's APOC library.
 
 ### Inspecting configured mappings

--- a/pages/advanced-algorithms/available-algorithms.mdx
+++ b/pages/advanced-algorithms/available-algorithms.mdx
@@ -134,6 +134,27 @@ If you want to know more and learn how this affects you, read our [announcement]
 
 This table shows the mapping between APOC functions/procedures and their Memgraph equivalents. Use these mappings if you're familiar with Neo4j's APOC library.
 
+### Inspecting configured mappings
+
+Memgraph loads callable aliases from the JSON file pointed to by the
+[`--query-callable-mappings-path`](/database-management/configuration) flag.
+To list every alias currently registered (including any custom mappings you
+add to that file), run:
+
+```cypher
+SHOW QUERY CALLABLE MAPPINGS;
+```
+
+The query returns three columns:
+
+- `alias_name: string` ➡ The name clients call (for example, `apoc.version`).
+- `source_name: string` ➡ The underlying Memgraph procedure or function the
+  alias resolves to (for example, `mgps.version`).
+- `type: string` ➡ Either `procedure`, `function`, or `unknown` if the source
+  cannot be resolved.
+
+Running `SHOW QUERY CALLABLE MAPPINGS` requires the `CONFIG` privilege.
+
 | APOC | Description | Memgraph equivalent |
 |-------------------------|-------------|---------------------|
 | apoc.coll.union | Unites two lists into one, eliminating duplicates | [collections.union()](/advanced-algorithms/available-algorithms/collections#union) |


### PR DESCRIPTION
### Release note

`SHOW QUERY CALLABLE MAPPINGS` feature added.

Columns:
1. alias_name -> string
2. source_name -> string - original query procedure / function
3. type -> string - "procedure" / "function"

### Related product PRs

PRs from product repo this doc page is related to: 
https://github.com/memgraph/memgraph/pull/4014

### Checklist:

- [x] Add appropriate milestone (current release cycle)
- [x] Add `bugfix` or `feature` label, based on the product PR type you're documenting
- [x] Make sure all relevant tech details are documented
    - [x] Update reference pages (e.g. [clauses](https://memgraph.com/docs/querying/clauses), [functions](https://memgraph.com/docs/querying/functions), [flags](https://memgraph.com/docs/database-management/configuration#list-of-configuration-flags), [experimental](https://memgraph.com/docs/database-management/experimental-features), [monitoring](https://memgraph.com/docs/database-management/monitoring), [Cypher differences](https://memgraph.com/docs/querying/differences-in-cypher-implementations))
    - [x] Search for the feature you are working on (mentions) and make updates if needed
    - [x] Provide a basic example of usage
    - [x] In case your feature is an Enterprise one, list it under [ME page](https://memgraph.com/docs/database-management/enabling-memgraph-enterprise) and mark its page with Enterprise ([example](https://memgraph.com/docs/database-management/authentication-and-authorization/role-based-access-control)).
- [x] Check all content with Grammarly
- [x] Perform a self-review of my code
- [x] The build passes locally
- [x] My changes generate no new warnings or errors