### PR TITLE
MemGQL v0.7 docs: typed projections, liveness queries, NUMERIC + ORDER BY alias

### DIFF
--- a/pages/memgraph-zero/memgql/changelog.mdx
+++ b/pages/memgraph-zero/memgql/changelog.mdx
@@ -5,6 +5,33 @@ description: MemGQL release notes
 
 # MemGQL Changelog
 
+## MemGQL v0.7.0 - TBD
+
+### ✨ New features & Improvements
+
+- **Typed projections on SQL backends.** `RETURN p` now returns a structured
+  Bolt **Node** and `RETURN r` a typed Bolt **Relationship** on PostgreSQL,
+  MySQL and DuckDB — previously these backends returned the underlying column
+  values and a map projection (`RETURN p {.id, .name}`) was required. Nodes
+  carry their label and mapped properties; relationships carry their type and
+  mapped properties. Mixing scalar and whole-element projections in one
+  `RETURN` (`RETURN p.name, p`) works too.
+- **Connection-less queries (liveness check).** `RETURN 1`, `RETURN 1 + 2 AS x`
+  and `WITH 1 AS x RETURN x` now evaluate locally with no connector configured
+  and no backend reachable — useful as a Bolt-level health probe.
+- **`ORDER BY` by `RETURN` alias in cross-backend queries.** A sort key can
+  reference a projected alias (`RETURN fact.tx_count AS tx_count … ORDER BY
+  tx_count`), including when the alias is nested inside an arithmetic
+  expression (`ORDER BY tx_count + 1`). The post-join sort rewrites the alias
+  back to its underlying expression.
+- **Delimited (quoted) identifiers** in GQL queries now parse.
+
+### 🐞 Bug fixes
+
+- **PostgreSQL `NUMERIC` columns** now deserialize correctly — whole and
+  fractional values arrive at the Bolt driver as Float and `NULL` is
+  preserved. Previously `NUMERIC`-typed columns were unsupported.
+
 ## MemGQL v0.6.1 - May 31st, 2026
 
 ### ✨ New features & Improvements

--- a/pages/memgraph-zero/memgql/changelog.mdx
+++ b/pages/memgraph-zero/memgql/changelog.mdx
@@ -9,13 +9,14 @@ description: MemGQL release notes
 
 ### ✨ New features & Improvements
 
-- **Typed projections on SQL backends.** `RETURN p` now returns a structured
-  Bolt **Node** and `RETURN r` a typed Bolt **Relationship** on PostgreSQL,
-  MySQL and DuckDB — previously these backends returned the underlying column
-  values and a map projection (`RETURN p {.id, .name}`) was required. Nodes
-  carry their label and mapped properties; relationships carry their type and
-  mapped properties. Mixing scalar and whole-element projections in one
-  `RETURN` (`RETURN p.name, p`) works too.
+- **Typed projections on every SQL backend.** `RETURN p` now returns a
+  structured Bolt **Node** and `RETURN r` a typed Bolt **Relationship** on
+  every SQL connector (PostgreSQL, MySQL, DuckDB, ClickHouse, Iceberg, Pinot,
+  Oracle) — previously SQL backends returned the underlying column values and a
+  map projection (`RETURN p {.id, .name}`) was required. Nodes carry their
+  label and mapped properties; relationships carry their type and mapped
+  properties. Mixing scalar and whole-element projections in one `RETURN`
+  (`RETURN p.name, p`) works too.
 - **Connection-less queries (liveness check).** `RETURN 1`, `RETURN 1 + 2 AS x`
   and `WITH 1 AS x RETURN x` now evaluate locally with no connector configured
   and no backend reachable — useful as a Bolt-level health probe.

--- a/pages/memgraph-zero/memgql/changelog.mdx
+++ b/pages/memgraph-zero/memgql/changelog.mdx
@@ -5,7 +5,7 @@ description: MemGQL release notes
 
 # MemGQL Changelog
 
-## MemGQL v0.7.0 - TBD
+## MemGQL v0.6.2 - June 7th, 2026
 
 ### ✨ New features & Improvements
 

