### PR TITLE
docs: update SHOW STORAGE INFO global/per-DB split and SHOW LICENSE INFO

### DIFF
--- a/pages/data-migration/migrate-from-neo4j/using-csv-files.mdx
+++ b/pages/data-migration/migrate-from-neo4j/using-csv-files.mdx
@@ -244,10 +244,11 @@ STORAGE MODE IN_MEMORY_ANALYTICAL;
 STORAGE MODE IN_MEMORY_TRANSACTIONAL;
 ```
 
-To check the current storage mode, run: 
+To check the current storage mode, run the following query and read the
+`storage_mode` field: 
 
 ```cypher
-SHOW STORAGE INFO;
+SHOW STORAGE INFO ON CURRENT DATABASE;
 ```
 
 **Change the storage mode to analytical before import.**
@@ -524,10 +525,11 @@ To switch back to the analytical storage mode, run:
 STORAGE MODE IN_MEMORY_TRANSACTIONAL;
 ```
 
-To check the switch was successful, run: 
+To check the switch was successful, run the following query and read the
+`storage_mode` field: 
 
 ```cypher
-SHOW STORAGE INFO;
+SHOW STORAGE INFO ON CURRENT DATABASE;
 ```
 
 You can query the database using the [Cypher query language](/querying), use

--- a/pages/data-migration/migrate-from-rdbms.mdx
+++ b/pages/data-migration/migrate-from-rdbms.mdx
@@ -261,10 +261,11 @@ STORAGE MODE IN_MEMORY_ANALYTICAL;
 STORAGE MODE IN_MEMORY_TRANSACTIONAL;
 ```
 
-To check the current storage mode, run:
+To check the current storage mode, run the following query and read the
+`storage_mode` field:
 
 ```
