### PR TITLE
new: Change Lab version to 3.10.2 in release notes

### DIFF
--- a/pages/release-notes.mdx
+++ b/pages/release-notes.mdx
@@ -54,9 +54,9 @@ guide.
   command line arguments provided, e.g. `docker run -it memgraph/memgraph:3.10.0`. 
   [#4145](https://github.com/memgraph/memgraph/pull/4145)
 
-### Lab v3.10.1 - May 20th, 2026
+### Lab v3.10.2 - May 29th, 2026
 
-<LabReleasesClient version="3.10.1" />
+<LabReleasesClient version="3.10.2" />
 
 ## Previous releases
 
@@ -351,6 +351,10 @@ guide.
   commit/abort load this could starve workers and make the database appear
   blocked to users.
   [#4122](https://github.com/memgraph/memgraph/pull/4122)
+
+### Lab v3.10.1 - May 20th, 2026
+
+<LabReleasesClient version="3.10.1" />
 
 ### Lab v3.10.0 - May 13th, 2026
 


### PR DESCRIPTION
### Release note

Added release notes for the Lab version for 3.10.2.

### Related product PRs

PRs from product repo this doc page is related to: 
(paste the links to the PRs)

### Checklist:

- [ ] Add appropriate milestone (current release cycle)
- [ ] Add `bugfix` or `feature` label, based on the product PR type you're documenting
- [x] Check all content with Grammarly
- [x] Perform a self-review of my code
- [x] The build passes locally
- [x] My changes generate no new warnings or errors