### PR TITLE
feat: document vector index on label/edge-type combinations

### DIFF
--- a/pages/querying/vector-search.mdx
+++ b/pages/querying/vector-search.mdx
@@ -58,6 +58,61 @@ To create a vector index on edges, use:
 CREATE VECTOR EDGE INDEX vector_index_name ON :EDGE_TYPE(embedding) WITH CONFIG {"dimension": 256, "capacity": 1000};
 ```
 
+### Index on multiple labels or edge types
+
+By default, a vector index targets a single label (for nodes) or a single edge
+type (for edges). You can also index a combination of labels or edge types, or
+every entity that has the property regardless of its labels. The matching mode is
+determined by the shape of the `ON` clause:
+
+| Syntax                       | Mode     | Applies to       | Semantics                                                                                  |
+| ---------------------------- | -------- | ---------------- | ------------------------------------------------------------------------------------------ |
+| `:Label(property)`           | single   | nodes and edges  | The default. Indexes entities that have exactly that one label or edge type.               |
+| `:Label1\|Label2(property)`  | any      | nodes and edges  | Indexes entities that have **any** of the listed labels or edge types.                     |
+| `:Label1&Label2(property)`   | all      | nodes only       | Indexes nodes that have **all** of the listed labels. Not supported for edges (see below). |
+| `(property)`                 | wildcard | nodes and edges  | Indexes **every** entity that has the property, with no label or edge-type filter.         |
+
+The colon before each name after the first one is optional, so `:Label1|Label2`
+and `:Label1|:Label2` are equivalent.
+
+For nodes, all four shapes are available:
+
+```cypher
+// any of the listed labels
+CREATE VECTOR INDEX or_index ON :Article|Blog(embedding) WITH CONFIG {"dimension": 256, "capacity": 1000};
+
+// all of the listed labels
+CREATE VECTOR INDEX and_index ON :Article&Published(embedding) WITH CONFIG {"dimension": 256, "capacity": 1000};
+
+// every node that has the property
+CREATE VECTOR INDEX wildcard_index ON (embedding) WITH CONFIG {"dimension": 256, "capacity": 1000};
+```
+
+For edges, the single, any (`|`) and wildcard shapes work the same way, but the
+all (`&`) shape is rejected with an error, because an edge always has exactly one
+type and could never match more than one:
+
+```cypher
+CREATE VECTOR EDGE INDEX or_edge_index ON :KNOWS|LIKES(embedding) WITH CONFIG {"dimension": 256, "capacity": 1000};
+CREATE VECTOR EDGE INDEX wildcard_edge_index ON (embedding) WITH CONFIG {"dimension": 256, "capacity": 1000};
+```
+
+A node or edge can match several overlapping indexes at once (for example, a
+wildcard index and a label-specific index on the same property). Such an entity is
+kept in every matching index, and inserts, updates and deletes are propagated to
+all of them. When a node loses one of several labels that qualified it for an
+`any` index, it remains in the index as long as it still has another matching
+label.
+
+<Callout type="info">
+
+In the output of `SHOW INDEX INFO` and [`SHOW VECTOR INDEX INFO`](#show-vector-indices),
+the `label` column shows the index filter: `*` for a wildcard index, `:Label` for
+a single label or edge type, `:Label1|Label2` for an `any` index, and
+`:Label1&Label2` for an `all` index.
+
+</Callout>
+
 ### Configuration parameters
 
 The following options apply to vector indexes on both nodes and edges:
@@ -140,7 +195,7 @@ Additionally, the same information can be retrieved with the `SHOW VECTOR INDEX 
 {<h3 className="custom-header"> Output: </h3>}
 
 - `index_name: string` ➡ The name of the vector index.
