### PR TITLE
docs: add mgp_graph_get_start_timestamp / Graph.start_timestamp

### DIFF
--- a/pages/custom-query-modules/c/c-api.mdx
+++ b/pages/custom-query-modules/c/c-api.mdx
@@ -200,6 +200,7 @@ Memgraph in order to use them.
 | enum [mgp_error](#variable-mgp-error) | **[mgp_edge_iter_properties](#function-mgp-edge-iter-properties)**(struct mgp_edge * e, struct mgp_memory * memory, struct mgp_properties_iterator ** result)<br />Start iterating over properties stored in the given edge.  |
 | enum [mgp_error](#variable-mgp-error) | **[mgp_graph_get_vertex_by_id](#function-mgp-graph-get-vertex-by-id)**(struct mgp_graph * g, struct [mgp_vertex_id](#mgp_vertex_id) id, struct mgp_memory * memory, struct mgp_vertex ** result)<br />Get the vertex corresponding to given ID, or NULL if no such vertex exists.  |
 | enum [mgp_error](#variable-mgp-error) | **[mgp_graph_is_transactional](#function-mgp-graph-is-transactional)**(struct mgp_graph * graph, int * result)<br />Result is non-zero if the graph is in transactional storage mode.  |
+| enum [mgp_error](#variable-mgp-error) | **[mgp_graph_get_start_timestamp](#function-mgp-graph-get-start-timestamp)**(struct mgp_graph * graph, int64_t * result)<br />Return the transaction's starting timestamp; stays stable across `USING PERIODIC COMMIT` batches.  |
 | enum [mgp_error](#variable-mgp-error) | **[mgp_graph_has_text_index](#function-mgp-graph-has-text-index)**(struct mgp_graph * graph, const char * index_name, int * result)<br />(Experimental) Result is non-zero if there exists a text index with the given name. |
 | enum [mgp_error](#variable-mgp-error) | **[mgp_graph_search_text_index](#function-mgp-graph-search-text-index)**(struct mgp_graph * graph, const char * index_name, const char * search_query, enum text_search_mode search_mode, struct mgp_memory * memory, struct mgp_map ** result)<br />(Experimental) Search over the given text index. The result contains a list of all vertices matching the search query. |
 | enum [mgp_error](#variable-mgp-error) | **[mgp_graph_aggregate_over_text_index](#function-mgp-graph-aggregate-over-text-index)**(struct mgp_graph * graph, const char * index_name, const char * search_query, const char * aggregation_query, struct mgp_memory * memory, struct mgp_map ** result)<br />(Experimental) Aggregate over the results of a search over the named text index.  |
@@ -2492,6 +2493,19 @@ enum mgp_error mgp_graph_is_mutable(
 Result is non-zero if the graph can be modified.
 
 If a graph is immutable, then vertices cannot be created or deleted, and all of the returned vertices will be immutable also. The same applies for edges. Current implementation always returns without errors.
+
+
+### mgp_graph_get_start_timestamp [#function-mgp-graph-get-start-timestamp]
+```cpp
+enum mgp_error mgp_graph_get_start_timestamp(
+    struct mgp_graph * graph,
+    int64_t * result
+)
+```
+
+Return the transaction's starting timestamp. The value is assigned when the transaction begins and stays the same for the rest of the query, including when `USING PERIODIC COMMIT` rotates the underlying transaction between batches.
+
+Procedures can rely on it as a stable per-query identifier (for example, as a key in caches that span procedure calls). The current implementation always returns without errors.
 
 
 ### mgp_graph_has_text_index [#function-mgp-graph-has-text-index]
@@ -5042,6 +5056,8 @@ enum mgp_error mgp_graph_get_vertex_by_id(struct mgp_graph *g, struct mgp_vertex
                                           struct mgp_vertex **result);
 
 enum mgp_error mgp_graph_is_transactional(struct mgp_graph *graph, int *result);
+
+enum mgp_error mgp_graph_get_start_timestamp(struct mgp_graph *graph, int64_t *result);
 
 enum mgp_error mgp_graph_is_mutable(struct mgp_graph *graph, int *result);
 

--- a/pages/custom-query-modules/python/python-api.mdx
+++ b/pages/custom-query-modules/python/python-api.mdx
@@ -1458,6 +1458,27 @@ Check if the graph is mutable. Thus it can be used to modify vertices and edges.
 
   ```graph.is_mutable()```
 
+### start\_timestamp
+
+```python
+@property
+def start_timestamp() -> int
+```
+
+Return the transaction's starting timestamp. The value is assigned when the
+transaction begins and stays the same for the rest of the query — including
+when `USING PERIODIC COMMIT` rotates the underlying transaction between
+batches. Procedures can rely on it as a stable per-query identifier (for
+example, as a key in caches that span procedure calls).
+
+**Returns**:
+
+  An `int` representing the transaction's starting timestamp.
+
+**Examples**:
+
+  ```graph.start_timestamp```
+
 ### create\_vertex()
 
 ```python


### PR DESCRIPTION
### Release note

Document `mgp_graph_get_start_timestamp` / `Graph.start_timestamp`, the per-query identifier exposed to procedures. The value is the transaction's starting timestamp and stays stable across `USING PERIODIC COMMIT` boundaries, making it usable as a cache key in batched procedures.

### Related product PRs

- memgraph/memgraph#4167

### Checklist:

- [x] Add appropriate milestone (current release cycle)
- [x] Add `bugfix` or `feature` label, based on the product PR type you're documenting
- [x] Make sure all relevant tech details are documented
    - [x] Update reference pages (Python API + C API)
    - [x] Search for the feature you are working on (mentions) and make updates if needed
    - [x] Provide a basic example of usage
    - [ ] N/A — not an Enterprise feature
- [ ] Check all content with Grammarly
- [x] Perform a self-review of my code
- [x] The build passes locally
- [x] My changes generate no new warnings or errors