### PR TITLE
feat: document start_time and elapsed_ms columns in SHOW TRANSACTIONS

### DIFF
--- a/pages/fundamentals/transactions.mdx
+++ b/pages/fundamentals/transactions.mdx
@@ -92,7 +92,7 @@ SHOW TRANSACTIONS;
 ```
 
 Each row in the result represents one transaction (or one in-progress snapshot
-creation) and contains five columns:
+creation) and contains seven columns:
 
 | Column | Type | Description |
 |---|---|---|
@@ -101,15 +101,17 @@ creation) and contains five columns:
 | `query` | `List[String]` | Queries executed within the transaction so far. |
 | `status` | `String` | Lifecycle phase of the transaction: `running`, `committing`, or `aborting`. Snapshot rows always show `running`. |
 | `metadata` | `Map` | Metadata supplied by the client when the transaction was opened. For in-progress snapshots this contains progress details (see below). |
+| `start_time` | `ZonedDateTime` | UTC time at which the transaction started. |
+| `elapsed_ms` | `Integer` | How long the transaction has been running, in milliseconds. |
 
 ```copy=false
 memgraph> SHOW TRANSACTIONS;
-+----------+------------------------+-----------------------------------------------+--------------+----------+
-| username | transaction_id         | query                                         | status       | metadata |
-+----------+------------------------+-----------------------------------------------+--------------+----------+
-| ""       | "9223372036854794885"  | ["UNWIND range(1,100) AS i CREATE(:L{p:i});"] | "committing" | {}       |
-| ""       | "9223372036854794896"  | ["SHOW TRANSACTIONS"]                         | "running"    | {}       |
-+----------+------------------------+-----------------------------------------------+--------------+----------+
++----------+-----------------------+-----------------------------------------------+--------------+----------+-------------------------------+------------+
+| username | transaction_id        | query                                         | status       | metadata | start_time                    | elapsed_ms |
++----------+-----------------------+-----------------------------------------------+--------------+----------+-------------------------------+------------+
+| ""       | "9223372036854794885" | ["UNWIND range(1,100) AS i CREATE(:L{p:i});"] | "committing" | {}       | 2026-05-12T14:32:18.412Z[UTC] | 47         |
+| ""       | "9223372036854794896" | ["SHOW TRANSACTIONS"]                         | "running"    | {}       | 2026-05-12T14:32:18.451Z[UTC] | 8          |
++----------+-----------------------+-----------------------------------------------+--------------+----------+-------------------------------+------------+
 ```
 
 #### Filter by status
@@ -140,16 +142,18 @@ rows contains:
 | `phase` | Current phase of snapshot creation: `EDGES`, `VERTICES`, `INDICES`, `CONSTRAINTS`, or `FINALIZING`. |
 | `items_done` | Number of objects serialized in the current phase so far. |
 | `items_total` | Total number of objects expected in the current phase. |
-| `elapsed_ms` | Milliseconds elapsed since the snapshot started. |
 | `db_name` | Name of the database whose snapshot is being created. |
+
+The top-level `start_time` and `elapsed_ms` columns are populated for snapshot
+rows as well, reflecting when the snapshot started.
 
 ```copy=false
 memgraph> SHOW TRANSACTIONS;
