### PR TITLE
Update baseline map count to 524k

### DIFF
--- a/pages/clustering/high-availability/setup-ha-cluster-k8s.mdx
+++ b/pages/clustering/high-availability/setup-ha-cluster-k8s.mdx
@@ -1076,7 +1076,7 @@ and their default values.
 | `data`                                                     | Configuration for data instances                                                                             | See `data` section             |
 | `coordinators`                                             | Configuration for coordinator instances                                                                      | See `coordinators` section     |
 | `sysctlInitContainer.enabled`                              | Enable the init container to set sysctl parameters                                                           | `true`                         |
-| `sysctlInitContainer.maxMapCount`                          | Value for `vm.max_map_count` to be set by the init container                                                 | `262144`                       |
+| `sysctlInitContainer.maxMapCount`                          | Value for `vm.max_map_count` to be set by the init container                                                 | `524288`                       |
 | `sysctlInitContainer.image.repository`                     | Image repository for the sysctl init container                                                               | `library/busybox`              |
 | `sysctlInitContainer.image.tag`                            | Image tag for the sysctl init container                                                                      | `latest`                       |
 | `sysctlInitContainer.image.pullPolicy`                     | Image pull policy for the sysctl init container                                                              | `IfNotPresent`                 |

--- a/pages/database-management/system-configuration.mdx
+++ b/pages/database-management/system-configuration.mdx
@@ -63,8 +63,7 @@ If you encounter `munmap` errors or crashes due to `bad_alloc` errors, you shoul
 
 | Amount of RAM | `vm.max_map_count` value |
 |---------------|-------------------------|
-| 8GB - 32GB    | `vm.max_map_count=262144`|
-| 32GB - 64GB   | `vm.max_map_count=524288`|
+| 8GB - 64GB    | `vm.max_map_count=524288`|
 | 64GB - 128GB  | `vm.max_map_count=1048576`|
 | 128GB - 256GB | `vm.max_map_count=2097152`|
 | 256GB - 512GB | `vm.max_map_count=4194304`|
@@ -78,9 +77,9 @@ If you encounter `munmap` errors or crashes due to `bad_alloc` errors, you shoul
 
 ### Immediate adjustment
 
-For instance, if your recommended `vm.max_map_count` value is `262144`, run
-`sudo sysctl -w vm.max_map_count=262144` to immediately increase the memory map
-area limit to 262,144. This change takes effect right away but lasts only until
+For instance, if your recommended `vm.max_map_count` value is `524288`, run
+`sudo sysctl -w vm.max_map_count=524288` to immediately increase the memory map
+area limit to 524,288. This change takes effect right away but lasts only until
 the next reboot.
 
 ### Persistent adjustment
@@ -90,7 +89,7 @@ To ensure that changes to `vm.max_map_count` persist after a reboot, follow thes
 <Steps>
 
 {<h3 className="custom-header">Edit `/etc/sysctl.conf`</h3>}
-Add `vm.max_map_count=262144` to
+Add `vm.max_map_count=524288` to
 `/etc/sysctl.conf`. Root privileges are required for editing.
 
 {<h3 className="custom-header">Apply the changes</h3>}
@@ -99,7 +98,7 @@ them right away.
 
 {<h3 className="custom-header">Verify the changes</h3>}
 Run `sysctl vm.max_map_count` to ensure the new
-value is in effect. It should return `262144`.
+value is in effect. It should return `524288`.
 
 </Steps>
 

--- a/pages/fundamentals/storage-memory-usage.mdx
+++ b/pages/fundamentals/storage-memory-usage.mdx
@@ -982,7 +982,7 @@ On Linux, you can increase the limits by running the following command as
 `root`:
 
 ```bash
-sysctl -w vm.max_map_count=262144
+sysctl -w vm.max_map_count=524288
 ```
 
 To increase this value permanently, update the `vm.max_map_count` setting in

--- a/pages/getting-started/install-memgraph/kubernetes.mdx
+++ b/pages/getting-started/install-memgraph/kubernetes.mdx
@@ -118,7 +118,7 @@ least once in 5 minutes for a pod to be considered ready.
 
 ### System configuration
 
-The Helm chart will set the linux kernel `vm.max_map_count` parameter to `262144` by default 
+The Helm chart will set the linux kernel `vm.max_map_count` parameter to `524288` by default 
 to ensure Memgraph won't run into issues with memory mapping. 
 
 <Callout type="info">

--- a/pages/memgraph-zero/memgql/connect/clickhouse.mdx
+++ b/pages/memgraph-zero/memgql/connect/clickhouse.mdx
@@ -20,7 +20,7 @@ docker run -d --rm \
     --network memgql-net \
     -p 9000:9000 \
     -p 8123:8123 \
-    --ulimit nofile=262144:262144 \
+    --ulimit nofile=524288:524288 \
     -e CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT=1 \
     -e CLICKHOUSE_PASSWORD="" \
     clickhouse/clickhouse-server:latest


### PR DESCRIPTION
### Release note

Minimum recommended max map count has been bumped to 524k as of v3.10

### Related product PRs

PRs from product repo this doc page is related to: 
(paste the links to the PRs)

### Checklist:

- [ ] Add appropriate milestone (current release cycle)
- [ ] Add `bugfix` or `feature` label, based on the product PR type you're documenting
- [ ] Make sure all relevant tech details are documented
    - [ ] Update reference pages (e.g. [clauses](https://memgraph.com/docs/querying/clauses), [functions](https://memgraph.com/docs/querying/functions), [flags](https://memgraph.com/docs/database-management/configuration#list-of-configuration-flags), [experimental](https://memgraph.com/docs/database-management/experimental-features), [monitoring](https://memgraph.com/docs/database-management/monitoring), [Cypher differences](https://memgraph.com/docs/querying/differences-in-cypher-implementations))
    - [ ] Search for the feature you are working on (mentions) and make updates if needed
    - [ ] Provide a basic example of usage
    - [ ] In case your feature is an Enterprise one, list it under [ME page](https://memgraph.com/docs/database-management/enabling-memgraph-enterprise) and mark its page with Enterprise ([example](https://memgraph.com/docs/database-management/authentication-and-authorization/role-based-access-control)).
- [ ] Check all content with Grammarly
- [ ] Perform a self-review of my code
- [ ] The build passes locally
- [ ] My changes generate no new warnings or errors