### PR TITLE
fix: out of date monitoring metrics

### DIFF
--- a/pages/database-management/monitoring.mdx
+++ b/pages/database-management/monitoring.mdx
@@ -268,17 +268,45 @@ three different types:
 
 #### Index metrics
 
- | Name                       | Type    | Description                                            |
- | -------------------------- | ------- | ------------------------------------------------------ |
- | ActiveLabelIndices         | Counter | Number of active label indexes in the system.          |
- | ActiveLabelPropertyIndices | Counter | Number of active label property indexes in the system. |
- | ActivePointIndices         | Counter | Number of active point indices in the system.          |
- | ActiveTextIndices          | Counter | Number of active text indexes in the system.           |
+ | Name                          | Type    | Description                                                  |
+ | ----------------------------- | ------- | ------------------------------------------------------------ |
+ | ActiveLabelIndices            | Counter | Number of active label indexes in the system.                |
+ | ActiveLabelPropertyIndices    | Counter | Number of active label property indexes in the system.       |
+ | ActiveEdgeTypeIndices         | Counter | Number of active edge-type indices in the system.            |
+ | ActiveEdgeTypePropertyIndices | Counter | Number of active edge-type property indices in the system.   |
+ | ActiveEdgePropertyIndices     | Counter | Number of active edge property indices in the system.        |
+ | ActivePointIndices            | Counter | Number of active point indices in the system.                |
+ | ActiveTextIndices             | Counter | Number of active text indices in the system.                 |
+ | ActiveTextEdgeIndices         | Counter | Number of active text edge indices in the system.            |
+ | ActiveVectorIndices           | Counter | Number of active vector indices in the system.               |
+ | ActiveVectorEdgeIndices       | Counter | Number of active vector edge indices in the system.          |
+
+#### Constraint metrics
+
+ | Name                        | Type    | Description                                          |
+ | --------------------------- | ------- | ---------------------------------------------------- |
+ | ActiveExistenceConstraints  | Counter | Number of active existence constraints in the system. |
+ | ActiveUniqueConstraints     | Counter | Number of active unique constraints in the system.    |
+ | ActiveTypeConstraints       | Counter | Number of active type constraints in the system.      |
+
+#### Schema info metrics
+
+ | Name       | Type    | Description                                            |
+ | ---------- | ------- | ------------------------------------------------------ |
+ | ShowSchema | Counter | Number of times the user called `SHOW SCHEMA INFO`.    |
+
+#### Storage info metrics
+
+ | Name                      | Type    | Description                                                        |
+ | ------------------------- | ------- | ------------------------------------------------------------------ |
+ | ShowStorageInfoOnDatabase | Counter | Number of times the user called `SHOW STORAGE INFO ON DATABASE`.   |
 
 #### Memory metrics
 
  | Name                            | Type      | Description                                                        |
  | ------------------------------- | --------- | -------------------------------------------------------------------|
+ | UnreleasedDeltaObjects          | Counter   | Total number of unreleased delta objects in memory.                |
+ | PeakMemoryRes                   | Gauge     | Peak resident memory in the system.                                |
  | GCLatency_us_50p                | Histogram | GC total cleanup time in microseconds (50th percentile).           |
  | GCLatency_us_90p                | Histogram | GC total cleanup time in microseconds (90th percentile).           |
  | GCLatency_us_99p                | Histogram | GC total cleanup time in microseconds (99th percentile).           |
@@ -331,13 +359,19 @@ and describes a particular operation.
  | ForeachOperator                        | Counter | Number of times Foreach operator was used.                          |
  | EvaluatePatternFilterOperator          | Counter | Number of times EvaluatePatternFilter operator was used.            |
  | ApplyOperator                          | Counter | Number of times Apply operator was used.                            |
- | HashJoin                               | Counter | Number of times HashJoin operator was used.                         |
- | IndexedJoin                            | Counter | Number of times IndexedJoin operator was used.                      |
- | PeriodicCommit                         | Counter | Number of times PeriodicCommit operator was used.                   |
- | PeriodicSubquery                       | Counter | Number of times PeriodicSubquery operator was used.                 |
+ | HashJoinOperator                       | Counter | Number of times HashJoin operator was used.                         |
+ | IndexedJoinOperator                    | Counter | Number of times IndexedJoin operator was used.                      |
+ | PeriodicCommitOperator                 | Counter | Number of times PeriodicCommit operator was used.                   |
+ | PeriodicSubqueryOperator               | Counter | Number of times PeriodicSubquery operator was used.                 |
  | RollUpApplyOperator                    | Counter | Number of times RollUpApply operator was used.                      |
+ | RemoveNestedPropertyOperator           | Counter | Number of times RemoveNestedProperty operator was used.             |
+ | SetNestedPropertyOperator              | Counter | Number of times SetNestedProperty operator was used.                |
+ | ScanAllByIdOperator                    | Counter | Number of times ScanAllById operator was used.                      |
  | ScanAllByEdgeIdOperator                | Counter | Number of times ScanAllByEdgeId operator was used.                  |
  | ScanAllByEdgeOperator                  | Counter | Number of times ScanAllByEdge operator was used.                    |
+ | ScanAllByEdgePropertyOperator          | Counter | Number of times ScanAllByEdgeProperty operator was used.            |
+ | ScanAllByEdgePropertyRangeOperator     | Counter | Number of times ScanAllByEdgePropertyRange operator was used.       |
+ | ScanAllByEdgePropertyValueOperator     | Counter | Number of times ScanAllByEdgePropertyValue operator was used.       |
  | ScanAllByEdgeTypeOperator              | Counter | Number of times ScanAllByEdgeType operator was used.                |
  | ScanAllByEdgeTypePropertyOperator      | Counter | Number of times ScanAllByEdgeTypeProperty operator was used.        |
  | ScanAllByEdgeTypePropertyRangeOperator | Counter | Number of times ScanAllByEdgeTypePropertyRange operator was used.   |