-+----------+----------------+-----------------------------+-----------+------------------------------------------------------------------+
-| username | transaction_id | query                       | status    | metadata                                                         |
-+----------+----------------+-----------------------------+-----------+------------------------------------------------------------------+
-| ""       | "snapshot"     | ["CREATE SNAPSHOT"]         | "running" | {phase: "VERTICES", items_done: 142000, items_total: 500000, ... |
-+----------+----------------+-----------------------------+-----------+------------------------------------------------------------------+
++----------+----------------+---------------------+-----------+------------------------------------------------------------------+-------------------------------+------------+
+| username | transaction_id | query               | status    | metadata                                                         | start_time                    | elapsed_ms |
++----------+----------------+---------------------+-----------+------------------------------------------------------------------+-------------------------------+------------+
+| ""       | "snapshot"     | ["CREATE SNAPSHOT"] | "running" | {phase: "VERTICES", items_done: 142000, items_total: 500000, ... | 2026-05-12T14:32:17.205Z[UTC] | 1247       |
++----------+----------------+---------------------+-----------+------------------------------------------------------------------+-------------------------------+------------+
 ```
 
 <Callout type="info">
@@ -157,8 +161,9 @@ Snapshot progress values are read from independent atomic counters and are not
 captured as a single consistent snapshot. `items_done`, `items_total`, and
 `phase` may reflect slightly different points in time, so treat them as
 best-effort estimates rather than exact figures. In particular, `items_done`
-may briefly read as `0` when the phase transitions, and `elapsed_ms` may be
-absent if the snapshot started between the phase check and the time read.
+may briefly read as `0` when the phase transitions, and `start_time` may be
+`null` if the snapshot was observed in the brief window before it recorded
+its start.
 </Callout>
 
 <Callout type="warning">
@@ -289,12 +294,12 @@ currently being run as part of the transaction ID "9223372036854794885".
 
 ```copy=false
 memgraph> SHOW TRANSACTIONS;
-+----------+------------------------+-------------------------------------------+-----------+----------+
-| username | transaction_id         | query                                     | status    | metadata |
-+----------+------------------------+-------------------------------------------+-----------+----------+
-| ""       | "9223372036854794885"  | ["CALL infinite.get() YIELD * RETURN *;"] | "running" | {}       |
-| ""       | "9223372036854794896"  | ["SHOW TRANSACTIONS"]                     | "running" | {}       |
-+----------+------------------------+-------------------------------------------+-----------+----------+
++----------+-----------------------+-------------------------------------------+-----------+----------+-------------------------------+------------+
+| username | transaction_id        | query                                     | status    | metadata | start_time                    | elapsed_ms |
++----------+-----------------------+-------------------------------------------+-----------+----------+-------------------------------+------------+
+| ""       | "9223372036854794885" | ["CALL infinite.get() YIELD * RETURN *;"] | "running" | {}       | 2026-05-12T14:32:00.000Z[UTC] | 18230      |
+| ""       | "9223372036854794896" | ["SHOW TRANSACTIONS"]                     | "running" | {}       | 2026-05-12T14:32:18.230Z[UTC] | 0          |
++----------+-----------------------+-------------------------------------------+-----------+----------+-------------------------------+------------+
 ```
 
 To terminate the transaction, run the following query:


### PR DESCRIPTION
Add the two new columns to the schema table and example outputs, note that snapshot rows now populate them at the top level, and update the snapshot-progress callout to mention the brief window where start_time can read as null.

### Related product PRs

[PR4136](https://github.com/memgraph/memgraph/pull/4136)

### Checklist:

- [x] Add appropriate milestone (current release cycle)
- [x] Add `bugfix` or `feature` label, based on the product PR type you're documenting
- [x] Make sure all relevant tech details are documented
    - [ ] Update reference pages (e.g. [clauses](https://memgraph.com/docs/querying/clauses), [functions](https://memgraph.com/docs/querying/functions), [flags](https://memgraph.com/docs/database-management/configuration#list-of-configuration-flags), [experimental](https://memgraph.com/docs/database-management/experimental-features), [monitoring](https://memgraph.com/docs/database-management/monitoring), [Cypher differences](https://memgraph.com/docs/querying/differences-in-cypher-implementations))
    - [ ] Search for the feature you are working on (mentions) and make updates if needed
    - [ ] Provide a basic example of usage
    - [ ] In case your feature is an Enterprise one, list it under [ME page](https://memgraph.com/docs/database-management/enabling-memgraph-enterprise) and mark its page with Enterprise ([example](https://memgraph.com/docs/database-management/authentication-and-authorization/role-based-access-control)).
- [x] Check all content with Grammarly
- [x] Perform a self-review of my code
- [x] The build passes locally
- [x] My changes generate no new warnings or errors