### PR TITLE
Stripped relwithdebinfo build

### DIFF
--- a/pages/database-management/debugging.mdx
+++ b/pages/database-management/debugging.mdx
@@ -17,25 +17,70 @@ replicate.
 To help with this, our containers come equipped with user-friendly debugging
 tools, empowering you to identify and report problems more effectively.
 
-## Chose the right debug image
+## Choose the right debug image or package
 
-Memgraph provides Docker images built in `RelWithDebInfo` mode, including tools
-like `perf`, `gdb` and `pgrep`. This image is about 10% slower but enables
-detailed debugging. 
+Memgraph's production Docker images and Linux packages are built in stripped
+`RelWithDebInfo` mode. These builds are performance-equivalent to the former
+`Release` builds, while their debug symbols are shipped separately so you only
+download them when you actually need to debug.
 
-To pull a debug image:
+Debug symbols are distributed in two ways:
+
+- **Docker**: dedicated `-relwithdebinfo` images bundle the debug symbols together
+  with debugging tools like `perf`, `gdb` and `pgrep`. Because the debug image
+  reuses the same binary as the production image, it runs at essentially the same
+  performance — the symbols are simply added on top.
+- **Native (Linux package) installations**: a separate `memgraph-debuginfo`
+  sidecar package (and `memgraph-mage-debuginfo` for MAGE) ships the debug symbols
+  for the matching main package. See [Installing debug symbols on native
+  installations](#installing-debug-symbols-on-native-installations) below.
+
+To pull a debug Docker image:
 
 ```
-docker image pull <memgraph_version>-relwithdebinfo
+docker image pull memgraph/memgraph:<memgraph_version>-relwithdebinfo
 ```
 For Memgraph MAGE:
 
 ```bash
-docker image pull <MAGE_version>-memgraph-<memgraph_version>-relwithdebinfo
+docker image pull memgraph/memgraph-mage:<MAGE_version>-relwithdebinfo
 ```
 
 All the images in the `RelWithDebInfo` build mode have the suffix
 `-relwithdebinfo`.
+
+## Installing debug symbols on native installations
+
+If you installed Memgraph from a Linux package (`.deb` or `.rpm`) instead of
+Docker, the default package contains a stripped binary. To debug it with `gdb`, or
+to analyze a core dump with full symbol information, install the matching
+`memgraph-debuginfo` sidecar package next to the one you already have. The
+debuginfo package is published alongside the main package for the same version and
+architecture.
+
+For Debian/Ubuntu:
+
+```bash
+sudo dpkg -i memgraph-debuginfo_<version>-1_amd64.deb
+```
+
+For RPM-based distributions (CentOS, Fedora, RHEL, Rocky):
+
+```bash
+sudo rpm -i memgraph-debuginfo-<version>_1-1.x86_64.rpm
+```
+
+If you also use MAGE, install the `memgraph-mage-debuginfo` package in the same
+way to get debug symbols for the MAGE query modules.
+
+The debug symbols are installed side by side with the binaries they originate
+from — for example, `memgraph.debug` is placed next to the `memgraph` binary in
+`/usr/lib/memgraph`, and the MAGE query module sidecars are placed next to their
+modules. Each binary embeds a `.gnu_debuglink` pointing at its sidecar, so `gdb`
+and `lldb` pick the symbols up automatically — no extra configuration required.
+You can then attach to a running instance or load a core dump exactly as described
+in the [Using GDB](#using-gdb) and [Generating a core
+dump](#generating-core-dump-via-docker) sections.
 
 ## Run Memgraph in debug mode
 

--- a/pages/database-management/debugging.mdx
+++ b/pages/database-management/debugging.mdx
@@ -19,10 +19,22 @@ tools, empowering you to identify and report problems more effectively.
 
 ## Choose the right debug image or package
 
-Memgraph's production Docker images and Linux packages are built in stripped
-`RelWithDebInfo` mode. These builds are performance-equivalent to the former
-`Release` builds, while their debug symbols are shipped separately so you only
-download them when you actually need to debug.
+<Callout type="info">
+
+**What changed in version 3.11**
+
+Before version 3.11, Memgraph shipped two separate builds: a `Release` build (fast,
+no debug symbols) and a `RelWithDebInfo` build (with debug symbols, slightly
+slower). You had to choose one up front.
+
+As of version 3.11, there is a single stripped `RelWithDebInfo` build that is
+performance-equivalent to the old `Release` build, and its debug symbols are
+shipped separately. For Docker this is the `-relwithdebinfo` image; for Linux
+packages it is the `memgraph-debuginfo` sidecar package. You install the symbols
+on top of the same binary only when you need them, so there is no longer a
+performance trade-off between the production and debug variants.
+
+</Callout>
 
 Debug symbols are distributed in two ways:
 

--- a/pages/getting-started/install-memgraph/direct-download-links.mdx
+++ b/pages/getting-started/install-memgraph/direct-download-links.mdx
@@ -2,6 +2,7 @@
 title: Memgraph direct download links
 description: Access Memgraph direct download links all in a single page. Our documentation is committed to ensuring a smooth developer experience. 
 ---
+import { Callout } from 'nextra/components'
 
 # Memgraph direct download links
 
@@ -9,67 +10,91 @@ You can download all of the Memgraph database packages from the [Memgraph
 Download Hub](https://memgraph.com/download/). If you need direct links for the
 latest version of Memgraph database, take a look at the list below.
 
+<Callout type="info">
+
+As of version 3.11, the Linux packages (`.deb` and `.rpm`) are built in stripped
+`RelWithDebInfo` mode and are performance-equivalent to the former `Release`
+builds. Their debug symbols are shipped separately as `memgraph-debuginfo` sidecar
+packages, which you only need when debugging with `gdb` or analyzing a core dump.
+See [Debugging Memgraph](/database-management/debugging) for details.
+
+</Callout>
+
 ## Docker
-- [https://download.memgraph.com/memgraph/v3.10.0/docker/memgraph-3.10.0-docker.tar.gz](https://download.memgraph.com/memgraph/v3.10.0/docker/memgraph-3.10.0-docker.tar.gz)
-- [https://download.memgraph.com/memgraph/v3.10.0/docker-aarch64/memgraph-3.10.0-docker.tar.gz](https://download.memgraph.com/memgraph/v3.10.0/docker-aarch64/memgraph-3.10.0-docker.tar.gz)
-- [https://download.memgraph.com/memgraph/v3.10.0/docker-relwithdebinfo/memgraph-3.10.0-relwithdebinfo-docker.tar.gz](https://download.memgraph.com/memgraph/v3.10.0/docker-relwithdebinfo/memgraph-3.10.0-relwithdebinfo-docker.tar.gz)
-- [https://download.memgraph.com/memgraph/v3.10.0/docker-aarch64-relwithdebinfo/memgraph-3.10.0-relwithdebinfo-docker.tar.gz](https://download.memgraph.com/memgraph/v3.10.0/docker-aarch64-relwithdebinfo/memgraph-3.10.0-relwithdebinfo-docker.tar.gz)
-- [https://download.memgraph.com/memgraph/v3.10.0/docker-malloc-relwithdebinfo/memgraph-3.10.0-relwithdebinfo-malloc-docker.tar.gz](https://download.memgraph.com/memgraph/v3.10.0/docker-malloc-relwithdebinfo/memgraph-3.10.0-relwithdebinfo-malloc-docker.tar.gz)
-- [https://download.memgraph.com/memgraph/v3.10.0/docker-malloc-aarch64-relwithdebinfo/memgraph-3.10.0-relwithdebinfo-malloc-docker.tar.gz](https://download.memgraph.com/memgraph/v3.10.0/docker-malloc-aarch64-relwithdebinfo/memgraph-3.10.0-relwithdebinfo-malloc-docker.tar.gz)
+- [https://download.memgraph.com/memgraph/v3.11.0/docker/memgraph-3.11.0-docker.tar.gz](https://download.memgraph.com/memgraph/v3.11.0/docker/memgraph-3.11.0-docker.tar.gz)
+- [https://download.memgraph.com/memgraph/v3.11.0/docker-aarch64/memgraph-3.11.0-docker.tar.gz](https://download.memgraph.com/memgraph/v3.11.0/docker-aarch64/memgraph-3.11.0-docker.tar.gz)
+- [https://download.memgraph.com/memgraph/v3.11.0/docker-relwithdebinfo/memgraph-3.11.0-relwithdebinfo-docker.tar.gz](https://download.memgraph.com/memgraph/v3.11.0/docker-relwithdebinfo/memgraph-3.11.0-relwithdebinfo-docker.tar.gz)
+- [https://download.memgraph.com/memgraph/v3.11.0/docker-aarch64-relwithdebinfo/memgraph-3.11.0-relwithdebinfo-docker.tar.gz](https://download.memgraph.com/memgraph/v3.11.0/docker-aarch64-relwithdebinfo/memgraph-3.11.0-relwithdebinfo-docker.tar.gz)
+- [https://download.memgraph.com/memgraph/v3.11.0/docker-malloc-relwithdebinfo/memgraph-3.11.0-relwithdebinfo-malloc-docker.tar.gz](https://download.memgraph.com/memgraph/v3.11.0/docker-malloc-relwithdebinfo/memgraph-3.11.0-relwithdebinfo-malloc-docker.tar.gz)
+- [https://download.memgraph.com/memgraph/v3.11.0/docker-malloc-aarch64-relwithdebinfo/memgraph-3.11.0-relwithdebinfo-malloc-docker.tar.gz](https://download.memgraph.com/memgraph/v3.11.0/docker-malloc-aarch64-relwithdebinfo/memgraph-3.11.0-relwithdebinfo-malloc-docker.tar.gz)
 
 ## Linux
 
-Memgraph can be run on the Linux distributions listed below.
+Memgraph can be run on the Linux distributions listed below. Each main package has
+a matching `memgraph-debuginfo` package containing its debug symbols.
 
 ### CentOS
-- [https://download.memgraph.com/memgraph/v3.10.0/centos-9/memgraph-3.10.0_1-1.x86_64.rpm](https://download.memgraph.com/memgraph/v3.10.0/centos-9/memgraph-3.10.0_1-1.x86_64.rpm)
-- [https://download.memgraph.com/memgraph/v3.10.0/centos-10/memgraph-3.10.0_1-1.x86_64.rpm](https://download.memgraph.com/memgraph/v3.10.0/centos-10/memgraph-3.10.0_1-1.x86_64.rpm)
+- [https://download.memgraph.com/memgraph/v3.11.0/centos-9/memgraph-3.11.0_1-1.x86_64.rpm](https://download.memgraph.com/memgraph/v3.11.0/centos-9/memgraph-3.11.0_1-1.x86_64.rpm)
+- [https://download.memgraph.com/memgraph/v3.11.0/centos-9/memgraph-debuginfo-3.11.0_1-1.x86_64.rpm](https://download.memgraph.com/memgraph/v3.11.0/centos-9/memgraph-debuginfo-3.11.0_1-1.x86_64.rpm)
+- [https://download.memgraph.com/memgraph/v3.11.0/centos-10/memgraph-3.11.0_1-1.x86_64.rpm](https://download.memgraph.com/memgraph/v3.11.0/centos-10/memgraph-3.11.0_1-1.x86_64.rpm)
+- [https://download.memgraph.com/memgraph/v3.11.0/centos-10/memgraph-debuginfo-3.11.0_1-1.x86_64.rpm](https://download.memgraph.com/memgraph/v3.11.0/centos-10/memgraph-debuginfo-3.11.0_1-1.x86_64.rpm)
 
 ### Debian
-- [https://download.memgraph.com/memgraph/v3.10.0/debian-12/memgraph_3.10.0-1_amd64.deb](https://download.memgraph.com/memgraph/v3.10.0/debian-12/memgraph_3.10.0-1_amd64.deb)
-- [https://download.memgraph.com/memgraph/v3.10.0/debian-12-aarch64/memgraph_3.10.0-1_arm64.deb](https://download.memgraph.com/memgraph/v3.10.0/debian-12-aarch64/memgraph_3.10.0-1_arm64.deb)
-- [https://download.memgraph.com/memgraph/v3.10.0/debian-13/memgraph_3.10.0-1_amd64.deb](https://download.memgraph.com/memgraph/v3.10.0/debian-13/memgraph_3.10.0-1_amd64.deb)
-- [https://download.memgraph.com/memgraph/v3.10.0/debian-13-aarch64/memgraph_3.10.0-1_arm64.deb](https://download.memgraph.com/memgraph/v3.10.0/debian-13-aarch64/memgraph_3.10.0-1_arm64.deb)
+- [https://download.memgraph.com/memgraph/v3.11.0/debian-12/memgraph_3.11.0-1_amd64.deb](https://download.memgraph.com/memgraph/v3.11.0/debian-12/memgraph_3.11.0-1_amd64.deb)
+- [https://download.memgraph.com/memgraph/v3.11.0/debian-12/memgraph-debuginfo_3.11.0-1_amd64.deb](https://download.memgraph.com/memgraph/v3.11.0/debian-12/memgraph-debuginfo_3.11.0-1_amd64.deb)
+- [https://download.memgraph.com/memgraph/v3.11.0/debian-12-aarch64/memgraph_3.11.0-1_arm64.deb](https://download.memgraph.com/memgraph/v3.11.0/debian-12-aarch64/memgraph_3.11.0-1_arm64.deb)
+- [https://download.memgraph.com/memgraph/v3.11.0/debian-12-aarch64/memgraph-debuginfo_3.11.0-1_arm64.deb](https://download.memgraph.com/memgraph/v3.11.0/debian-12-aarch64/memgraph-debuginfo_3.11.0-1_arm64.deb)
+- [https://download.memgraph.com/memgraph/v3.11.0/debian-13/memgraph_3.11.0-1_amd64.deb](https://download.memgraph.com/memgraph/v3.11.0/debian-13/memgraph_3.11.0-1_amd64.deb)
+- [https://download.memgraph.com/memgraph/v3.11.0/debian-13/memgraph-debuginfo_3.11.0-1_amd64.deb](https://download.memgraph.com/memgraph/v3.11.0/debian-13/memgraph-debuginfo_3.11.0-1_amd64.deb)
+- [https://download.memgraph.com/memgraph/v3.11.0/debian-13-aarch64/memgraph_3.11.0-1_arm64.deb](https://download.memgraph.com/memgraph/v3.11.0/debian-13-aarch64/memgraph_3.11.0-1_arm64.deb)
+- [https://download.memgraph.com/memgraph/v3.11.0/debian-13-aarch64/memgraph-debuginfo_3.11.0-1_arm64.deb](https://download.memgraph.com/memgraph/v3.11.0/debian-13-aarch64/memgraph-debuginfo_3.11.0-1_arm64.deb)
 
 ### Fedora
-- [https://download.memgraph.com/memgraph/v3.10.0/fedora-42/memgraph-3.10.0_1-1.x86_64.rpm](https://download.memgraph.com/memgraph/v3.10.0/fedora-42/memgraph-3.10.0_1-1.x86_64.rpm)
-- [https://download.memgraph.com/memgraph/v3.10.0/fedora-42-aarch64/memgraph-3.10.0_1-1.aarch64.rpm](https://download.memgraph.com/memgraph/v3.10.0/fedora-42-aarch64/memgraph-3.10.0_1-1.aarch64.rpm)
+- [https://download.memgraph.com/memgraph/v3.11.0/fedora-42/memgraph-3.11.0_1-1.x86_64.rpm](https://download.memgraph.com/memgraph/v3.11.0/fedora-42/memgraph-3.11.0_1-1.x86_64.rpm)
+- [https://download.memgraph.com/memgraph/v3.11.0/fedora-42/memgraph-debuginfo-3.11.0_1-1.x86_64.rpm](https://download.memgraph.com/memgraph/v3.11.0/fedora-42/memgraph-debuginfo-3.11.0_1-1.x86_64.rpm)
+- [https://download.memgraph.com/memgraph/v3.11.0/fedora-42-aarch64/memgraph-3.11.0_1-1.aarch64.rpm](https://download.memgraph.com/memgraph/v3.11.0/fedora-42-aarch64/memgraph-3.11.0_1-1.aarch64.rpm)
+- [https://download.memgraph.com/memgraph/v3.11.0/fedora-42-aarch64/memgraph-debuginfo-3.11.0_1-1.aarch64.rpm](https://download.memgraph.com/memgraph/v3.11.0/fedora-42-aarch64/memgraph-debuginfo-3.11.0_1-1.aarch64.rpm)
 
 ### Rocky
-- [https://download.memgraph.com/memgraph/v3.10.0/rocky-10/memgraph-3.10.0_1-1.x86_64.rpm](https://download.memgraph.com/memgraph/v3.10.0/rocky-10/memgraph-3.10.0_1-1.x86_64.rpm)
+- [https://download.memgraph.com/memgraph/v3.11.0/rocky-10/memgraph-3.11.0_1-1.x86_64.rpm](https://download.memgraph.com/memgraph/v3.11.0/rocky-10/memgraph-3.11.0_1-1.x86_64.rpm)
+- [https://download.memgraph.com/memgraph/v3.11.0/rocky-10/memgraph-debuginfo-3.11.0_1-1.x86_64.rpm](https://download.memgraph.com/memgraph/v3.11.0/rocky-10/memgraph-debuginfo-3.11.0_1-1.x86_64.rpm)
 
 ### Red Hat
-- [https://download.memgraph.com/memgraph/v3.10.0/centos-9/memgraph-3.10.0_1-1.x86_64.rpm](https://download.memgraph.com/memgraph/v3.10.0/centos-9/memgraph-3.10.0_1-1.x86_64.rpm)
+- [https://download.memgraph.com/memgraph/v3.11.0/centos-9/memgraph-3.11.0_1-1.x86_64.rpm](https://download.memgraph.com/memgraph/v3.11.0/centos-9/memgraph-3.11.0_1-1.x86_64.rpm)
+- [https://download.memgraph.com/memgraph/v3.11.0/centos-9/memgraph-debuginfo-3.11.0_1-1.x86_64.rpm](https://download.memgraph.com/memgraph/v3.11.0/centos-9/memgraph-debuginfo-3.11.0_1-1.x86_64.rpm)
 
 ### Ubuntu
-- [https://download.memgraph.com/memgraph/v3.10.0/ubuntu-22.04/memgraph_3.10.0-1_amd64.deb](https://download.memgraph.com/memgraph/v3.10.0/ubuntu-22.04/memgraph_3.10.0-1_amd64.deb)
-- [https://download.memgraph.com/memgraph/v3.10.0/ubuntu-24.04/memgraph_3.10.0-1_amd64.deb](https://download.memgraph.com/memgraph/v3.10.0/ubuntu-24.04/memgraph_3.10.0-1_amd64.deb)
-- [https://download.memgraph.com/memgraph/v3.10.0/ubuntu-24.04-relwithdebinfo/memgraph_3.10.0-1_amd64.deb](https://download.memgraph.com/memgraph/v3.10.0/ubuntu-24.04-relwithdebinfo/memgraph_3.10.0-1_amd64.deb)
-- [https://download.memgraph.com/memgraph/v3.10.0/ubuntu-24.04-aarch64/memgraph_3.10.0-1_arm64.deb](https://download.memgraph.com/memgraph/v3.10.0/ubuntu-24.04-aarch64/memgraph_3.10.0-1_arm64.deb)
-- [https://download.memgraph.com/memgraph/v3.10.0/ubuntu-24.04-aarch64-relwithdebinfo/memgraph_3.10.0-1_arm64.deb](https://download.memgraph.com/memgraph/v3.10.0/ubuntu-24.04-aarch64-relwithdebinfo/memgraph_3.10.0-1_arm64.deb)
+- [https://download.memgraph.com/memgraph/v3.11.0/ubuntu-22.04/memgraph_3.11.0-1_amd64.deb](https://download.memgraph.com/memgraph/v3.11.0/ubuntu-22.04/memgraph_3.11.0-1_amd64.deb)
+- [https://download.memgraph.com/memgraph/v3.11.0/ubuntu-22.04/memgraph-debuginfo_3.11.0-1_amd64.deb](https://download.memgraph.com/memgraph/v3.11.0/ubuntu-22.04/memgraph-debuginfo_3.11.0-1_amd64.deb)
+- [https://download.memgraph.com/memgraph/v3.11.0/ubuntu-24.04/memgraph_3.11.0-1_amd64.deb](https://download.memgraph.com/memgraph/v3.11.0/ubuntu-24.04/memgraph_3.11.0-1_amd64.deb)
+- [https://download.memgraph.com/memgraph/v3.11.0/ubuntu-24.04/memgraph-debuginfo_3.11.0-1_amd64.deb](https://download.memgraph.com/memgraph/v3.11.0/ubuntu-24.04/memgraph-debuginfo_3.11.0-1_amd64.deb)
+- [https://download.memgraph.com/memgraph/v3.11.0/ubuntu-24.04-aarch64/memgraph_3.11.0-1_arm64.deb](https://download.memgraph.com/memgraph/v3.11.0/ubuntu-24.04-aarch64/memgraph_3.11.0-1_arm64.deb)
+- [https://download.memgraph.com/memgraph/v3.11.0/ubuntu-24.04-aarch64/memgraph-debuginfo_3.11.0-1_arm64.deb](https://download.memgraph.com/memgraph/v3.11.0/ubuntu-24.04-aarch64/memgraph-debuginfo_3.11.0-1_arm64.deb)
 
 # MAGE direct download links
 
 ## Docker
 
-- [MAGE Docker amd64 (release)](https://download.memgraph.com/memgraph-mage/v3.10.0/docker/mage-3.10.0.tar.gz)
-- [MAGE Docker arm64 (release)](https://download.memgraph.com/memgraph-mage/v3.10.0/docker-aarch64/mage-3.10.0-arm64.tar.gz)
-- [MAGE Docker amd64 (relwithdebinfo)](https://download.memgraph.com/memgraph-mage/v3.10.0/docker-relwithdebinfo/mage-3.10.0-relwithdebinfo.tar.gz)
-- [MAGE Docker arm64 (relwithdebinfo)](https://download.memgraph.com/memgraph-mage/v3.10.0/docker-aarch64-relwithdebinfo/mage-3.10.0-arm64-relwithdebinfo.tar.gz)
-- [MAGE Docker amd64 (malloc)](https://download.memgraph.com/memgraph-mage/v3.10.0/docker-malloc/mage-3.10.0-malloc.tar.gz)
-- [MAGE Docker amd64 (relwithdebinfo-malloc)](https://download.memgraph.com/memgraph-mage/v3.10.0/docker-malloc-relwithdebinfo/mage-3.10.0-relwithdebinfo-malloc.tar.gz)
-- [MAGE Docker arm64 (relwithdebinfo-malloc)](https://download.memgraph.com/memgraph-mage/v3.10.0/docker-malloc-aarch64-relwithdebinfo/mage-3.10.0-arm64-relwithdebinfo-malloc.tar.gz)
-- [MAGE Docker amd64 (relwithdebinfo-cuda)](https://download.memgraph.com/memgraph-mage/v3.10.0/docker-relwithdebinfo-cuda/mage-3.10.0-relwithdebinfo-cuda.tar.gz)
-- [MAGE Docker amd64 (relwithdebinfo-cugraph)](https://download.memgraph.com/memgraph-mage/v3.10.0/docker-relwithdebinfo-cugraph/mage-3.10.0-relwithdebinfo-cugraph.tar.gz)
+- [MAGE Docker amd64 (release)](https://download.memgraph.com/memgraph-mage/v3.11.0/docker/mage-3.11.0.tar.gz)
+- [MAGE Docker arm64 (release)](https://download.memgraph.com/memgraph-mage/v3.11.0/docker-aarch64/mage-3.11.0-arm64.tar.gz)
+- [MAGE Docker amd64 (relwithdebinfo)](https://download.memgraph.com/memgraph-mage/v3.11.0/docker-relwithdebinfo/mage-3.11.0-relwithdebinfo.tar.gz)
+- [MAGE Docker arm64 (relwithdebinfo)](https://download.memgraph.com/memgraph-mage/v3.11.0/docker-aarch64-relwithdebinfo/mage-3.11.0-arm64-relwithdebinfo.tar.gz)
+- [MAGE Docker amd64 (malloc)](https://download.memgraph.com/memgraph-mage/v3.11.0/docker-malloc/mage-3.11.0-malloc.tar.gz)
+- [MAGE Docker amd64 (relwithdebinfo-malloc)](https://download.memgraph.com/memgraph-mage/v3.11.0/docker-malloc-relwithdebinfo/mage-3.11.0-relwithdebinfo-malloc.tar.gz)
+- [MAGE Docker arm64 (relwithdebinfo-malloc)](https://download.memgraph.com/memgraph-mage/v3.11.0/docker-malloc-aarch64-relwithdebinfo/mage-3.11.0-arm64-relwithdebinfo-malloc.tar.gz)
+- [MAGE Docker amd64 (relwithdebinfo-cuda)](https://download.memgraph.com/memgraph-mage/v3.11.0/docker-relwithdebinfo-cuda/mage-3.11.0-relwithdebinfo-cuda.tar.gz)
+- [MAGE Docker amd64 (relwithdebinfo-cugraph)](https://download.memgraph.com/memgraph-mage/v3.11.0/docker-relwithdebinfo-cugraph/mage-3.11.0-relwithdebinfo-cugraph.tar.gz)
 
 
 ## Ubuntu 24.04
 
-These packages require the Memgraph packages to be installed first. The standard Release and RelWithDebInfo packages install with the CPU-only version of PyTorch. The CUDA and cuGraph versions use the CUDA-enabled version of PyTorch; the cuGraph version also requires cuGraph and CUDA Toolkit to be installed.
+These packages require the Memgraph packages to be installed first. The standard package installs with the CPU-only version of PyTorch. The CUDA and cuGraph versions use the CUDA-enabled version of PyTorch; the cuGraph version also requires cuGraph and CUDA Toolkit to be installed. The `memgraph-mage-debuginfo` package ships the debug symbols for the matching standard package.
 
-- [MAGE Ubuntu 24.04 amd64 (release)](https://download.memgraph.com/memgraph-mage/v3.10.0/ubuntu-24.04/memgraph-mage_3.10.0-1_amd64.deb)
-- [MAGE Ubuntu 24.04 arm64 (release)](https://download.memgraph.com/memgraph-mage/v3.10.0/ubuntu-24.04/memgraph-mage_3.10.0-1_arm64.deb)
-- [MAGE Ubuntu 24.04 amd64 (relwithdebinfo)](https://download.memgraph.com/memgraph-mage/v3.10.0/ubuntu-24.04/memgraph-mage_3.10.0-1_amd64-relwithdebinfo.deb)
-- [MAGE Ubuntu 24.04 arm64 (relwithdebinfo)](https://download.memgraph.com/memgraph-mage/v3.10.0/ubuntu-24.04/memgraph-mage_3.10.0-1_arm64-relwithdebinfo.deb)
-- [MAGE Ubuntu 24.04 amd64 (relwithdebinfo-cuda)](https://download.memgraph.com/memgraph-mage/v3.10.0/ubuntu-24.04/memgraph-mage_3.10.0-1_amd64-relwithdebinfo-cuda.deb)
-- [MAGE Ubuntu 24.04 amd64 (relwithdebinfo-cugraph)](https://download.memgraph.com/memgraph-mage/v3.10.0/ubuntu-24.04/memgraph-mage_3.10.0-1_amd64-relwithdebinfo-cugraph.deb)
+- [MAGE Ubuntu 24.04 amd64](https://download.memgraph.com/memgraph-mage/v3.11.0/ubuntu-24.04/memgraph-mage_3.11.0-1_amd64.deb)
+- [MAGE Ubuntu 24.04 arm64](https://download.memgraph.com/memgraph-mage/v3.11.0/ubuntu-24.04/memgraph-mage_3.11.0-1_arm64.deb)
+- [MAGE Ubuntu 24.04 amd64 (debuginfo)](https://download.memgraph.com/memgraph-mage/v3.11.0/ubuntu-24.04/memgraph-mage-debuginfo_3.11.0-1_amd64.deb)
+- [MAGE Ubuntu 24.04 arm64 (debuginfo)](https://download.memgraph.com/memgraph-mage/v3.11.0/ubuntu-24.04/memgraph-mage-debuginfo_3.11.0-1_arm64.deb)
+- [MAGE Ubuntu 24.04 amd64 (cuda)](https://download.memgraph.com/memgraph-mage/v3.11.0/ubuntu-24.04/memgraph-mage_3.11.0-1_amd64-cuda.deb)
+- [MAGE Ubuntu 24.04 amd64 (cuda debuginfo)](https://download.memgraph.com/memgraph-mage/v3.11.0/ubuntu-24.04/memgraph-mage-debuginfo_3.11.0-1_amd64-cuda.deb)
+- [MAGE Ubuntu 24.04 amd64 (cugraph)](https://download.memgraph.com/memgraph-mage/v3.11.0/ubuntu-24.04/memgraph-mage_3.11.0-1_amd64-cugraph.deb)
+- [MAGE Ubuntu 24.04 amd64 (cugraph debuginfo)](https://download.memgraph.com/memgraph-mage/v3.11.0/ubuntu-24.04/memgraph-mage-debuginfo_3.11.0-1_amd64-cugraph.deb)


### PR DESCRIPTION
### Release note

Updated the debugging page to explain that debugging symbols now have their own package corresponding the the stripped relwithdebinfo binary that is installed by default. 

Updated direct download links to include the debug symbol packages and for version 3.11.

### Related product PRs

PRs from product repo this doc page is related to: 
https://github.com/memgraph/memgraph/pull/4079

### Checklist:

- [x] Add appropriate milestone (current release cycle)
- [x] Add `bugfix` or `feature` label, based on the product PR type you're documenting
- [x] Make sure all relevant tech details are documented
    - [ ] Update reference pages (e.g. [clauses](https://memgraph.com/docs/querying/clauses), [functions](https://memgraph.com/docs/querying/functions), [flags](https://memgraph.com/docs/database-management/configuration#list-of-configuration-flags), [experimental](https://memgraph.com/docs/database-management/experimental-features), [monitoring](https://memgraph.com/docs/database-management/monitoring), [Cypher differences](https://memgraph.com/docs/querying/differences-in-cypher-implementations))
    - [ ] Search for the feature you are working on (mentions) and make updates if needed
    - [x] Provide a basic example of usage
    - [ ] In case your feature is an Enterprise one, list it under [ME page](https://memgraph.com/docs/database-management/enabling-memgraph-enterprise) and mark its page with Enterprise ([example](https://memgraph.com/docs/database-management/authentication-and-authorization/role-based-access-control)).
- [x] Check all content with Grammarly
- [x] Perform a self-review of my code
- [x] The build passes locally
- [x] My changes generate no new warnings or errors