@@ -395,7 +429,7 @@ and describes a particular operation.
  | Name                   | Type    | Description                                                                                                               |
  | ---------------------- | ------- | --------------------------------------------------------------------------------------------------------------------------|
  | ActiveTransactions     | Counter | Number of active transactions.                                                                                            |
- | CommittedTransactions  | Counter | Number of committed transactions.                                                                                         |
+ | CommitedTransactions   | Counter | Number of committed transactions.                                                                                         |
  | RollbackedTransactions | Counter | Number of rollbacked transactions.                                                                                        |
  | FailedQuery            | Counter | Number of times executing a query failed (either during parse time or runtime).                                           |
  | FailedPrepare          | Counter | Number of times preparing a query failed.                                                                                 |
@@ -489,6 +523,9 @@ and describes a particular operation.
  | UnregisterReplicaRpc_us_50p       | Histogram | UnregisterReplicaRpc latency in microseconds (50th percentile).                                    |
  | UnregisterReplicaRpc_us_90p       | Histogram | UnregisterReplicaRpc latency in microseconds (90th percentile).                                    |
  | UnregisterReplicaRpc_us_99p       | Histogram | UnregisterReplicaRpc latency in microseconds (99th percentile).                                    |
+ | UpdateDataInstanceConfigRpc_us_50p | Histogram | UpdateDataInstanceConfigRpc latency in microseconds (50th percentile).                            |
+ | UpdateDataInstanceConfigRpc_us_90p | Histogram | UpdateDataInstanceConfigRpc latency in microseconds (90th percentile).                            |
+ | UpdateDataInstanceConfigRpc_us_99p | Histogram | UpdateDataInstanceConfigRpc latency in microseconds (99th percentile).                            |
  | BecomeLeaderSuccess               | Counter   | The number of times coordinators successfully became leaders.                                      |
  | FailedToBecomeLeader              | Counter   | The number of times coordinators failed to become leaders.                                         |
  | SuccessfulFailovers               | Counter   | The number of times failover was done successfully.                                                |
@@ -515,6 +552,8 @@ and describes a particular operation.
  | SwapMainUUIDRpcSuccess            | Counter   | The number of times coordinators received successful response to SwapMainUUIDRpc.                  |
  | GetDatabaseHistoriesRpcFail       | Counter   | The number of times coordinators received unsuccessful or no response to GetDatabaseHistoriesRpc.  |
  | GetDatabaseHistoriesRpcSuccess    | Counter   | The number of times coordinators received successful response to GetDatabaseHistoriesRpc.          |
+ | UpdateDataInstanceConfigRpcFail   | Counter   | The number of times coordinators received unsuccessful or no response to UpdateDataInstanceConfigRpc. |
+ | UpdateDataInstanceConfigRpcSuccess | Counter   | The number of times coordinators received successful response to UpdateDataInstanceConfigRpc.     |
  | ReplicaRecoverySuccess            | Counter   | The number of times the replica recovery process finished successfully.                            |
  | ReplicaRecoveryFail               | Counter   | The number of times the replica recovery process finished unsuccessfully.                          |
  | ReplicaRecoverySkip               | Counter   | The number of times the replica recovery task was skipped.                                         |

--- a/pages/database-management/monitoring.mdx
+++ b/pages/database-management/monitoring.mdx
@@ -270,8 +270,8 @@ three different types:
 
  | Name                          | Type    | Description                                                  |
  | ----------------------------- | ------- | ------------------------------------------------------------ |
- | ActiveLabelIndices            | Counter | Number of active label indexes in the system.                |
- | ActiveLabelPropertyIndices    | Counter | Number of active label property indexes in the system.       |
+ | ActiveLabelIndices            | Counter | Number of active label indices in the system.                |
+ | ActiveLabelPropertyIndices    | Counter | Number of active label property indices in the system.       |
  | ActiveEdgeTypeIndices         | Counter | Number of active edge-type indices in the system.            |
  | ActiveEdgeTypePropertyIndices | Counter | Number of active edge-type property indices in the system.   |
  | ActiveEdgePropertyIndices     | Counter | Number of active edge property indices in the system.        |


### PR DESCRIPTION
Monitoring metrics docs were out of date.

### Release note

Please briefly explain the changes you made which will be added to the changelog.

### Related product PRs

### Checklist:

- [x] Add appropriate milestone (current release cycle)
- [x] Add `bugfix` or `feature` label, based on the product PR type you're documenting
- [x] Make sure all relevant tech details are documented
    - [ ] Update reference pages (e.g. [clauses](https://memgraph.com/docs/querying/clauses), [functions](https://memgraph.com/docs/querying/functions), [flags](https://memgraph.com/docs/database-management/configuration#list-of-configuration-flags), [experimental](https://memgraph.com/docs/database-management/experimental-features), [monitoring](https://memgraph.com/docs/database-management/monitoring), [Cypher differences](https://memgraph.com/docs/querying/differences-in-cypher-implementations))
    - [ ] Search for the feature you are working on (mentions) and make updates if needed
    - [ ] Provide a basic example of usage
    - [ ] In case your feature is an Enterprise one, list it under [ME page](https://memgraph.com/docs/database-management/enabling-memgraph-enterprise) and mark its page with Enterprise ([example](https://memgraph.com/docs/database-management/authentication-and-authorization/role-based-access-control)).
- [x] Check all content with Grammarly
- [x] Perform a self-review of my code
- [x] The build passes locally
- [x] My changes generate no new warnings or errors