### PR TITLE
feat: HA chart log_retention_days

### DIFF
--- a/pages/clustering/high-availability/setup-ha-cluster-k8s.mdx
+++ b/pages/clustering/high-availability/setup-ha-cluster-k8s.mdx
@@ -777,10 +777,11 @@ concern, first set `commonArgs.data.logging.also_log_to_stderr` and
 to files is cheaper. If you're still unhappy with the performance overhead of
 logging, set `commonArgs.{data,coordinators}.logging.log_level` to `DEBUG`
 (higher log levels like `INFO` or `CRITICAL` are also fine) and keep
-`also_log_to_stderr: true`. These settings replace the `--log-level` and
-`--also-log-to-stderr` flags that the chart now appends to instance args
-automatically — setting them directly in `data[].args` or
-`coordinators[].args` is rejected.
+`also_log_to_stderr: true`. These settings replace the `--log-level`,
+`--also-log-to-stderr`, `--log-file` and `--log-retention-days` flags that the
+chart now appends to instance args automatically — setting them directly in
+`data[].args` or `coordinators[].args` is rejected. Configure log retention via
+`commonArgs.{data,coordinators}.logging.log_retention_days` (defaults to `35`).
 
 By default, the chart provisions a dedicated log PVC for every data and
 coordinator pod. If you only log to stderr and don't need a persistent log
@@ -1295,9 +1296,11 @@ and their default values.
 | `commonArgs.data.logging.log_level`                        | Log level applied to every data instance via `--log-level`. Must not be empty.                               | `TRACE`                        |
 | `commonArgs.data.logging.also_log_to_stderr`               | When `true`, appends `--also-log-to-stderr` to every data instance. Must be a boolean.                       | `true`                         |
 | `commonArgs.data.logging.log_file`                         | Log-file path applied to every data instance via `--log-file`. Empty disables file logging.                  | `/var/log/memgraph/memgraph.log` |
+| `commonArgs.data.logging.log_retention_days`               | Number of days to retain log files on every data instance via `--log-retention-days`.                        | `35`                           |
 | `commonArgs.coordinators.logging.log_level`                | Log level applied to every coordinator via `--log-level`. Must not be empty.                                 | `TRACE`                        |
 | `commonArgs.coordinators.logging.also_log_to_stderr`       | When `true`, appends `--also-log-to-stderr` to every coordinator. Must be a boolean.                         | `true`                         |
 | `commonArgs.coordinators.logging.log_file`                 | Log-file path applied to every coordinator via `--log-file`. Empty disables file logging.                    | `/var/log/memgraph/memgraph.log` |
+| `commonArgs.coordinators.logging.log_retention_days`       | Number of days to retain log files on every coordinator via `--log-retention-days`.                          | `35`                           |
 | `userContainers.data`                                      | Additional sidecar containers for data instance pods                                                         | `[]`                           |
 | `userContainers.coordinators`                              | Additional sidecar containers for coordinator pods                                                           | `[]`                           |
 | `tolerations.data`                                         | Tolerations for data instance pods                                                                           | `[]`                           |


### PR DESCRIPTION
### Release note

Users can now set log_retention_days directly in values.yaml file instead of previously needing to manually append --log-retention-days flag. 

### Related product PRs

PRs from product repo this doc page is related to: 
https://github.com/memgraph/helm-charts/pull/253

### Checklist:

- [x] Add appropriate milestone (current release cycle)
- [x] Add `bugfix` or `feature` label, based on the product PR type you're documenting
- [x] Make sure all relevant tech details are documented
    - [x] Update reference pages (e.g. [clauses](https://memgraph.com/docs/querying/clauses), [functions](https://memgraph.com/docs/querying/functions), [flags](https://memgraph.com/docs/database-management/configuration#list-of-configuration-flags), [experimental](https://memgraph.com/docs/database-management/experimental-features), [monitoring](https://memgraph.com/docs/database-management/monitoring), [Cypher differences](https://memgraph.com/docs/querying/differences-in-cypher-implementations))
    - [x] Search for the feature you are working on (mentions) and make updates if needed
    - [x] Provide a basic example of usage
    - [x] In case your feature is an Enterprise one, list it under [ME page](https://memgraph.com/docs/database-management/enabling-memgraph-enterprise) and mark its page with Enterprise ([example](https://memgraph.com/docs/database-management/authentication-and-authorization/role-based-access-control)).
- [x] Check all content with Grammarly
- [x] Perform a self-review of my code
- [x] The build passes locally
- [x] My changes generate no new warnings or errors