### PR TITLE
MemGQL v0.6

### DIFF
--- a/pages/memgraph-zero/memgql/changelog.mdx
+++ b/pages/memgraph-zero/memgql/changelog.mdx
@@ -5,6 +5,28 @@ description: MemGQL release notes
 
 # MemGQL Changelog
 
+## MemGQL v0.6.0 - TBD
+
+### ⚠️ Breaking changes
+
+- **`id_column` is now required on every edge mapping.** Previously optional
+  (enforced at query time only for variable-length traversal), it must now
+  be present on every edge entry in the mapping JSON. A mapping without
+  `id_column` on an edge now fails at startup with
+  `Failed to parse mapping JSON: missing field 'id_column' at line N`.
+  Update existing mappings by adding the edge table's primary key column
+  to every edge — see the [quick-start](/memgraph-zero/memgql/quick-start)
+  and connector examples for the new shape.
+
+### ✨ New features & Improvements
+
+- **GQL parse errors now surface the actual ANTLR diagnostic** (`line 1:N
+  no viable alternative at input '...'`) instead of being swallowed into
+  the generic `No statements in GQL query` message.
+- **Cypher-style variable-length syntax** (`[:R*]`, `[:R*1..3]`, `[:R*1..]`)
+  now produces an actionable hint pointing at the GQL quantified-path-pattern
+  form `(-[:R]->()){1,3}` instead of a confusing parse error.
+
 ## MemGQL v0.5.0 - May 16th, 2026
 
 ### ✨ New features & Improvements

--- a/pages/memgraph-zero/memgql/changelog.mdx
+++ b/pages/memgraph-zero/memgql/changelog.mdx
@@ -12,20 +12,56 @@ description: MemGQL release notes
 - **`id_column` is now required on every edge mapping.** Previously optional
   (enforced at query time only for variable-length traversal), it must now
   be present on every edge entry in the mapping JSON. A mapping without
-  `id_column` on an edge now fails at startup with
-  `Failed to parse mapping JSON: missing field 'id_column' at line N`.
-  Update existing mappings by adding the edge table's primary key column
-  to every edge — see the [quick-start](/memgraph-zero/memgql/quick-start)
-  and connector examples for the new shape.
+  `id_column` on an edge now fails at registration with
+  `Failed to parse mapping JSON: missing field 'id_column' at line N`,
+  whether the mapping is supplied via `MAPPING_FILE` at startup or via
+  `ADD MAPPING` at runtime. Update existing mappings by adding the edge
+  table's primary key column to every edge — see the
+  [quick-start](/memgraph-zero/memgql/quick-start) and connector examples
+  for the new shape.
+- **Untyped edge traversal `()-[]->(b)` now errors on SQL backends.**
+  Previously this expanded into a `UNION` over candidate rel-type mappings
+  and could silently over-count when label-distinct node tables shared
+  numeric IDs. The translator now returns an actionable error explaining
+  why untyped traversal isn't safe on SQL backends and pointing users at
+  either declaring the edge type or running on a Cypher backend (Memgraph,
+  Neo4j). Cypher backends still accept `()-[]->()` natively.
 
 ### ✨ New features & Improvements
 
+- **Trail semantics for bounded variable-length on SQL backends.** Patterns
+  like `(){1,3}` now enforce the GQL `DIFFERENT EDGES` default — no edge
+  is reused within a single matched path. The recursive CTE carries an
+  `_edges` visited-set whose shape is per-dialect (Postgres `ARRAY`, MySQL
+  `JSON_ARRAY`, DuckDB `LIST`). On cyclic graphs this matches Memgraph and
+  Neo4j byte-for-byte where previously SQL backends returned extra rows.
+- **`COUNT(DISTINCT …)`** works end-to-end on every backend. Previously
+  `count(DISTINCT x)` could leak through to backends as the synthetic
+  `COUNT_DISTINCT(...)` function (no engine has that). Both Cypher and SQL
+  translators now special-case `count_distinct` / `collect_distinct` /
+  `collect_list_distinct` to emit the dialect-native `COUNT(DISTINCT …)`.
 - **GQL parse errors now surface the actual ANTLR diagnostic** (`line 1:N
   no viable alternative at input '...'`) instead of being swallowed into
   the generic `No statements in GQL query` message.
 - **Cypher-style variable-length syntax** (`[:R*]`, `[:R*1..3]`, `[:R*1..]`)
   now produces an actionable hint pointing at the GQL quantified-path-pattern
   form `(-[:R]->()){1,3}` instead of a confusing parse error.
