### PR TITLE
feat: Add support for annotations in internal services

### DIFF
--- a/pages/clustering/high-availability/setup-ha-cluster-k8s.mdx
+++ b/pages/clustering/high-availability/setup-ha-cluster-k8s.mdx
@@ -326,6 +326,29 @@ In this example, each data instance's external Service gets the shared
 hostname. Bolt and management ports are not set per-instance — they come from
 `ports.boltPort` and `ports.managementPort`.
 
+{<h4 className="custom-header"> Per-instance internal access annotations </h4>}
+
+Each data instance and coordinator also has an internal ClusterIP Service used
+for in-cluster communication. You can set per-instance annotations on these
+internal Services using the `internalAccessAnnotations` field on individual
+entries in `data[]` or `coordinators[]`. This is useful for integrations or other tooling that consumes annotations on the internal
+Services.
+
+```yaml
+data:
+  - id: "0"
+    internalAccessAnnotations:
+      mycompany.io/service-mesh: "enabled"
+  - id: "1"
+    internalAccessAnnotations:
+      mycompany.io/service-mesh: "enabled"
+
+coordinators:
+  - id: "1"
+    internalAccessAnnotations:
+      mycompany.io/service-mesh: "enabled"
+```
+
 ### Node affinity
 
 Memgraph HA deploys multiple pods, and you can control pod placement with
@@ -1128,6 +1151,7 @@ following parameters:
 | Parameter                                   | Description                                                                                         | Default                                 |
 |---------------------------------------------|-----------------------------------------------------------------------------------------------------|-----------------------------------------|
 | `id`                                        | ID of the instance                                                                                  | `0` for data, `1` for coordinators      |
+| `internalAccessAnnotations`                 | Per-instance annotations for the internal ClusterIP Service.                                        | `{}`                                    |
 | `externalAccessAnnotations`                 | Per-instance annotations for the external access Service, merged with global annotations.           | `{}`                                    |
 | `args`                                      | Per-instance Memgraph CLI flags. Append-only — see the note below for flags the chart manages.       | `["--storage-snapshot-on-exit=false"]` for data, `[]` for coordinators |
 


### PR DESCRIPTION
### Release note

Added docs describing the support for internal services' annotations in Memgraph HA helm chart.

### Related product PRs

PRs from product repo this doc page is related to: 
https://github.com/memgraph/helm-charts/pull/235

### Checklist:

- [x] Add appropriate milestone (current release cycle)
- [x] Add `bugfix` or `feature` label, based on the product PR type you're documenting
- [x] Make sure all relevant tech details are documented
    - [x] Update reference pages (e.g. [clauses](https://memgraph.com/docs/querying/clauses), [functions](https://memgraph.com/docs/querying/functions), [flags](https://memgraph.com/docs/database-management/configuration#list-of-configuration-flags), [experimental](https://memgraph.com/docs/database-management/experimental-features), [monitoring](https://memgraph.com/docs/database-management/monitoring), [Cypher differences](https://memgraph.com/docs/querying/differences-in-cypher-implementations))
    - [x] Search for the feature you are working on (mentions) and make updates if needed
    - [x] Provide a basic example of usage
    - [x] In case your feature is an Enterprise one, list it under [ME page](https://memgraph.com/docs/database-management/enabling-memgraph-enterprise) and mark its page with Enterprise ([example](https://memgraph.com/docs/database-management/authentication-and-authorization/role-based-access-control)).
- [x] Check all content with Grammarly
- [x] Perform a self-review of my code
- [x] The build passes locally
- [x] My changes generate no new warnings or errors