--- a/pages/memgraph-zero/memgql/complete.mdx
+++ b/pages/memgraph-zero/memgql/complete.mdx
@@ -102,7 +102,7 @@ Save the following as `docker-compose.yml`:
 ```yaml
 services:
   memgql:
-    image: ${MEMGQL_IMAGE:-memgraph/memgql:0.6.1}
+    image: ${MEMGQL_IMAGE:-memgraph/memgql:0.6.2}
     container_name: memgql
     ports:
       - "7688:7688"

--- a/pages/memgraph-zero/memgql/connect/clickhouse.mdx
+++ b/pages/memgraph-zero/memgql/connect/clickhouse.mdx
@@ -102,6 +102,7 @@ For environment variables, see [Reference](../reference.mdx#clickhouse-clickhous
 | Feature                                       | ClickHouse |
 |-----------------------------------------------|------------|
 | `MATCH (n:Label) RETURN n.prop`               | ✓          |
+| Whole-node `RETURN n` / whole-rel `RETURN r`  | ✓          |
 | Pattern-level `WHERE` (`MATCH (n WHERE …)`)   | ✓          |
 | Typed edge `(a)-[r:R]->(b)`                   | ✓          |
 | `ORDER BY` / `LIMIT`                          | ✓          |

--- a/pages/memgraph-zero/memgql/connect/duckdb.mdx
+++ b/pages/memgraph-zero/memgql/connect/duckdb.mdx
@@ -91,6 +91,7 @@ For environment variables, see [Reference](../reference.mdx#duckdb-duckdb).
 | Untyped edge `()-[]->(b)`                     | ✗      |
 | `UNION` / `UNION ALL` / `UNION DISTINCT`      | ✓      |
 | Quantified path `(){m,n}` — bounded           | ✓      |
+| Whole-node `RETURN n` / whole-rel `RETURN r`  | ✓      |
 | Map projections `RETURN n {.a, .b}`           | ✓      |
 | `IN` list membership `WHERE x IN [...]`       | ✓      |
 | `STARTS WITH` / `ENDS WITH` / `CONTAINS`      | ✓      |
@@ -113,4 +114,3 @@ For environment variables, see [Reference](../reference.mdx#duckdb-duckdb).
 - **Unbounded variable-length paths** (`()-[*]->()`) are rejected. Bound the depth (`{1,5}`) or run the query against a Cypher backend.
 - **`FOR x IN [...]` (UNWIND-style)** is rejected with an actionable error. Cypher backends (Memgraph, Neo4j) handle this syntax natively.
 - **Path variables on variable-length patterns** — `MATCH p = (a){1,3}(b) RETURN p` is not supported. Drop the `p =` binding (or query a Cypher backend) and `RETURN` the individual nodes / edges instead.
-- **`RETURN n`** returns the node's column values rather than a single structured node object. For a structured result, use a map projection: `RETURN n {.id, .name} AS info`.

--- a/pages/memgraph-zero/memgql/connect/iceberg.mdx
+++ b/pages/memgraph-zero/memgql/connect/iceberg.mdx
@@ -100,6 +100,7 @@ For environment variables, see [Reference](../reference.mdx#iceberg-iceberg).
 | Feature                                       | Iceberg / Trino |
 |-----------------------------------------------|-----------------|
 | `MATCH (n:Label) RETURN n.prop`               | ✓               |
+| Whole-node `RETURN n` / whole-rel `RETURN r`  | ✓               |
 | Pattern-level `WHERE` (`MATCH (n WHERE …)`)   | ✓               |
 | Typed edge `(a)-[r:R]->(b)`                   | ✓               |
 | `ORDER BY` / `LIMIT`                          | ✓               |

--- a/pages/memgraph-zero/memgql/connect/mysql.mdx
+++ b/pages/memgraph-zero/memgql/connect/mysql.mdx
@@ -122,6 +122,7 @@ For environment variables, see [Reference](../reference.mdx#mysql-mysql).
 | Untyped edge `()-[]->(b)`                     | ✗     |
 | `UNION` / `UNION ALL` / `UNION DISTINCT`      | ✓     |
 | Quantified path `(){m,n}` — bounded           | ✓     |
+| Whole-node `RETURN n` / whole-rel `RETURN r`  | ✓     |
 | Map projections `RETURN n {.a, .b}`           | ✓     |
 | `IN` list membership `WHERE x IN [...]`       | ✓     |
 | `STARTS WITH` / `ENDS WITH` / `CONTAINS`      | ✓     |
@@ -144,4 +145,3 @@ For environment variables, see [Reference](../reference.mdx#mysql-mysql).
 - **Unbounded variable-length paths** (`()-[*]->()`) are rejected. Bound the depth (`{1,5}`) or run the query against a Cypher backend.
 - **`FOR x IN [...]` (UNWIND-style)** is rejected with an actionable error. Cypher backends (Memgraph, Neo4j) handle this syntax natively.
 - **Path variables on variable-length patterns** — `MATCH p = (a){1,3}(b) RETURN p` is not supported. Drop the `p =` binding (or query a Cypher backend) and `RETURN` the individual nodes / edges instead.
-- **`RETURN n`** returns the node's column values rather than a single structured node object. For a structured result, use a map projection: `RETURN n {.id, .name} AS info`.

--- a/pages/memgraph-zero/memgql/connect/pinot.mdx
+++ b/pages/memgraph-zero/memgql/connect/pinot.mdx
@@ -100,5 +100,6 @@ For environment variables, see [Reference](../reference.mdx#apache-pinot-pinot).
 | Feature                                       | Pinot |
 |-----------------------------------------------|-------|
 | `MATCH (n:Label) RETURN n.prop`               | ✓     |
+| Whole-node `RETURN n` / whole-rel `RETURN r`  | ✓     |
 | Pattern-level `WHERE` (`MATCH (n WHERE …)`)   | ✓     |
 | Typed edge `(a)-[r:R]->(b)`                   | ✓     |

--- a/pages/memgraph-zero/memgql/connect/postgres.mdx
+++ b/pages/memgraph-zero/memgql/connect/postgres.mdx
@@ -106,6 +106,7 @@ For environment variables, see [Reference](../reference.mdx#postgresql-postgres)
 | Untyped edge `()-[]->(b)`                     | ✗        |
 | `UNION` / `UNION ALL` / `UNION DISTINCT`      | ✓        |
 | Quantified path `(){m,n}` — bounded           | ✓        |
+| Whole-node `RETURN n` / whole-rel `RETURN r`  | ✓        |
 | Map projections `RETURN n {.a, .b}`           | ✓        |
 | `IN` list membership `WHERE x IN [...]`       | ✓        |
 | `STARTS WITH` / `ENDS WITH` / `CONTAINS`      | ✓        |
@@ -128,4 +129,3 @@ For environment variables, see [Reference](../reference.mdx#postgresql-postgres)
 - **Unbounded variable-length paths** (`()-[*]->()`) are rejected. Bound the depth (`{1,5}`) or run the query against a Cypher backend.
 - **`FOR x IN [...]` (UNWIND-style)** is rejected with an actionable error. Cypher backends (Memgraph, Neo4j) handle this syntax natively.
 - **Path variables on variable-length patterns** — `MATCH p = (a){1,3}(b) RETURN p` is not supported. Drop the `p =` binding (or query a Cypher backend) and `RETURN` the individual nodes / edges instead.
-- **`RETURN n`** returns the node's column values rather than a single structured node object. For a structured result, use a map projection: `RETURN n {.id, .name} AS info`.

--- a/pages/memgraph-zero/memgql/reference.mdx
+++ b/pages/memgraph-zero/memgql/reference.mdx
@@ -30,7 +30,9 @@ supports.
 | Quantified path `(){m,n}` — bounded                                | ✓               | ✓            |
 | Quantified path `(){m,}` — unbounded                               | ✓               | ✗            |
 | Shortest-path (`ALL SHORTEST` / `ANY SHORTEST` / `SHORTEST k`) | ✓ | ✗               | ✗            |
+| Whole-node `RETURN n` / whole-relationship `RETURN r`              | ✓               | ✓            |
 | Map projections `RETURN n {.id, .title}`                           | ✓               | ✓            |
+| Connection-less `RETURN 1` / `RETURN 1 + 2` (liveness)            | ✓               | ✓            |
 | `IN` list membership `WHERE x IN […]`                              | ✓               | ✓            |
 | `STARTS WITH` / `ENDS WITH` / `CONTAINS`                           | ✓               | ✓            |
 | `collect()` / `collect_list()` (aggregate)                         | ✓               | ✓            |
@@ -61,9 +63,6 @@ supports.
   `MATCH p = (a){1,3}(b) RETURN p` is not yet supported on SQL backends.
   Drop the `p =` binding (or query a Cypher backend) and `RETURN` the
   individual nodes / edges instead.
-- **`RETURN n` on SQL backends returns the node's column values** rather
-  than a single structured node object. For a structured result, use a
-  map projection: `RETURN n {.id, .name} AS info`.
 
 ## Graph Management Query Syntax
 

--- a/pages/memgraph-zero/memgql/use-cases/public-private.mdx
+++ b/pages/memgraph-zero/memgql/use-cases/public-private.mdx
@@ -62,7 +62,7 @@ MemGQL, and a one-shot init container:
 cat > docker-compose.yml << 'EOF'
 services:
   memgql:
-    image: ${MEMGQL_IMAGE:-memgraph/memgql:0.6.1}
+    image: ${MEMGQL_IMAGE:-memgraph/memgql:0.6.2}
     ports:
       - "7688:7688"
     environment:


### PR DESCRIPTION
### Release note

Catches the MemGQL docs up to three merged product PRs:

- `RETURN p` / `RETURN r` now return structured Bolt **Nodes** & **Relationships** on every SQL backend (PostgreSQL, MySQL, DuckDB, ClickHouse, Iceberg, Pinot, Oracle) — a map projection is no longer required.
- **Connection-less liveness queries** (`RETURN 1`, `RETURN 1 + 2 AS x`) now work with no backend configured.
- PostgreSQL `NUMERIC` columns deserialize correctly, `ORDER BY` can reference a `RETURN` alias in cross-backend queries, and delimited (quoted) identifiers parse.

Adds a v0.7.0 changelog section and new feature-matrix rows, and removes the now-obsolete "`RETURN n` returns column values" limitation from the reference and the postgres/mysql/duckdb connector pages.

### Related product PRs

PRs from product repo this doc page is related to:
- https://github.com/memgraph/zero/pull/29
- https://github.com/memgraph/zero/pull/30
- https://github.com/memgraph/zero/pull/24

### Checklist:

- [ ] Add appropriate milestone (current release cycle)
- [ ] Add `bugfix` or `feature` label, based on the product PR type you're documenting
- [ ] Make sure all relevant tech details are documented
    - [ ] Update reference pages
    - [ ] Search for the feature you are working on (mentions) and make updates if needed
    - [ ] Provide a basic example of usage
    - [ ] In case your feature is an Enterprise one, list it under ME page and mark its page with Enterprise.
- [ ] Check all content with Grammarly
- [ ] Perform a self-review of my code
- [ ] The build passes locally
- [ ] My changes generate no new warnings or errors