+- **Cross-graph parse errors** (multiple `USE <graph>` clauses in one query)
+  now return a clear "not yet supported" message instead of the generic
+  parse-failure error.
+
+### 🐞 Bug fixes
+
+- `%` (modulo) parses as a proper binary operator, not as a synthetic
+  function call.
+- `FOR x IN [...]` retains the iterated list and binds `x` correctly
+  (new `UnwindClause` AST node; planner emits `LogicalPlan::Unwind`).
+- `NEXT` query composition resolves names bound on the left-hand-side
+  when the right-hand-side `RETURN` references them.
+- Rel-variable reuse across `MATCH` clauses parses without a redeclaration
+  error.
+- `RETURN 1`'s internal `_dummy` placeholder no longer leaks into Cypher
+  queries sent to native backends.
 
 ## MemGQL v0.5.0 - May 16th, 2026
 

--- a/pages/memgraph-zero/memgql/changelog.mdx
+++ b/pages/memgraph-zero/memgql/changelog.mdx
@@ -5,7 +5,7 @@ description: MemGQL release notes
 
 # MemGQL Changelog
 
-## MemGQL v0.6.0 - TBD
+## MemGQL v0.6.0 - May 23rd, 2026
 
 ### ⚠️ Breaking changes
 

--- a/pages/memgraph-zero/memgql/changelog.mdx
+++ b/pages/memgraph-zero/memgql/changelog.mdx
@@ -56,6 +56,10 @@ description: MemGQL release notes
   function call.
 - `FOR x IN [...]` retains the iterated list and binds `x` correctly
   (new `UnwindClause` AST node; planner emits `LogicalPlan::Unwind`).
+  **Execution is Cypher-only today** — SQL backends parse and plan it,
+  then return an actionable error. See the
+  [reference](/memgraph-zero/memgql/reference) limitations for the
+  SQL-side status.
 - `NEXT` query composition resolves names bound on the left-hand-side
   when the right-hand-side `RETURN` references them.
 - Rel-variable reuse across `MATCH` clauses parses without a redeclaration

--- a/pages/memgraph-zero/memgql/complete.mdx
+++ b/pages/memgraph-zero/memgql/complete.mdx
@@ -47,7 +47,7 @@ docker network create memgql-net
 
 ## 2. Create the PostgreSQL init files
 
-MemGQL needs a schema mapping to translate graph patterns into SQL. Create
+MemGQL needs a graph mapping to translate graph patterns into SQL. Create
 these two files next to your `docker-compose.yml`:
 
 **`pg_init.sql`** — creates the relational tables:
@@ -102,7 +102,7 @@ Save the following as `docker-compose.yml`:
 ```yaml
 services:
   memgql:
-    image: memgraph/memgql:0.5.0
+    image: memgraph/memgql:latest
     container_name: memgql
     ports:
       - "7688:7688"

--- a/pages/memgraph-zero/memgql/complete.mdx
+++ b/pages/memgraph-zero/memgql/complete.mdx
@@ -102,7 +102,7 @@ Save the following as `docker-compose.yml`:
 ```yaml
 services:
   memgql:
-    image: memgraph/memgql:latest
+    image: ${MEMGQL_IMAGE:-memgraph/memgql:0.6.0}
     container_name: memgql
     ports:
       - "7688:7688"
@@ -169,7 +169,7 @@ services:
       - memgql-net
 
   lab:
-    image: memgraph/lab:3.10.0
+    image: memgraph/lab:3.10.1
     container_name: lab
     ports:
       - "3000:3000"

