### PR TITLE
feat: document fuzzy text search

### DIFF
--- a/pages/querying/text-search.mdx
+++ b/pages/querying/text-search.mdx
@@ -396,7 +396,6 @@ it to the results of a search query.
 - `search_query: string` ➡ The query applied to the text-indexed nodes or edges.
 - `aggregation_query: string` ➡ The aggregation (JSON-formatted) to be applied
     to the output of `search_query`.
-- `limit: int (optional, default=1000)` ➡ The maximum number of results to return. 
 
 {<h3 className="custom-header"> Output: </h3>}
 

--- a/pages/querying/text-search.mdx
+++ b/pages/querying/text-search.mdx
@@ -107,6 +107,20 @@ Unlike other index types, the query planner currently does not utilize text indi
 To list all text indices in Memgraph, use the `SHOW INDEX INFO`
 [statement](/fundamentals/indexes#show-created-indexes).
 
+### Search configuration
+
+The `text_search.search`, `text_search.search_edges`, `text_search.search_all`,
+`text_search.search_all_edges`, `text_search.regex_search` and
+`text_search.regex_search_edges` procedures accept an optional `config` map as
+their last argument. All keys are optional:
+
+| Key                    | Type    | Default | Description                                                                                                                                                                          |
+| ---------------------- | ------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `limit`                | integer | `1000`  | The maximum number of results to return.                                                                                                                                           |
+| `fuzzy_distance`       | integer | `0`     | The maximum number of single-character edits (Levenshtein distance) a term may differ from the query and still match. Allowed values are `0`, `1` and `2` (`0` is exact matching); a higher value is rejected. |
+| `fuzzy_prefix`         | boolean | `false` | When `true` and `fuzzy_distance` is greater than `0`, every query term is matched as a prefix: it matches indexed terms that start with the term, tolerating up to `fuzzy_distance` edits. Has no effect when `fuzzy_distance` is `0`. |
+| `fuzzy_transpositions` | boolean | `true`  | When `true`, swapping two adjacent characters counts as a single edit; when `false`, it counts as two.                                                                             |
+
 ### Query text index
 
 <Callout type="warning">
@@ -124,7 +138,7 @@ your search query based on their indexed properties.
 
 - `index_name: string` ➡ The text index to search.
 - `search_query: string` ➡ The query to search for in the index.
-- `limit: int (optional, default=1000)` ➡ The maximum number of results to return.
+- `config: Map (optional)` ➡ The [search configuration](#search-configuration), including `limit` and the fuzzy-matching keys. Defaults to an empty map.
 
 {<h3 className="custom-header"> Output: </h3>}
 
@@ -178,6 +192,25 @@ Result:
 +-------------+-------------+
 ```
 
+### Fuzzy search
+
+Fuzzy matching lets a search tolerate typos and partial terms. Using the
+[`config` map](#search-configuration), you can search with fuzzy matching:
+
+```cypher
+// exact match (default behavior)
+CALL text_search.search('complianceDocuments', 'data.title:memgraph') YIELD node RETURN node;
+
+// tolerate a single typo, e.g. 'memgrahp' still matches 'memgraph'
+CALL text_search.search('complianceDocuments', 'data.title:memgrahp', {fuzzy_distance: 1}) YIELD node RETURN node;
+
+// prefix + fuzzy, capped at 5 results
+CALL text_search.search('complianceDocuments', 'data.title:mem', {fuzzy_distance: 1, fuzzy_prefix: true, limit: 5}) YIELD node RETURN node;
+
+// fuzzy matching over all indexed properties
+CALL text_search.search_all('complianceDocuments', 'memgrahp', {fuzzy_distance: 1}) YIELD node RETURN node;
+```
+
 ### Boolean expressions
 
 You can use boolean logic in your search queries to create more complex search conditions. Boolean operators include `AND`, `OR`, and `NOT`, and you can use parentheses to group conditions.
@@ -225,7 +258,7 @@ there is no need to specify property names in the query.
 
 - `index_name: string` ➡ The text index to be searched.
 - `search_query: string` ➡ The query applied to the text-indexed nodes or edges.
-- `limit: int (optional, default=1000)` ➡ The maximum number of results to return. 
+- `config: Map (optional)` ➡ The [search configuration](#search-configuration), including `limit` and the fuzzy-matching keys. Defaults to an empty map.
 
 {<h3 className="custom-header"> Output: </h3>}
 
@@ -290,7 +323,7 @@ least one property value matches the given regular expression (regex).
 
 - `index_name: string` ➡ The text index to be searched.
 - `search_query: string` ➡ The regex applied to the text-indexed nodes or edges.
-- `limit: int (optional, default=1000)` ➡ The maximum number of results to return. 
+- `config: Map (optional)` ➡ The [search configuration](#search-configuration). Only `limit` is supported here; the fuzzy-matching keys are not allowed for regex search. Defaults to an empty map.
 
 {<h3 className="custom-header"> Output: </h3>}
 


### PR DESCRIPTION
### Release note

The `text_search` search procedures now accept an optional `config` map as their last argument, adding fuzzy (typo-tolerant) matching. The map supports `limit` (max results), `fuzzy_distance` (max Levenshtein edits, `0`–`2`, `0` meaning exact), `fuzzy_prefix` (when paired with a non-zero `fuzzy_distance`, matches indexed terms that start with the query term while tolerating up to that many edits), and `fuzzy_transpositions` (whether swapping two adjacent characters counts as one edit or two). Fuzzy keys apply to `text_search.search`, `text_search.search_all` and their edge variants; `text_search.regex_search` accepts only `limit`. This is a breaking change: `limit` was previously a positional argument and is now a key inside the `config` map, so calls passing `limit` positionally must be updated.

### Related product PRs

PRs from product repo this doc page is related to:
- memgraph/memgraph#4191

### Checklist:

- [x] Add appropriate milestone (current release cycle)
- [x] Add `bugfix` or `feature` label, based on the product PR type you're documenting
- [x] Make sure all relevant tech details are documented
    - [x] Update reference pages (e.g. [clauses](https://memgraph.com/docs/querying/clauses), [functions](https://memgraph.com/docs/querying/functions), [flags](https://memgraph.com/docs/database-management/configuration#list-of-configuration-flags), [experimental](https://memgraph.com/docs/database-management/experimental-features), [monitoring](https://memgraph.com/docs/database-management/monitoring), [Cypher differences](https://memgraph.com/docs/querying/differences-in-cypher-implementations))
    - [x] Search for the feature you are working on (mentions) and make updates if needed
    - [x] Provide a basic example of usage
    - [x] In case your feature is an Enterprise one, list it under [ME page](https://memgraph.com/docs/database-management/enabling-memgraph-enterprise) and mark its page with Enterprise ([example](https://memgraph.com/docs/database-management/authentication-and-authorization/role-based-access-control)).
- [x] Check all content with Grammarly
- [x] Perform a self-review of my code
- [x] The build passes locally
- [x] My changes generate no new warnings or errors
