### PR TITLE
fix: Expose only probes' timings

### DIFF
--- a/pages/clustering/high-availability/setup-ha-cluster-k8s.mdx
+++ b/pages/clustering/high-availability/setup-ha-cluster-k8s.mdx
@@ -649,6 +649,17 @@ Memgraph HA uses standard Kubernetes **startup**, **readiness**, and
 - **Coordinators**: probed on the **NuRaft server**
 - **Data instances**: probed on the **Bolt server**
 
+<Callout type="warning">
+**Breaking change (HA Helm chart 1.0.0)**: The probe target port is no longer configurable through
+`container.data.{readinessProbe,livenessProbe,startupProbe}.tcpSocket.port` or
+`container.coordinators.{readinessProbe,livenessProbe,startupProbe}.tcpSocket.port`.
+Probes are now hard-coded to a `tcpSocket` check against `ports.boltPort` for data
+instances and `ports.coordinatorPort` for coordinators. Only the probe timings
+(`failureThreshold`, `timeoutSeconds`, `periodSeconds`) remain configurable.
+Remove any `tcpSocket` overrides from your `values.yaml` and change the bolt or
+coordinator port via `ports.boltPort` / `ports.coordinatorPort` instead.
+</Callout>
+
 ## Debugging
 
 There are different ways in which you can debug Memgraph's HA cluster in
@@ -1042,28 +1053,22 @@ and their default values.
 | `affinity.dataNodeLabelValue`                              | Label value for data nodes                                                                                   | `data-node`                    |
 | `affinity.coordinatorNodeLabelValue`                       | Label value for coordinator nodes                                                                            | `coordinator-node`             |
 | `container.data.terminationGracePeriodSeconds`             | Grace period for data instance pod termination                                                               | `1800`                         |
-| `container.data.livenessProbe.tcpSocket.port`              | Port used for TCP connection. Should be the same as bolt port.                                               | `7687`                         |
 | `container.data.livenessProbe.failureThreshold`            | Failure threshold for liveness probe                                                                         | `20`                           |
 | `container.data.livenessProbe.timeoutSeconds`              | Timeout for liveness probe                                                                                   | `10`                           |
 | `container.data.livenessProbe.periodSeconds`               | Period seconds for liveness probe                                                                            | `5`                            |
-| `container.data.readinessProbe.tcpSocket.port`             | Port used for TCP connection. Should be the same as bolt port.                                               | `7687`                         |
 | `container.data.readinessProbe.failureThreshold`           | Failure threshold for readiness probe                                                                        | `20`                           |
 | `container.data.readinessProbe.timeoutSeconds`             | Timeout for readiness probe                                                                                  | `10`                           |
 | `container.data.readinessProbe.periodSeconds`              | Period seconds for readiness probe                                                                           | `5`                            |
-| `container.data.startupProbe.tcpSocket.port`               | Port used for TCP connection. Should be the same as bolt port.                                               | `7687`                         |
 | `container.data.startupProbe.failureThreshold`             | Failure threshold for startup probe                                                                          | `1440`                         |
 | `container.data.startupProbe.timeoutSeconds`               | Timeout for probe                                                                                            | `10`                           |
 | `container.data.startupProbe.periodSeconds`                | Period seconds for startup probe                                                                             | `10`                           |
 | `container.data.terminationGracePeriodSeconds`             | Grace period for data pod termination. Increase when `--storage-snapshot-on-exit` is enabled so the snapshot has time to finish. | `30`       |
-| `container.coordinators.livenessProbe.tcpSocket.port`      | Port used for TCP connection. Should be the same as coordinator port.                                        | `12000`                        |
 | `container.coordinators.livenessProbe.failureThreshold`    | Failure threshold for liveness probe                                                                         | `20`                           |
 | `container.coordinators.livenessProbe.timeoutSeconds`      | Timeout for liveness probe                                                                                   | `10`                           |
 | `container.coordinators.livenessProbe.periodSeconds`       | Period seconds for liveness probe                                                                            | `5`                            |
-| `container.coordinators.readinessProbe.tcpSocket.port`     | Port used for TCP connection. Should be the same as coordinator port.                                        | `12000`                        |
 | `container.coordinators.readinessProbe.failureThreshold`   | Failure threshold for readiness probe                                                                        | `20`                           |
 | `container.coordinators.readinessProbe.timeoutSeconds`     | Timeout for readiness probe                                                                                  | `10`                           |
 | `container.coordinators.readinessProbe.periodSeconds`      | Period seconds for readiness probe                                                                           | `5`                            |
-| `container.coordinators.startupProbe.tcpSocket.port`       | Port used for TCP connection. Should be the same as coordinator port.                                        | `12000`                        |
 | `container.coordinators.startupProbe.failureThreshold`     | Failure threshold for startup probe                                                                          | `20`                           |
 | `container.coordinators.startupProbe.timeoutSeconds`       | Timeout for probe                                                                                            | `10`                           |
 | `container.coordinators.startupProbe.periodSeconds`        | Period seconds for startup probe                                                                             | `10`                           |


### PR DESCRIPTION
### Release note

Users cannot change anymore probes' ports/

### Related product PRs

PRs from product repo this doc page is related to: 
https://github.com/memgraph/helm-charts/pull/239

### Checklist:

- [x] Add appropriate milestone (current release cycle)
- [x] Add `bugfix` or `feature` label, based on the product PR type you're documenting
- [x] Make sure all relevant tech details are documented
    - [x] Update reference pages (e.g. [clauses](https://memgraph.com/docs/querying/clauses), [functions](https://memgraph.com/docs/querying/functions), [flags](https://memgraph.com/docs/database-management/configuration#list-of-configuration-flags), [experimental](https://memgraph.com/docs/database-management/experimental-features), [monitoring](https://memgraph.com/docs/database-management/monitoring), [Cypher differences](https://memgraph.com/docs/querying/differences-in-cypher-implementations))
    - [x] Search for the feature you are working on (mentions) and make updates if needed
    - [x] Provide a basic example of usage
    - [x] In case your feature is an Enterprise one, list it under [ME page](https://memgraph.com/docs/database-management/enabling-memgraph-enterprise) and mark its page with Enterprise ([example](https://memgraph.com/docs/database-management/authentication-and-authorization/role-based-access-control)).
- [x] Check all content with Grammarly
- [x] Perform a self-review of my code
- [x] The build passes locally
- [x] My changes generate no new warnings or errors