-- `label: string` ➡ The name of the label (or edge type) on which the vector index is defined.
+- `label: string` ➡ The label (or edge type) filter the vector index is defined on. For [multi-label, edge-type or wildcard indexes](#index-on-multiple-labels-or-edge-types) this shows the filter shape: `*` (wildcard), `:Label` (single), `:Label1|Label2` (any), or `:Label1&Label2` (all).
 - `property: string` ➡ The name of the property on which the vector index is indexed.
 - `dimension: int` ➡ The dimension of vectors in the index.
 - `capacity: int` ➡ The capacity of the vector index.
@@ -337,11 +392,11 @@ SHOW VECTOR INDEX INFO;
 The above query will result with:
 
 ```
-+----------+-----------+-------------+--------+----------+------+-------------+-------------------------+
-| capacity | dimension | index_name  | label  | property | size | scalar_kind | index_type              |
-+----------+-----------+-------------+--------+----------+------+-------------+-------------------------+
-| 2048     | 2         | "index_name"| "Node" | "vector" | 0    | "f16"       | "label+property_vector" |
-+----------+-----------+-------------+--------+----------+------+-------------+-------------------------+
++----------+-----------+-------------+---------+----------+------+-------------+-------------------------+
+| capacity | dimension | index_name  | label   | property | size | scalar_kind | index_type              |
++----------+-----------+-------------+---------+----------+------+-------------+-------------------------+
+| 2048     | 2         | "index_name"| ":Node" | "vector" | 0    | "f16"       | "label+property_vector" |
++----------+-----------+-------------+---------+----------+------+-------------+-------------------------+
 ```
 
 {<h3 className="custom-header"> Create a node </h3>}
@@ -362,11 +417,11 @@ CALL vector_search.show_index_info() YIELD * RETURN *;
 The above query results in:
 
 ```
-+----------+-----------+-------------+--------+----------+------+-------------+-------------------------+
-| capacity | dimension | index_name  | label  | property | size | scalar_kind | index_type              |
-+----------+-----------+-------------+--------+----------+------+-------------+-------------------------+
-| 2048     | 2         | "index_name"| "Node" | "vector" | 1    | "f16"       | "label+property_vector" |
-+----------+-----------+-------------+--------+----------+------+-------------+-------------------------+
++----------+-----------+-------------+---------+----------+------+-------------+-------------------------+
+| capacity | dimension | index_name  | label   | property | size | scalar_kind | index_type              |
++----------+-----------+-------------+---------+----------+------+-------------+-------------------------+
+| 2048     | 2         | "index_name"| ":Node" | "vector" | 1    | "f16"       | "label+property_vector" |
++----------+-----------+-------------+---------+----------+------+-------------+-------------------------+
 ```
 
 We can see the size of the index changed, due to one new node.
@@ -410,11 +465,11 @@ CALL vector_search.show_index_info() YIELD * RETURN *;
 
 The size is now 5, due to 4 additional nodes:
 ```
-+----------+-----------+-------------+--------+----------+------+-------------+-------------------------+
-| capacity | dimension | index_name  | label  | property | size | scalar_kind | index_type              |
-+----------+-----------+-------------+--------+----------+------+-------------+-------------------------+
-| 2048     | 2         | "index_name"| "Node" | "vector" | 5    | "f16"       | "label+property_vector" |
-+----------+-----------+-------------+--------+----------+------+-------------+-------------------------+
++----------+-----------+-------------+---------+----------+------+-------------+-------------------------+
+| capacity | dimension | index_name  | label   | property | size | scalar_kind | index_type              |
++----------+-----------+-------------+---------+----------+------+-------------+-------------------------+
+| 2048     | 2         | "index_name"| ":Node" | "vector" | 5    | "f16"       | "label+property_vector" |
++----------+-----------+-------------+---------+----------+------+-------------+-------------------------+
 ```
 
 Let's again search for the top five similar nodes to the vector [2.0, 2.0] (to compare it to all nodes we have):


### PR DESCRIPTION
### Release note

Vector indexes can now target a combination of labels or edge types instead of a single one. On top of the existing `:Label(property)` form, `CREATE VECTOR INDEX` and `CREATE VECTOR EDGE INDEX` accept `:Label1|Label2(property)` (matches entities with any of the listed labels/edge types), `:Label1&Label2(property)` (matches nodes that have all of the listed labels; rejected for edges, since an edge has exactly one type), and `(property)` (a wildcard that indexes every entity with the property regardless of its labels).
### Related product PRs

PRs from product repo this doc page is related to:
- memgraph/memgraph#3981

### Checklist:

- [x] Add appropriate milestone (current release cycle)
- [x] Add `bugfix` or `feature` label, based on the product PR type you're documenting
- [x] Make sure all relevant tech details are documented
    - [x] Update reference pages (e.g. [clauses](https://memgraph.com/docs/querying/clauses), [functions](https://memgraph.com/docs/querying/functions), [flags](https://memgraph.com/docs/database-management/configuration#list-of-configuration-flags), [experimental](https://memgraph.com/docs/database-management/experimental-features), [monitoring](https://memgraph.com/docs/database-management/monitoring), [Cypher differences](https://memgraph.com/docs/querying/differences-in-cypher-implementations))
    - [x] Search for the feature you are working on (mentions) and make updates if needed
    - [x] Provide a basic example of usage
    - [x] In case your feature is an Enterprise one, list it under [ME page](https://memgraph.com/docs/database-management/enabling-memgraph-enterprise) and mark its page with Enterprise ([example](https://memgraph.com/docs/database-management/authentication-and-authorization/role-based-access-control)).
- [x] Check all content with Grammarly
- [x] Perform a self-review of my code
- [x] The build passes locally
- [x] My changes generate no new warnings or errors