--- a/pages/memgraph-zero/memgql/complete.mdx
+++ b/pages/memgraph-zero/memgql/complete.mdx
@@ -85,6 +85,7 @@ CREATE TABLE friend_of (
     {
       "rel_type": "FRIEND_OF",
       "table": "friend_of",
+      "id_column": "id",
       "source_column": "user_id",
       "target_column": "friend_id",
       "source_label": "User",

--- a/pages/memgraph-zero/memgql/connect/duckdb.mdx
+++ b/pages/memgraph-zero/memgql/connect/duckdb.mdx
@@ -81,12 +81,12 @@ For environment variables, see [Reference](../reference.mdx#duckdb-duckdb).
 |-----------------------------------------------|--------|
 | `MATCH` / `WHERE` / `RETURN`                  | ✓      |
 | Pattern-level `WHERE` (`MATCH (n WHERE …)`)   | ✓      |
-| Multi-MATCH (cross-join)                      | ✓      |
+| Multiple `MATCH` clauses in one query         | ✓      |
 | `OPTIONAL MATCH`                              | ✓      |
-| `WITH` pipeline boundary                      | ✓      |
+| `WITH` clause (chain query steps)             | ✓      |
 | `WITH DISTINCT` / `WITH … ORDER BY … LIMIT N` | ✓      |
-| Chained `WITH … WITH …`                       | ✓      |
-| Whole-node `WITH n` carry-through             | ✓      |
+| Multiple chained `WITH` steps                 | ✓      |
+| Pass a whole node through `WITH n`            | ✓      |
 | Typed edge `(a)-[r:R]->(b)`                   | ✓      |
 | Untyped edge `()-[]->(b)`                     | ✗      |
 | `UNION` / `UNION ALL` / `UNION DISTINCT`      | ✓      |
@@ -111,5 +111,5 @@ For environment variables, see [Reference](../reference.mdx#duckdb-duckdb).
 ## Known limitations
 
 - **Unbounded variable-length paths** (`()-[*]->()`) are rejected. Bound the depth (`{1,5}`) or run the query against a Cypher backend.
-- **`MATCH p = (...)` path binding on quantified traversals** is not supported. Drop the path binding or run on a Cypher backend.
-- **Whole-node `RETURN n`** projects scalar columns rather than a Bolt Node struct. Use a map projection (`RETURN n {.id, .name} AS info`) for a single structured cell.
+- **Path variables on variable-length patterns** — `MATCH p = (a){1,3}(b) RETURN p` is not supported. Drop the `p =` binding (or query a Cypher backend) and `RETURN` the individual nodes / edges instead.
+- **`RETURN n`** returns the node's column values rather than a single structured node object. For a structured result, use a map projection: `RETURN n {.id, .name} AS info`.

--- a/pages/memgraph-zero/memgql/connect/duckdb.mdx
+++ b/pages/memgraph-zero/memgql/connect/duckdb.mdx
@@ -111,5 +111,6 @@ For environment variables, see [Reference](../reference.mdx#duckdb-duckdb).
 ## Known limitations
 
 - **Unbounded variable-length paths** (`()-[*]->()`) are rejected. Bound the depth (`{1,5}`) or run the query against a Cypher backend.
+- **`FOR x IN [...]` (UNWIND-style)** is rejected with an actionable error. Cypher backends (Memgraph, Neo4j) handle this syntax natively.
 - **Path variables on variable-length patterns** — `MATCH p = (a){1,3}(b) RETURN p` is not supported. Drop the `p =` binding (or query a Cypher backend) and `RETURN` the individual nodes / edges instead.
 - **`RETURN n`** returns the node's column values rather than a single structured node object. For a structured result, use a map projection: `RETURN n {.id, .name} AS info`.

--- a/pages/memgraph-zero/memgql/connect/duckdb.mdx
+++ b/pages/memgraph-zero/memgql/connect/duckdb.mdx
@@ -88,7 +88,7 @@ For environment variables, see [Reference](../reference.mdx#duckdb-duckdb).
 | Chained `WITH … WITH …`                       | ✓      |
 | Whole-node `WITH n` carry-through             | ✓      |
 | Typed edge `(a)-[r:R]->(b)`                   | ✓      |
-| Untyped edge `()-[]->(b)`                     | ✓      |
+| Untyped edge `()-[]->(b)`                     | ✗      |
 | `UNION` / `UNION ALL` / `UNION DISTINCT`      | ✓      |
 | Quantified path `(){m,n}` — bounded           | ✓      |
 | Map projections `RETURN n {.a, .b}`           | ✓      |

--- a/pages/memgraph-zero/memgql/connect/mysql.mdx
+++ b/pages/memgraph-zero/memgql/connect/mysql.mdx
@@ -142,5 +142,6 @@ For environment variables, see [Reference](../reference.mdx#mysql-mysql).
 ## Known limitations
 
 - **Unbounded variable-length paths** (`()-[*]->()`) are rejected. Bound the depth (`{1,5}`) or run the query against a Cypher backend.
+- **`FOR x IN [...]` (UNWIND-style)** is rejected with an actionable error. Cypher backends (Memgraph, Neo4j) handle this syntax natively.
 - **Path variables on variable-length patterns** — `MATCH p = (a){1,3}(b) RETURN p` is not supported. Drop the `p =` binding (or query a Cypher backend) and `RETURN` the individual nodes / edges instead.
 - **`RETURN n`** returns the node's column values rather than a single structured node object. For a structured result, use a map projection: `RETURN n {.id, .name} AS info`.

--- a/pages/memgraph-zero/memgql/connect/mysql.mdx
+++ b/pages/memgraph-zero/memgql/connect/mysql.mdx
@@ -112,12 +112,12 @@ For environment variables, see [Reference](../reference.mdx#mysql-mysql).
 |-----------------------------------------------|-------|
 | `MATCH` / `WHERE` / `RETURN`                  | ✓     |
 | Pattern-level `WHERE` (`MATCH (n WHERE …)`)   | ✓     |
-| Multi-MATCH (cross-join)                      | ✓     |
+| Multiple `MATCH` clauses in one query         | ✓     |
 | `OPTIONAL MATCH`                              | ✓     |
-| `WITH` pipeline boundary                      | ✓     |
+| `WITH` clause (chain query steps)             | ✓     |
 | `WITH DISTINCT` / `WITH … ORDER BY … LIMIT N` | ✓     |
-| Chained `WITH … WITH …`                       | ✓     |
-| Whole-node `WITH n` carry-through             | ✓     |
+| Multiple chained `WITH` steps                 | ✓     |
+| Pass a whole node through `WITH n`            | ✓     |
 | Typed edge `(a)-[r:R]->(b)`                   | ✓     |
 | Untyped edge `()-[]->(b)`                     | ✗     |
 | `UNION` / `UNION ALL` / `UNION DISTINCT`      | ✓     |
@@ -142,5 +142,5 @@ For environment variables, see [Reference](../reference.mdx#mysql-mysql).
 ## Known limitations
 
 - **Unbounded variable-length paths** (`()-[*]->()`) are rejected. Bound the depth (`{1,5}`) or run the query against a Cypher backend.
-- **`MATCH p = (...)` path binding on quantified traversals** is not supported. Drop the path binding or run on a Cypher backend.
-- **Whole-node `RETURN n`** projects scalar columns rather than a Bolt Node struct. Use a map projection (`RETURN n {.id, .name} AS info`) for a single structured cell.
+- **Path variables on variable-length patterns** — `MATCH p = (a){1,3}(b) RETURN p` is not supported. Drop the `p =` binding (or query a Cypher backend) and `RETURN` the individual nodes / edges instead.
+- **`RETURN n`** returns the node's column values rather than a single structured node object. For a structured result, use a map projection: `RETURN n {.id, .name} AS info`.

--- a/pages/memgraph-zero/memgql/connect/mysql.mdx
+++ b/pages/memgraph-zero/memgql/connect/mysql.mdx
@@ -119,7 +119,7 @@ For environment variables, see [Reference](../reference.mdx#mysql-mysql).
 | Chained `WITH … WITH …`                       | ✓     |
 | Whole-node `WITH n` carry-through             | ✓     |
 | Typed edge `(a)-[r:R]->(b)`                   | ✓     |
-| Untyped edge `()-[]->(b)`                     | ✓     |
+| Untyped edge `()-[]->(b)`                     | ✗     |
 | `UNION` / `UNION ALL` / `UNION DISTINCT`      | ✓     |
 | Quantified path `(){m,n}` — bounded           | ✓     |
 | Map projections `RETURN n {.a, .b}`           | ✓     |

--- a/pages/memgraph-zero/memgql/connect/postgres.mdx
+++ b/pages/memgraph-zero/memgql/connect/postgres.mdx
@@ -96,12 +96,12 @@ For environment variables, see [Reference](../reference.mdx#postgresql-postgres)
 |-----------------------------------------------|----------|
 | `MATCH` / `WHERE` / `RETURN`                  | ✓        |
 | Pattern-level `WHERE` (`MATCH (n WHERE …)`)   | ✓        |
-| Multi-MATCH (cross-join)                      | ✓        |
+| Multiple `MATCH` clauses in one query         | ✓        |
 | `OPTIONAL MATCH`                              | ✓        |
-| `WITH` pipeline boundary                      | ✓        |
+| `WITH` clause (chain query steps)             | ✓        |
 | `WITH DISTINCT` / `WITH … ORDER BY … LIMIT N` | ✓        |
-| Chained `WITH … WITH …`                       | ✓        |
-| Whole-node `WITH n` carry-through             | ✓        |
+| Multiple chained `WITH` steps                 | ✓        |
+| Pass a whole node through `WITH n`            | ✓        |
 | Typed edge `(a)-[r:R]->(b)`                   | ✓        |
 | Untyped edge `()-[]->(b)`                     | ✗        |
 | `UNION` / `UNION ALL` / `UNION DISTINCT`      | ✓        |
@@ -126,5 +126,5 @@ For environment variables, see [Reference](../reference.mdx#postgresql-postgres)
 ## Known limitations
 
 - **Unbounded variable-length paths** (`()-[*]->()`) are rejected. Bound the depth (`{1,5}`) or run the query against a Cypher backend.
-- **`MATCH p = (...)` path binding on quantified traversals** is not supported. Drop the path binding or run on a Cypher backend.
-- **Whole-node `RETURN n`** projects scalar columns rather than a Bolt Node struct. Use a map projection (`RETURN n {.id, .name} AS info`) for a single structured cell.
+- **Path variables on variable-length patterns** — `MATCH p = (a){1,3}(b) RETURN p` is not supported. Drop the `p =` binding (or query a Cypher backend) and `RETURN` the individual nodes / edges instead.
+- **`RETURN n`** returns the node's column values rather than a single structured node object. For a structured result, use a map projection: `RETURN n {.id, .name} AS info`.

--- a/pages/memgraph-zero/memgql/connect/postgres.mdx
+++ b/pages/memgraph-zero/memgql/connect/postgres.mdx
@@ -103,7 +103,7 @@ For environment variables, see [Reference](../reference.mdx#postgresql-postgres)
 | Chained `WITH … WITH …`                       | ✓        |
 | Whole-node `WITH n` carry-through             | ✓        |
 | Typed edge `(a)-[r:R]->(b)`                   | ✓        |
-| Untyped edge `()-[]->(b)`                     | ✓        |
+| Untyped edge `()-[]->(b)`                     | ✗        |
 | `UNION` / `UNION ALL` / `UNION DISTINCT`      | ✓        |
 | Quantified path `(){m,n}` — bounded           | ✓        |
 | Map projections `RETURN n {.a, .b}`           | ✓        |

--- a/pages/memgraph-zero/memgql/connect/postgres.mdx
+++ b/pages/memgraph-zero/memgql/connect/postgres.mdx
@@ -126,5 +126,6 @@ For environment variables, see [Reference](../reference.mdx#postgresql-postgres)
 ## Known limitations
 
 - **Unbounded variable-length paths** (`()-[*]->()`) are rejected. Bound the depth (`{1,5}`) or run the query against a Cypher backend.
+- **`FOR x IN [...]` (UNWIND-style)** is rejected with an actionable error. Cypher backends (Memgraph, Neo4j) handle this syntax natively.
 - **Path variables on variable-length patterns** — `MATCH p = (a){1,3}(b) RETURN p` is not supported. Drop the `p =` binding (or query a Cypher backend) and `RETURN` the individual nodes / edges instead.
 - **`RETURN n`** returns the node's column values rather than a single structured node object. For a structured result, use a map projection: `RETURN n {.id, .name} AS info`.

--- a/pages/memgraph-zero/memgql/quick-start.mdx
+++ b/pages/memgraph-zero/memgql/quick-start.mdx
@@ -177,6 +177,7 @@ cat > mapping.json << 'EOF'
     {
       "rel_type": "KNOWS",
       "table": "knows",
+      "id_column": "id",
       "source_column": "from_id",
       "target_column": "to_id",
       "source_label": "Person",
@@ -185,6 +186,7 @@ cat > mapping.json << 'EOF'
     {
       "rel_type": "WORKS_AT",
       "table": "works_at",
+      "id_column": "id",
       "source_column": "person_id",
       "target_column": "company_id",
       "source_label": "Person",

--- a/pages/memgraph-zero/memgql/quick-start.mdx
+++ b/pages/memgraph-zero/memgql/quick-start.mdx
@@ -142,8 +142,8 @@ MATCH (d:Developer {name: "Lana"})-[:MENTORS]->{1,3}(mentee:Developer) RETURN me
 
 ## Environment Variables
 
-See [Configuration](config.mdx) for the full list of environment variables
-and connector-specific settings.
+See [Reference](/memgraph-zero/memgql/reference) for the full list of
+environment variables and connector-specific settings.
 
 
 ## Mapping File
@@ -283,7 +283,7 @@ DROP MAPPING social;
 
 | Statement                                          | Description                           |
 |----------------------------------------------------|---------------------------------------|
-| `ADD MAPPING <name> FROM '<file>'`                 | Load a JSON schema mapping            |
+| `ADD MAPPING <name> FROM '<file>'`                 | Load a graph mapping from a JSON file |
 | `DROP MAPPING <name>`                              | Remove a mapping                      |
 | `ADD CONNECTOR <name> TYPE <type> [options...]`    | Register a backend connector          |
 | `DROP CONNECTOR <name>`                            | Remove a connector                    |

--- a/pages/memgraph-zero/memgql/reference.mdx
+++ b/pages/memgraph-zero/memgql/reference.mdx
@@ -24,7 +24,7 @@ supports.
 | Chained `WITH … WITH …`                                            | ✓               | ✓            |
 | Whole-node `WITH n` carry-through                                  | ✓               | ✓            |
 | `MATCH (n)-[r:R]->(m)` typed edge expansion                        | ✓               | ✓            |
-| Untyped edge `()-[]->(b)` (union over types)                       | ✓               | ✓            |
+| Untyped edge `()-[]->(b)` (union over types)                       | ✓               | ✗            |
 | `UNION` / `UNION ALL` / `UNION DISTINCT`                           | ✓               | ✓            |
 | `INTERSECT` / `EXCEPT`                                             | ✗               | ✗            |
 | Quantified path `(){m,n}` — bounded                                | ✓               | ✓            |
@@ -242,3 +242,90 @@ macOS, Linux, and Windows without any extra system packages.
 | `TRINO_CATALOG` | `iceberg`               | Trino catalog             |
 | `TRINO_SCHEMA`  | `default`               | Trino schema              |
 | `MAPPING_FILE`  | _(none, uses built-in default)_ | Path to JSON mapping file |
+
+## Mapping Schema
+
+The graph mapping file is a JSON document with two top-level arrays:
+`nodes` and `edges`. MemGQL loads it either from the path in `MAPPING_FILE`
+at startup or via the `ADD MAPPING <name> FROM '<path>'` statement at
+runtime — both paths apply the same validation. A mapping with any
+required field missing is rejected before the server begins serving
+queries against it.
+
+```json
+{
+  "nodes": [ /* NodeMapping objects */ ],
+  "edges": [ /* EdgeMapping objects */ ]
+}
+```
+
+### Node mapping fields
+
+| Field        | Type                    | Required | Description |
+|--------------|-------------------------|----------|-------------|
+| `label`      | string                  | yes      | GQL node label (e.g. `"Person"`). Looked up case-insensitively. |
+| `table`      | string                  | yes      | Backend table or view name backing this label. |
+| `id_column`  | string                  | yes      | Primary key column. Surfaces as GQL `id(n)` and is used to join across edges. |
+| `properties` | object (string→string)  | no       | Map from GQL property name → backend column name. Properties not listed here pass through with the same name (`p.name` → column `name`). |
+
+Connector-specific fields:
+
+- **Iceberg** also accepts `catalog` and `schema_name` to fully qualify the
+  table reference (defaults: `"iceberg"`, `"default"`).
+- **ClickHouse** also accepts `database` (default: `"default"`).
+
+### Edge mapping fields
+
+| Field            | Type                    | Required | Description |
+|------------------|-------------------------|----------|-------------|
+| `rel_type`       | string                  | yes      | GQL relationship type (e.g. `"KNOWS"`). Looked up case-insensitively. |
+| `table`          | string                  | yes      | Junction or association table backing this edge type. |
+| `id_column`      | string                  | yes      | Per-edge primary key. **Required since v0.6.** Carried through the recursive CTE's visited-edge set to enforce trail semantics on variable-length traversal. |
+| `source_column`  | string                  | yes      | FK column pointing to the source node's `id_column`. |
+| `target_column`  | string                  | yes      | FK column pointing to the target node's `id_column`. |
+| `source_label`   | string                  | yes      | Label of the source node (must match a `label` declared in `nodes`). |
+| `target_label`   | string                  | yes      | Label of the target node. |
+| `properties`     | object (string→string)  | no       | Map from GQL property name → column name on the edge table. |
+
+Connector-specific fields are the same as for nodes (`catalog` / `schema_name`
+for Iceberg; `database` for ClickHouse).
+
+### Example
+
+```json
+{
+  "nodes": [
+    {
+      "label": "Person",
+      "table": "persons",
+      "id_column": "id",
+      "properties": { "name": "full_name", "age": "age" }
+    },
+    {
+      "label": "Company",
+      "table": "companies",
+      "id_column": "id"
+    }
+  ],
+  "edges": [
+    {
+      "rel_type": "KNOWS",
+      "table": "knows",
+      "id_column": "id",
+      "source_column": "from_id",
+      "target_column": "to_id",
+      "source_label": "Person",
+      "target_label": "Person"
+    },
+    {
+      "rel_type": "WORKS_AT",
+      "table": "works_at",
+      "id_column": "id",
+      "source_column": "person_id",
+      "target_column": "company_id",
+      "source_label": "Person",
+      "target_label": "Company"
+    }
+  ]
+}
+```

--- a/pages/memgraph-zero/memgql/reference.mdx
+++ b/pages/memgraph-zero/memgql/reference.mdx
@@ -17,12 +17,12 @@ supports.
 |--------------------------------------------------------------------|-----------------|--------------|
 | `MATCH` / `WHERE` / `RETURN`                                       | ✓               | ✓            |
 | Pattern-level `WHERE` (`MATCH (n WHERE …)`)                        | ✓               | ✓            |
-| Multi-MATCH (cross-join)                                           | ✓               | ✓            |
-| `OPTIONAL MATCH` (LEFT JOIN semantics)                             | ✓               | ✓            |
-| `WITH` pipeline boundary (scope D)                                 | ✓               | ✓            |
+| Multiple `MATCH` clauses in one query                              | ✓               | ✓            |
+| `OPTIONAL MATCH` (keep left side when no match found)              | ✓               | ✓            |
+| `WITH` clause (chain query steps)                                  | ✓               | ✓            |
 | `WITH DISTINCT` / `WITH … ORDER BY … LIMIT N`                      | ✓               | ✓            |
-| Chained `WITH … WITH …`                                            | ✓               | ✓            |
-| Whole-node `WITH n` carry-through                                  | ✓               | ✓            |
+| Multiple chained `WITH` steps in one query                         | ✓               | ✓            |
+| Pass a whole node through `WITH n` to a later step                 | ✓               | ✓            |
 | `MATCH (n)-[r:R]->(m)` typed edge expansion                        | ✓               | ✓            |
 | Untyped edge `()-[]->(b)` (union over types)                       | ✓               | ✗            |
 | `UNION` / `UNION ALL` / `UNION DISTINCT`                           | ✓               | ✓            |
@@ -54,12 +54,13 @@ supports.
   no rel-type) returns an actionable error pointing users at declaring
   the edge type or running on a Cypher backend. The form is still
   accepted natively on Cypher backends.
-- **`MATCH p = (...)` path binding** on quantified traversals
-  (`MATCH p = (a){1,3}(b) RETURN p`) is not yet supported on SQL
-  backends. Drop the path binding or run the query against a Cypher
-  backend.
-- **Whole-node `RETURN n`** over SQL backends projects scalar columns;
-  the Bolt Node struct shape is reserved for Cypher backends today.
+- **Path variables on variable-length patterns** —
+  `MATCH p = (a){1,3}(b) RETURN p` is not yet supported on SQL backends.
+  Drop the `p =` binding (or query a Cypher backend) and `RETURN` the
+  individual nodes / edges instead.
+- **`RETURN n` on SQL backends returns the node's column values** rather
+  than a single structured node object. For a structured result, use a
+  map projection: `RETURN n {.id, .name} AS info`.
 
 ## Graph Management Query Syntax
 

--- a/pages/memgraph-zero/memgql/reference.mdx
+++ b/pages/memgraph-zero/memgql/reference.mdx
@@ -50,6 +50,10 @@ supports.
 
 - **Unbounded variable-length paths on SQL backends** (`()-[*]->()`)
   return an actionable error.
+- **Untyped edge traversal on SQL backends** (`MATCH ()-[]->(b)` with
+  no rel-type) returns an actionable error pointing users at declaring
+  the edge type or running on a Cypher backend. The form is still
+  accepted natively on Cypher backends.
 - **`MATCH p = (...)` path binding** on quantified traversals
   (`MATCH p = (a){1,3}(b) RETURN p`) is not yet supported on SQL
   backends. Drop the path binding or run the query against a Cypher

--- a/pages/memgraph-zero/memgql/reference.mdx
+++ b/pages/memgraph-zero/memgql/reference.mdx
@@ -54,6 +54,9 @@ supports.
   no rel-type) returns an actionable error pointing users at declaring
   the edge type or running on a Cypher backend. The form is still
   accepted natively on Cypher backends.
+- **`FOR x IN [...]` (UNWIND-style) on SQL backends** returns an
+  actionable error pointing users at running the query on a Cypher
+  backend. The form is still accepted natively on Cypher backends.
 - **Path variables on variable-length patterns** —
   `MATCH p = (a){1,3}(b) RETURN p` is not yet supported on SQL backends.
   Drop the `p =` binding (or query a Cypher backend) and `RETURN` the

--- a/pages/memgraph-zero/memgql/use-cases/public-private.mdx
+++ b/pages/memgraph-zero/memgql/use-cases/public-private.mdx
@@ -174,6 +174,7 @@ cat > pg_mapping.json << 'EOF'
     {
       "rel_type": "FRIEND_OF",
       "table": "friend_of",
+      "id_column": "id",
       "source_column": "user_id",
       "target_column": "friend_id",
       "source_label": "User",

--- a/pages/memgraph-zero/memgql/use-cases/public-private.mdx
+++ b/pages/memgraph-zero/memgql/use-cases/public-private.mdx
@@ -62,7 +62,7 @@ MemGQL, and a one-shot init container:
 cat > docker-compose.yml << 'EOF'
 services:
   memgql:
-    image: ${MEMGQL_IMAGE:-memgraph/memgql:0.5.0}
+    image: ${MEMGQL_IMAGE:-memgraph/memgql:0.6.0}
     ports:
       - "7688:7688"
     environment:


### PR DESCRIPTION
### Release note

Docs for the MemGQL v0.6 release. Three categories of change:

**1. Breaking change: `id_column` on edges.** v0.6 makes `id_column` required on every edge mapping, validated at both `MAPPING_FILE` startup and `ADD MAPPING` runtime. Mapping examples updated in `quick-start.mdx`, `complete.mdx`, and `use-cases/public-private.mdx`. New `v0.6.0` changelog entry under `⚠️ Breaking changes`.

**2. v0.6.0 changelog now covers all the user-facing landings:**

- Trail semantics for bounded `(){m,n}` on SQL backends (no edge reused within a path; matches Memgraph/Neo4j on cyclic graphs).
- Untyped edge `()-[]->(b)` on SQL backends now returns an actionable error instead of silently overcounting.
- `COUNT(DISTINCT …)` works end-to-end on every backend.
- GQL parse errors surface the actual ANTLR diagnostic instead of `No statements in GQL query`.
- Cypher-style `[:R*]` / `[:R*1..3]` now hints at the GQL form `(-[:R]->()){1,3}`.
- Multi-`USE` cross-graph parse errors are actionable instead of generic.
- Five triaged parser bug fixes (`%` modulo, `FOR x IN [...]` UNWIND, `NEXT` composition name resolution, rel-variable reuse, `RETURN 1` `_dummy` leak).

**3. Global audit-driven cleanups (not tied to v0.6):**

- Feature matrices on `reference.mdx`, `connect/postgres.mdx`, `connect/mysql.mdx`, and `connect/duckdb.mdx` all marked untyped edges as supported on SQL (✓). The same files' Known Limitations sections already said otherwise. Flipped to ✗ everywhere the matrix surfaces.
- `quick-start.mdx` referenced a non-existent `config.mdx`; repointed at `reference.mdx`.
- `complete.mdx` Docker Compose pinned `memgraph/memgql:0.5.0`, which lacks every v0.6 behavior the rest of the docs describe; bumped to `:latest`.
- `reference.mdx` gains a **Mapping Schema** section listing every field of the mapping JSON (top-level, node, edge, connector-specific extensions) with required/optional and semantic notes. Centralizes a contract that was previously scattered across `quick-start`, `complete`, and the per-connector pages.
- Light terminology unification: "schema mapping" → "graph mapping" (two occurrences). "mapping file" and "mapping JSON" left intact because they carry distinct meanings.

### Related product PRs

PRs from product repo this doc page is related to: 
https://github.com/memgraph/zero/pull/3
https://github.com/memgraph/zero/pull/4
https://github.com/memgraph/zero/pull/5

### Checklist:

- [ ] Add appropriate milestone (current release cycle)
- [ ] Add `bugfix` or `feature` label, based on the product PR type you're documenting
- [ ] Make sure all relevant tech details are documented
    - [ ] Update reference pages (e.g. [clauses](https://memgraph.com/docs/querying/clauses), [functions](https://memgraph.com/docs/querying/functions), [flags](https://memgraph.com/docs/database-management/configuration#list-of-configuration-flags), [experimental](https://memgraph.com/docs/database-management/experimental-features), [monitoring](https://memgraph.com/docs/database-management/monitoring), [Cypher differences](https://memgraph.com/docs/querying/differences-in-cypher-implementations))
    - [ ] Search for the feature you are working on (mentions) and make updates if needed
    - [ ] Provide a basic example of usage
    - [ ] In case your feature is an Enterprise one, list it under [ME page](https://memgraph.com/docs/database-management/enabling-memgraph-enterprise) and mark its page with Enterprise ([example](https://memgraph.com/docs/database-management/authentication-and-authorization/role-based-access-control)).
- [ ] Check all content with Grammarly
- [ ] Perform a self-review of my code
- [ ] The build passes locally
- [ ] My changes generate no new warnings or errors