-SHOW STORAGE INFO;
+SHOW STORAGE INFO ON CURRENT DATABASE;
 ```
 
 **Change the storage mode to analytical before import.**

--- a/pages/database-management/backup-and-restore.mdx
+++ b/pages/database-management/backup-and-restore.mdx
@@ -297,7 +297,7 @@ storage.
 
 When running Memgraph with multi-tenancy, every database other than the default database
 (named `memgraph`) will have its own associated database UUID. Database UUID can be inspected
-by running the `SHOW STORAGE INFO` command and reading the value under the `database_uuid` key.
+by running the `SHOW STORAGE INFO ON CURRENT DATABASE` command (after selecting the database) and reading the value under the `database_uuid` key.
 The default data directory location for a specific database is `/var/lib/memgraph/<database_uuid>/`. 
 The default database `memgraph` does not follow this directory structure and the data files are directly located under `/var/lib/memgraph`.
 

--- a/pages/database-management/enabling-memgraph-enterprise.mdx
+++ b/pages/database-management/enabling-memgraph-enterprise.mdx
@@ -114,10 +114,10 @@ SHOW LICENSE INFO;
 
 Memgraph licenses are issued based on the maximum unique data stored. So, if
 you get a 1TB license, you can store 1TB of data. The enforced value is
-`global_memory_tracked` (visible in [`SHOW STORAGE
+`memory_tracked` (visible in [`SHOW STORAGE
 INFO`](/database-management/server-stats#storage-information)), which
 represents the total RAM allocated and tracked by Memgraph across all databases
-in the instance. When `global_memory_tracked` reaches the license's
+in the instance. When `memory_tracked` reaches the license's
 `memory_limit`, write queries are blocked — only `read` and `delete` queries
 are allowed. That means it is possible to analyze the existing data but new
 data can no longer be added until you upgrade or free storage by deleting some
@@ -130,7 +130,7 @@ one with the furthest expiry, so providing a longer-lived key from any source
 takes effect immediately.
 
 To check the used storage, run `SHOW STORAGE INFO;` and compare the
-`global_memory_tracked` value against the `global_runtime_allocation_limit`.
+`memory_tracked` value against the `memory_limit`.
 
 ## License key expiry
 

--- a/pages/database-management/enabling-memgraph-enterprise.mdx
+++ b/pages/database-management/enabling-memgraph-enterprise.mdx
@@ -53,8 +53,8 @@ memory limit is applied.
 
 | Type           | Feature gating | What the license memory limit gates |
 | -------------- | -------------- | ----------------------------------- |
-| `enterprise`   | Enterprise     | **Total** tracked memory (graph + vector index combined). |
-| `ai_platform`  | Enterprise     | **Graph memory only** (vertices, edges, properties). Vector index memory grows unconstrained, gated only by the system [`--memory-limit`](/configuration/configuration-settings) flag. |
+| `enterprise`   | Enterprise     | **All** tracked memory — graph, query execution, and vector index memory combined. |
+| `ai_platform`  | Enterprise     | **Graph and query memory** (the `query+graph_memory_tracked` arena). Vector index memory grows unconstrained, gated only by the system [`--memory-limit`](/database-management/configuration#other) flag. |
 | `oem`          | OEM-specific   | Reserved for OEM deployments.       |
 
 The license type for the active license is reported by

--- a/pages/database-management/monitoring.mdx
+++ b/pages/database-management/monitoring.mdx
@@ -258,7 +258,7 @@ three different types:
  | average_degree           | Counter   | Average number of relationships of a single node.                                            |
  | disk_usage               | Gauge     | Amount of disk space used by the [data directory](/fundamentals/data-durability) (in bytes). |
  | edge_count               | Counter   | Number of relationships stored in the system.                                                |
- | memory_usage             | Gauge     | Amount of RAM used reported by the OS (in bytes). This corresponds to `memory_res` in `SHOW STORAGE INFO` and reflects the OS-reported resident set size — **not** the value used for [license enforcement](/database-management/enabling-memgraph-enterprise#upgrading-or-downgrading-the-license). To monitor the license-enforced value, check `global_memory_tracked` via [`SHOW STORAGE INFO`](/database-management/server-stats#storage-information). |
+ | memory_usage             | Gauge     | Amount of RAM used reported by the OS (in bytes). This corresponds to `memory_res` in `SHOW STORAGE INFO` and reflects the OS-reported resident set size — **not** the value used for [license enforcement](/database-management/enabling-memgraph-enterprise#upgrading-or-downgrading-the-license). To monitor the license-enforced value, check `memory_tracked` via [`SHOW STORAGE INFO`](/database-management/server-stats#storage-information). |
  | peak_memory_usage        | Gauge     | Peak amount of RAM used reported by the OS (in bytes). Corresponds to `peak_memory_res` in `SHOW STORAGE INFO`.                                       |
  | unreleased_delta_objects | Counter   | Number of unreleased delta objects.                                                          |
  | vertex_count             | Counter   | Number of nodes stored in the system.                                                        |
@@ -297,9 +297,10 @@ three different types:
 
 #### Storage info metrics
 
- | Name                      | Type    | Description                                                        |
- | ------------------------- | ------- | ------------------------------------------------------------------ |
- | ShowStorageInfoOnDatabase | Counter | Number of times the user called `SHOW STORAGE INFO ON DATABASE`.   |
+ | Name                      | Type    | Description                                                                                          |
+ | ------------------------- | ------- | --------------------------------------------------------------------------------------------------- |
+ | ShowStorageInfo           | Counter | Number of times the user called the instance-level (no-database) `SHOW STORAGE INFO`.               |
+ | ShowStorageInfoOnDatabase | Counter | Number of times the user called the per-database `SHOW STORAGE INFO ON [CURRENT] DATABASE` (summed across all databases). |
 
 #### Memory metrics
 

--- a/pages/database-management/server-stats.mdx
+++ b/pages/database-management/server-stats.mdx
@@ -3,6 +3,8 @@ title: Server stats
 description: Monitor the performance and health of your Memgraph server with confidence. Head over to Memgraph's documentation page to gain more insights into server stats.
 ---
 
+import { Callout } from 'nextra/components'
+
 # Server stats
 
 Memgraph supports multiple queries to get information about the instance that is
@@ -18,52 +20,92 @@ SHOW VERSION;
 
 ## Storage information
 
-Running the following query will return certain information about the storage of
-the current instance:
+`SHOW STORAGE INFO` comes in two flavors:
+
+- The unscoped `SHOW STORAGE INFO` query returns **instance-level** (process-wide)
+  metrics only.
+- The `ON DATABASE <name>` and `ON CURRENT DATABASE` variants return
+  **per-database** metrics. See [Per-database storage information](#per-database-storage-information).
+
+<Callout type="warning">
+
+**Breaking change (Memgraph 3.11):** The unscoped `SHOW STORAGE INFO` no longer
+returns database-level metrics. Columns such as `name`, `database_uuid`,
+`vertex_count`, `edge_count`, `average_degree`, `unreleased_delta_objects`,
+`db_memory_tracked`, `db_storage_memory_tracked`, `db_embedding_memory_tracked`
+and `db_query_memory_tracked` are no longer part of its result set. Use
+`SHOW STORAGE INFO ON CURRENT DATABASE` (or `ON DATABASE <name>`) to obtain
+those per-database metrics.
+
+Several instance-level fields were also renamed:
+
+| Old name                          | New name                       |
+|-----------------------------------|--------------------------------|
+| `global_memory_tracked`           | `memory_tracked`               |
+| `global_runtime_allocation_limit` | `memory_limit`                 |
+| `global_license_allocation_limit` | `license_memory_limit`         |
+| `global_disk_usage`               | `disk_usage`                   |
+| `storage_mode`                    | `global_storage_mode`          |
+
+`global_isolation_level` keeps its name but its semantics changed: it now reports
+the startup-default isolation level (the [`--isolation-level`](/database-management/configuration)
+flag) instead of the current database's runtime isolation level. The same applies
+to `global_storage_mode` (renamed from `storage_mode`), which now reflects the
+startup-default [`--storage-mode`](/database-management/configuration). To observe
+runtime changes made via `SET GLOBAL TRANSACTION ISOLATION LEVEL` or
+`STORAGE MODE …`, query `SHOW STORAGE INFO ON CURRENT DATABASE` and read
+`storage_isolation_level` / `storage_mode`.
+
+</Callout>
+
+Running the following query returns instance-level (process-wide) information
+about the storage of the current instance:
 
 ```cypher
 SHOW STORAGE INFO;
 ```
 
-The result will contain the following fields:
+The result contains the following fields, all scoped to the entire Memgraph
+process (across all databases):
 
-> **Instance-wide vs. per-database fields:** The memory-related fields (`memory_res`, `peak_memory_res`, `global_memory_tracked`) are **instance-wide** — they reflect the total memory used by the entire Memgraph process across all databases.
-> The `disk_usage` field, `vertex_count`, `edge_count` and `average_degree` refer to a database (**per-database**), scoped to the database you are currently connected to.
-
-| Field                             | Description                                                                                                                                                                                                                                                                                             |
-|-----------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| name                              | Name of the current database.                                                                                                                                                                                                                                                                           |
-| database_uuid                     | Unique UUID of the database.                                                                                                                                                                                                                                                                            |
-| vertex_count                      | The number of stored nodes (vertices) in the current database.                                                                                                                                                                                                                                          |
-| edge_count                        | The number of stored relationships (edges) in the current database.                                                                                                                                                                                                                                     |
-| average_degree                    | The average number of relationships of a single node in the current database.                                                                                                                                                                                                                           |
-| vm_max_map_count                  | The number of memory-mapped areas that the kernel allows a process to have. If it is unknown, returns -1.<br/>For more info, check out the [virtual memory section](/fundamentals/storage-memory-usage#virtual-memory).                                                                                 |
-| memory_res                        | The non-swapped physical RAM memory used by the whole Memgraph process, as reported by the OS (in B, KiB, MiB, GiB or TiB).                                                                                                                                                                             |
-| peak_memory_res                   | Peak RAM memory usage of the Memgraph process during the whole run (instance-wide).                                                                                                                                                                                                                     |
-| unreleased_delta_objects          | The current number of still allocated objects with the information about the changes that write transactions have made, called Delta objects. Refer to allocation and deallocation of Delta objects [on this page](/fundamentals/storage-memory-usage#in-memory-transactional-storage-mode-default).    |
-| global_disk_usage                 | The amount of disk space used by the data directory (in B, KiB, MiB, GiB or TiB).                                                                                                                                                                                                                       |
-| global_memory_tracked             | The total amount of RAM allocated across the instance and tracked by Memgraph (in B, KiB, MiB, GiB or TiB).<br/>For more info, check out [memory control](/fundamentals/storage-memory-usage).                                                                                                          |
-| global_runtime_allocation_limit   | The instance-level memory limit, taken from the [`--memory-limit`](/database-management/configuration) flag (in B, KiB, MiB, GiB or TiB).                                                                                                                                                               |
-| global_license_allocation_limit   | The memory limit imposed by the active license, or `"unlimited"` if no license is active. With an `enterprise` license this gates total tracked memory; with an `ai_platform` license it gates only graph memory. See [License types](/database-management/enabling-memgraph-enterprise#license-types). |
-| db_memory_tracked                 | RAM tracked for the **current database** (sum of `db_storage_memory_tracked`, `db_embedding_memory_tracked`, and `db_query_memory_tracked`).                                                                                                                                                            |
-| db_storage_memory_tracked         | The portion of `db_memory_tracked` used by graph structures (vertices, edges, properties) of the current database.                                                                                                                                                                                      |
-| db_embedding_memory_tracked       | The portion of `db_memory_tracked` used by vector index embeddings of the current database.                                                                                                                                                                                                             |
-| db_query_memory_tracked           | The portion of `db_memory_tracked` used by query execution against the current database.                                                                                                                                                                                                                |
-| global_isolation_level            | The current `global` isolation level.<br/>For more info, check out [isolation levels](/fundamentals/transactions#isolation-levels).                                                                                                                                                                     |
-| session_isolation_level           | The current `session` isolation level.                                                                                                                                                                                                                                                                  |
-| next_session_isolation_level      | The current `next` isolation level.                                                                                                                                                                                                                                                                     |
-| storage_mode                      | The current storage mode.<br/>For more info, check out [storage modes](/fundamentals/storage-memory-usage#storage-modes).                                                                                                                                                                               |
+| Field                          | Description                                                                                                                                                                                                                                                                                          |
+|--------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| vm_max_map_count               | The number of memory-mapped areas that the kernel allows a process to have. If it is unknown, returns -1.<br/>For more info, check out the [virtual memory section](/fundamentals/storage-memory-usage#virtual-memory).                                                                              |
+| memory_res                     | The non-swapped physical RAM memory (RSS) used by the whole Memgraph process, as reported by the OS (in B, KiB, MiB, GiB or TiB).                                                                                                                                                                   |
+| peak_memory_res                | Peak RAM memory (RSS) usage of the Memgraph process during the whole run.                                                                                                                                                                                                                           |
+| disk_usage                     | The amount of disk space used by the data directory ([`--data-directory`](/database-management/configuration), in B, KiB, MiB, GiB or TiB).                                                                                                                                                          |
+| memory_tracked                 | The total amount of RAM allocated across the instance and tracked by Memgraph (in B, KiB, MiB, GiB or TiB).<br/>For more info, check out [memory control](/fundamentals/storage-memory-usage).                                                                                                       |
+| memory_limit                   | The active instance-level runtime memory limit, taken from the [`--memory-limit`](/database-management/configuration) flag (in B, KiB, MiB, GiB or TiB).                                                                                                                                             |
+| license_memory_limit           | The memory limit imposed by the active license, or `"unlimited"` if no license is active. With an `enterprise` license this gates total tracked memory; with an `ai_platform` license it gates only graph and query memory. See [License types](/database-management/enabling-memgraph-enterprise#license-types). |
+| query+graph_memory_tracked     | The process-wide graph-arena tracked memory. Captures all default `new` allocations across the instance — both graph data and query-execution heap allocations.                                                                                                                                      |
+| vector_index_memory_tracked    | The process-wide memory tracked for vector indices and embeddings across the instance.                                                                                                                                                                                                              |
+| global_isolation_level         | The **startup-default** isolation level (the [`--isolation-level`](/database-management/configuration) flag). It does **not** reflect runtime `SET GLOBAL TRANSACTION ISOLATION LEVEL` changes — read `storage_isolation_level` from the per-database variant for those.<br/>For more info, check out [isolation levels](/fundamentals/transactions#isolation-levels). |
+| session_isolation_level        | The current `session` isolation level.                                                                                                                                                                                                                                                              |
+| next_session_isolation_level   | The current `next` isolation level.                                                                                                                                                                                                                                                                 |
+| global_storage_mode            | The **startup-default** storage mode (the [`--storage-mode`](/database-management/configuration) flag). It does **not** reflect runtime `STORAGE MODE …` changes — read `storage_mode` from the per-database variant for those.<br/>For more info, check out [storage modes](/fundamentals/storage-memory-usage#storage-modes). |
 
 ### Per-database storage information
 
-To get storage information for a specific database, use the `ON DATABASE` variant.
-This is available only in Memgraph Enterprise Edition and requires the `STATS` privilege.
+To get storage information for a specific database, use the `ON CURRENT DATABASE`
+or `ON DATABASE <name>` variant. Both return the same per-database field set.
+
+```cypher
+SHOW STORAGE INFO ON CURRENT DATABASE;
+```
+
+`ON CURRENT DATABASE` targets the database the session is currently using.
 
 ```cypher
 SHOW STORAGE INFO ON DATABASE mydb;
 ```
 
-This variant returns its own field set, scoped to the named database. Process-wide fields such as `vm_max_map_count`, `memory_res`, `peak_memory_res`, and the `global_*` allocation limits are **not** included — those are only available from the unscoped `SHOW STORAGE INFO`.
+`ON DATABASE <name>` targets a named database. Accessing a **non-default**
+database this way requires Memgraph Enterprise Edition; the default database is
+available in all editions. Both variants require the `STATS` privilege.
+
+Process-wide fields such as `vm_max_map_count`, `memory_res`, `peak_memory_res`,
+`memory_tracked` and the license/runtime memory limits are **not** included —
+those are only available from the unscoped `SHOW STORAGE INFO`.
 
 | Field                         | Description                                                                                                                                                  |
 |-------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -116,10 +158,24 @@ SHOW LICENSE INFO;
 | organization_name | Organization name for the enterprise license.                                                        |
 | license_key       | Encoded license key.                                                                                 |
 | is_valid          | Whether the license is currently valid. Uses the same validation logic as enterprise feature checks. |
-| license_type      | `enterprise` / `ai_platform` / `oem`                                                                  |
+| license_type      | `enterprise` / `ai_platform` / `oem` / `oem_community`                                                |
 | valid_until       | Date when the license expires, or `FOREVER` for non-expiring licenses.                               |
-| memory_limit      | The maximum `global_memory_tracked` value allowed by this license (in GiB). When `global_memory_tracked` (from `SHOW STORAGE INFO`) reaches this limit, write queries are blocked. |
+| memory_limit      | The maximum tracked-memory value allowed by this license (in GiB), or `UNLIMITED` if the license sets no limit. When tracked memory reaches this limit, write queries are blocked. |
 | status            | Descriptive status of the license validity.                                                          |
+| memory_limit_policy | A human-readable description of how the license's `memory_limit` is enforced (see the table below). |
+
+The value of `memory_limit_policy` depends on the `license_type` **and** whether
+the license carries a non-zero `memory_limit`:
+
+| License type                       | `memory_limit` | `memory_limit_policy`                                                            |
+|------------------------------------|----------------|----------------------------------------------------------------------------------|
+| `ai_platform`                      | `> 0`          | `"Graph and query memory are limited. Vector index memory is not limited."`      |
+| `enterprise` / `oem` / other       | `> 0`          | `"All memory usage is limited."`                                                 |
+| Any license type (incl. `ai_platform`) | `== 0`     | `"Memory usage is not limited."`                                                 |
+| No / invalid license               | n/a            | `"Memory usage is not limited."`                                                 |
+
+An `ai_platform` license with `memory_limit == 0` reports the unlimited string,
+not the AI Platform policy string.
 
 If no license has been provided, `is_valid` is `false` and `status` reads
 `"You have not provided any license!"`.

--- a/pages/database-management/tenant-profiles.mdx
+++ b/pages/database-management/tenant-profiles.mdx
@@ -242,5 +242,8 @@ SHOW MEMORY INFO;
   storage, embedding, and query execution memory attributed to the database. It
   does not include process-level overhead (e.g., the Memgraph binary itself,
   connection buffers, or the global jemalloc metadata).
-- `SHOW STORAGE INFO ON DATABASE` and `SHOW MEMORY INFO` are enterprise-only
-  queries. They return an error on Community Edition.
+- `SHOW STORAGE INFO ON DATABASE <name>` targeting a **non-default** database
+  requires Memgraph Enterprise Edition (it returns an error on Community Edition).
+  Targeting the default database — and `SHOW STORAGE INFO ON CURRENT DATABASE` —
+  works on all editions. `SHOW MEMORY INFO` is enterprise-only and returns an
+  error on Community Edition.

--- a/pages/database-management/tenant-profiles.mdx
+++ b/pages/database-management/tenant-profiles.mdx
@@ -158,6 +158,9 @@ This returns per-database storage and memory fields, including:
 | `tenant_peak_memory_tracked`  | Peak memory tracked                                            |
 | `tenant_memory_limit`         | Limit from the tenant profile, or `"unlimited"`                |
 
+For the complete per-database field set, see
+[Per-database storage information](/database-management/server-stats#per-database-storage-information).
+
 ## What happens when a limit is hit
 
 - Any query that needs to allocate memory beyond the limit is **rejected**.

--- a/pages/fundamentals/storage-memory-usage.mdx
+++ b/pages/fundamentals/storage-memory-usage.mdx
@@ -808,13 +808,17 @@ Storage, query execution, and vector index allocations are all attributed to the
 database that originated them, giving a complete picture of per-database memory
 usage.
 
-Per-database tracking enables several new queries:
+Per-database storage and memory metrics are exposed through these queries
+(`SHOW STORAGE INFO ON CURRENT DATABASE` is new in Memgraph 3.11; the other two
+already existed):
 
 ```cypher
 SHOW STORAGE INFO ON CURRENT DATABASE;
 SHOW STORAGE INFO ON DATABASE mydb;
 SHOW MEMORY INFO;
 ```
+
+Their editions and privileges differ — see the availability note below.
 
 `ON CURRENT DATABASE` targets the session's currently-selected database, while
 `ON DATABASE <name>` targets a named database. Both return the full per-database

--- a/pages/fundamentals/storage-memory-usage.mdx
+++ b/pages/fundamentals/storage-memory-usage.mdx
@@ -97,11 +97,16 @@ storage mode even upon restart.
 
 ### Check storage mode
 
-You can check the current storage mode using the following query:
+You can check the current (runtime) storage mode of the database you are
+connected to using the following query and reading the `storage_mode` field:
 
 ```cypher
-SHOW STORAGE INFO;
+SHOW STORAGE INFO ON CURRENT DATABASE;
 ```
+
+The unscoped `SHOW STORAGE INFO` only reports `global_storage_mode`, which is the
+**startup-default** storage mode (the [`--storage-mode`](/database-management/configuration)
+flag) and does **not** reflect runtime `STORAGE MODE …` changes.
 
 ### In-memory transactional storage mode (default)
 
@@ -683,7 +688,7 @@ memory limit is exceeded, only the queries that don't require additional memory
 are allowed. If the memory limit is exceeded while a query is running, the query
 is aborted and its transaction becomes invalid.
 
-The effective allocation limit (shown as `global_runtime_allocation_limit` in
+The effective allocation limit (shown as `memory_limit` in
 `SHOW STORAGE INFO`) is set to the **lower** of the `--memory-limit`
 configuration flag and the [Enterprise license memory
 limit](/database-management/enabling-memgraph-enterprise#upgrading-or-downgrading-the-license).
@@ -757,9 +762,8 @@ CALL example.procedure(arg1, arg2, ...) PROCEDURE MEMORY UNLIMITED YIELD result;
 
 ### Inspect memory usage
 
-Run the following query to get information about the currently
-used storage mode, memory usage, disk usage, allocated memory and the allocation
-limit:
+Run the following query to get instance-level (process-wide) information about
+memory usage, disk usage, tracked memory and the allocation limit:
 
 ```plaintext
 SHOW STORAGE INFO;
@@ -769,26 +773,26 @@ SHOW STORAGE INFO;
 +--------------------------------+----------------------------------------+
 | storage info                   | value                                  |
 +--------------------------------+----------------------------------------+
-| "name"                         | "memgraph"                             |
-| "database_uuid"                | "99f743e8-5b98-4b78-8384-f96862b7f01b" |
-| "vertex_count"                 | 0                                      |
-| "edge_count"                   | 0                                      |
-| "average_degree"               | 0                                      |
 | "vm_max_map_count"             | 453125                                 |
 | "memory_res"                   | "43.16MiB"                             |
 | "peak_memory_res"              | "43.16MiB"                             |
-| "unreleased_delta_objects"     | 0                                      |
 | "disk_usage"                   | "104.46KiB"                            |
 | "memory_tracked"               | "8.52MiB"                              |
-| "graph_memory_tracked"         | "6.14MiB"                              |
+| "memory_limit"                 | "58.55GiB"                             |
+| "license_memory_limit"         | "unlimited"                            |
+| "query+graph_memory_tracked"   | "6.14MiB"                              |
 | "vector_index_memory_tracked"  | "2.38MiB"                              |
-| "allocation_limit"             | "58.55GiB"                             |
 | "global_isolation_level"       | "SNAPSHOT_ISOLATION"                   |
 | "session_isolation_level"      | ""                                     |
 | "next_session_isolation_level" | ""                                     |
-| "storage_mode"                 | "IN_MEMORY_TRANSACTIONAL"              |
+| "global_storage_mode"          | "IN_MEMORY_TRANSACTIONAL"              |
 +--------------------------------+----------------------------------------+
 ```
+
+The unscoped `SHOW STORAGE INFO` returns only instance-level fields. For
+per-database metrics (such as `vertex_count`, `edge_count`, the live
+`storage_mode` and per-database memory trackers), use
+`SHOW STORAGE INFO ON CURRENT DATABASE` or `SHOW STORAGE INFO ON DATABASE <name>`.
 
 Find out more about `SHOW STORAGE INFO` query on [Server
 stats](/database-management/server-stats).
@@ -807,11 +811,14 @@ usage.
 Per-database tracking enables several new queries:
 
 ```cypher
+SHOW STORAGE INFO ON CURRENT DATABASE;
 SHOW STORAGE INFO ON DATABASE mydb;
 SHOW MEMORY INFO;
 ```
 
-`SHOW STORAGE INFO ON DATABASE` returns per-database storage and memory fields:
+`ON CURRENT DATABASE` targets the session's currently-selected database, while
+`ON DATABASE <name>` targets a named database. Both return per-database storage
+and memory fields:
 
 | Field                         | Description                                               |
 |-------------------------------|-----------------------------------------------------------|
@@ -831,9 +838,12 @@ SHOW MEMORY INFO;
 | `profile`               | Tenant profile name, or `null`                              |
 | `tenant_memory_limit`   | Configured limit, or `"unlimited"`                          |
 
-`SHOW STORAGE INFO ON DATABASE` requires the `STATS` privilege.
-`SHOW MEMORY INFO` requires no privilege beyond a valid Enterprise license.
-Both queries are available only in the Memgraph Enterprise Edition.
+Both per-database `SHOW STORAGE INFO` variants require the `STATS` privilege.
+`SHOW STORAGE INFO ON CURRENT DATABASE` and `SHOW STORAGE INFO ON DATABASE` for
+the **default** database work in all editions; targeting a **non-default**
+database via `ON DATABASE <name>` requires the Memgraph Enterprise Edition.
+`SHOW MEMORY INFO` requires no privilege beyond a valid Enterprise license and is
+available only in the Memgraph Enterprise Edition.
 
 ### How the memory fields relate
 
@@ -852,12 +862,11 @@ Per-database fields also include:
   tenant_memory_limit          cap from tenant profile, or "unlimited"
 
 Global relationship:
-  graph_memory_tracked       (per-DB)  ──sum──▶  graph_memory_tracked       (global)
+  graph_memory_tracked       (per-DB)  ──┐
+  query_memory_tracked        (per-DB)  ──┴▶  query+graph_memory_tracked (global)
+                               (the global graph arena tracks all default-new
+                               allocations — both graph data and query heap)
   vector_index_memory_tracked (per-DB)  ──sum──▶  vector_index_memory_tracked (global)
-  query_memory_tracked        (per-DB)  counts only against the per-DB total;
-                               at the global level it is accounted via
-                               the global graph tracker's arena hooks,
-                               not double-counted under graph or vector.
 ```
 
 <Callout type="info">

--- a/pages/fundamentals/storage-memory-usage.mdx
+++ b/pages/fundamentals/storage-memory-usage.mdx
@@ -817,8 +817,9 @@ SHOW MEMORY INFO;
 ```
 
 `ON CURRENT DATABASE` targets the session's currently-selected database, while
-`ON DATABASE <name>` targets a named database. Both return per-database storage
-and memory fields:
+`ON DATABASE <name>` targets a named database. Both return the full per-database
+field set (storage stats, isolation level, storage mode and the memory trackers).
+The memory-related fields are:
 
 | Field                         | Description                                               |
 |-------------------------------|-----------------------------------------------------------|
@@ -828,6 +829,11 @@ and memory fields:
 | `tenant_memory_tracked`       | Current tracked memory for the database                   |
 | `tenant_peak_memory_tracked`  | Peak memory tracked                                       |
 | `tenant_memory_limit`         | Limit from the tenant profile, or `"unlimited"`           |
+
+For the complete list of per-database fields (including `name`, `database_uuid`,
+`storage_mode`, `vertex_count`, `edge_count`, `average_degree`,
+`unreleased_delta_objects`, `disk_usage` and `storage_isolation_level`), see
+[Per-database storage information](/database-management/server-stats#per-database-storage-information).
 
 `SHOW MEMORY INFO` lists all databases with their profile and current usage:
 

--- a/pages/fundamentals/transactions.mdx
+++ b/pages/fundamentals/transactions.mdx
@@ -379,11 +379,17 @@ In terms of Adya's isolation levels, Memgraph supports: PL-1, PL-MSR (Monotonic 
 
 You can find tests for these phenomena [here](https://github.com/memgraph/memgraph/blob/master/tests/manual/test_isolation_level.py).
 
-To check the current isolation level run the following query:
+To check the current (runtime) isolation level of the database you are connected
+to, run the following query and read the `storage_isolation_level` field:
 
 ```cypher
-SHOW STORAGE INFO;
+SHOW STORAGE INFO ON CURRENT DATABASE;
 ```
+
+The unscoped `SHOW STORAGE INFO` only reports `global_isolation_level`, which is
+the **startup-default** isolation level (the [`--isolation-level`](/database-management/configuration)
+flag) and does **not** reflect runtime `SET GLOBAL TRANSACTION ISOLATION LEVEL`
+changes.
 
 `IN_MEMORY_ANALYTICAL` storage modes offers no isolation levels and no ACID
 guarantees. Multiple transactions can write data to Memgraph simultaneously. One

--- a/pages/help-center/faq.mdx
+++ b/pages/help-center/faq.mdx
@@ -324,9 +324,12 @@ replication is a bottleneck for highly parallel workflows.
 
 ### How can I check storage information?
 
-You can check storage information by running the [SHOW STORAGE
-INFO;](/database-management/server-stats) that will provide information about the
-number of stored nodes and relationships and memory usage. 
+You can check storage information by running [SHOW STORAGE
+INFO;](/database-management/server-stats), which returns instance-level
+(process-wide) metrics such as resident and tracked memory, disk usage and the
+configured memory limits. To get per-database metrics such as the number of
+stored nodes and relationships, run `SHOW STORAGE INFO ON CURRENT DATABASE` (or
+`SHOW STORAGE INFO ON DATABASE <name>`).
 
 ### Where does Memgraph save or preview logs?
 

--- a/pages/querying/vector-search.mdx
+++ b/pages/querying/vector-search.mdx
@@ -260,15 +260,17 @@ Memgraph tracks vector index memory separately from the rest of the graph data. 
 SHOW STORAGE INFO;
 ```
 
-Two fields are relevant:
+Two instance-level fields are relevant:
 
-- `graph_memory_tracked` — memory used by graph structures (vertices, edges, properties).
-- `vector_index_memory_tracked` — memory used by vector index embeddings stored in the index backend.
+- `query+graph_memory_tracked` — process-wide memory used by graph structures (vertices, edges, properties) and query execution.
+- `vector_index_memory_tracked` — process-wide memory used by vector index embeddings stored in the index backend.
 
 Together, these two fields sum to `memory_tracked` (the total tracked allocation). The instance-level `--memory-limit` applies to the combined total: if inserting a vector would exceed the limit, Memgraph throws a `Memory limit exceeded` error.
 
+To inspect the same split for a single database, use `SHOW STORAGE INFO ON CURRENT DATABASE` (or `ON DATABASE <name>`) and read its per-database `graph_memory_tracked`, `query_memory_tracked` and `vector_index_memory_tracked` fields.
+
 <Callout type="info">
-With the [AI Platform license](/database-management/enabling-memgraph-enterprise#license-types), the license-imposed memory limit gates only `graph_memory_tracked`. Vector index memory grows up to the system `--memory-limit`, so embedding storage does not consume the licensed graph capacity.
+With the [AI Platform license](/database-management/enabling-memgraph-enterprise#license-types), the license-imposed memory limit gates only graph and query memory (`query+graph_memory_tracked`). Vector index memory grows up to the system `--memory-limit`, so embedding storage does not consume the licensed graph capacity.
 </Callout>
 
 <Callout type="warning">

--- a/pages/release-notes.mdx
+++ b/pages/release-notes.mdx
@@ -186,9 +186,11 @@ guide.
   without calculating elapsed time manually.
   [#4136](https://github.com/memgraph/memgraph/pull/4136)
 - Added `SHOW STORAGE INFO ON CURRENT DATABASE` for per-database storage and
-  memory metrics without naming the database explicitly. `SHOW LICENSE INFO` now
-  includes a `memory_limit_policy` row that explains how memory limits apply for
-  your license tier.
+  memory metrics without naming the database explicitly. `SHOW STORAGE INFO ON
+  DATABASE <name>` (and `ON CURRENT DATABASE`) now work on Community Edition for
+  the default database; only non-default databases still require Memgraph
+  Enterprise. `SHOW LICENSE INFO` now includes a `memory_limit_policy` row that
+  explains how memory limits apply for your license tier.
   [#4155](https://github.com/memgraph/memgraph/pull/4155)
 - The OEM license tier is now split into `OEM` (enterprise-equivalent) and
   `OEM_COMMUNITY` (community-tier tracking). Existing OEM license keys continue


### PR DESCRIPTION
### Release note

Reflect show_storage_info_disk_fix changes:
- Rewrite bare SHOW STORAGE INFO to instance-only schema; add breaking-change callout (field renames + global_isolation_level/global_storage_mode now report startup defaults).
- Document SHOW STORAGE INFO ON CURRENT DATABASE and correct enterprise gating (non-default DB only).
- Add memory_limit_policy row + evaluation matrix to SHOW LICENSE INFO.
- Add ShowStorageInfo global metric to monitoring.
- Fix stale field references across storage-memory-usage, transactions, vector-search, enabling-memgraph-enterprise, backup-and-restore, and migration pages.

### Related product PRs

PRs from product repo this doc page is related to: 
https://github.com/memgraph/memgraph/pull/4155

### Checklist:

- [x] Add appropriate milestone (current release cycle)
- [x] Add `bugfix` or `feature` label, based on the product PR type you're documenting
- [x] Make sure all relevant tech details are documented
    - [x] Update reference pages (e.g. [clauses](https://memgraph.com/docs/querying/clauses), [functions](https://memgraph.com/docs/querying/functions), [flags](https://memgraph.com/docs/database-management/configuration#list-of-configuration-flags), [experimental](https://memgraph.com/docs/database-management/experimental-features), [monitoring](https://memgraph.com/docs/database-management/monitoring), [Cypher differences](https://memgraph.com/docs/querying/differences-in-cypher-implementations))
    - [x] Search for the feature you are working on (mentions) and make updates if needed
    - [x] Provide a basic example of usage
    - [x] In case your feature is an Enterprise one, list it under [ME page](https://memgraph.com/docs/database-management/enabling-memgraph-enterprise) and mark its page with Enterprise ([example](https://memgraph.com/docs/database-management/authentication-and-authorization/role-based-access-control)).
- [ ] Check all content with Grammarly
- [ ] Perform a self-review of my code
- [ ] The build passes locally
- [ ] My changes generate no new warnings or errors