### PR TITLE
Added RPM builds of MAGE and updated the direct download links

### DIFF
--- a/pages/advanced-algorithms/install-mage.mdx
+++ b/pages/advanced-algorithms/install-mage.mdx
@@ -10,7 +10,7 @@ import { Callout } from 'nextra/components'
 
 Use MAGE with an instance installed within a [Docker container](#docker), from a
 prebuilt [package](#install-from-a-package) on Ubuntu or CentOS, or [built from
-source](#linux). 
+source](#build-from-source-linux). 
 
 ## Docker
 
@@ -55,7 +55,7 @@ discontinued as of `3.2` onwards.
 
 ## Install from a package
 
-On Ubuntu 24.04 (DEB) and CentOS 9 / CentOS 10 (RPM, `x86_64` only), MAGE is
+On Ubuntu 24.04 (DEB `x86_64` and `aarch64`) and CentOS 9 / CentOS 10 (RPM, `x86_64` only), MAGE is
 available as a prebuilt `memgraph-mage` package, so you don't have to build it
 from source.
 
@@ -76,9 +76,9 @@ links](/getting-started/install-memgraph/direct-download-links). For example:
 
 ```shell
 # Ubuntu 24.04
-sudo wget https://download.memgraph.com/memgraph-mage/v3.11.0/ubuntu-24.04/memgraph-mage_3.11.0-1_amd64.deb
+wget https://download.memgraph.com/memgraph-mage/v3.11.0/ubuntu-24.04/memgraph-mage_3.11.0-1_amd64.deb
 # CentOS 9
-sudo wget https://download.memgraph.com/memgraph-mage/v3.11.0/centos-9/memgraph-mage-3.11.0-1.centos-9.x86_64.rpm
+wget https://download.memgraph.com/memgraph-mage/v3.11.0/centos-9/memgraph-mage-3.11.0-1.centos-9.x86_64.rpm
 ```
 
 CUDA and cuGraph variants are also available for Ubuntu — see the download links page.
@@ -112,7 +112,7 @@ sudo systemctl restart memgraph
 
 </Steps>
 
-## Linux
+## Build from source (Linux)
 
 Follow the steps if you want to use the MAGE library with [installed Linux based
 Memgraph package](/getting-started/install-memgraph). 

--- a/pages/advanced-algorithms/install-mage.mdx
+++ b/pages/advanced-algorithms/install-mage.mdx
@@ -8,8 +8,9 @@ import { Callout } from 'nextra/components'
 
 # Install MAGE graph algorithm library
 
-Use MAGE with an instance installed within a [Docker container](#docker) or on
-[Linux](#linux). 
+Use MAGE with an instance installed within a [Docker container](#docker), from a
+prebuilt [package](#install-from-a-package) on Ubuntu or CentOS, or [built from
+source](#linux). 
 
 ## Docker
 
@@ -51,6 +52,65 @@ discontinued as of `3.2` onwards.
 
 
 </Callout>
+
+## Install from a package
+
+On Ubuntu 24.04 (DEB) and CentOS 9 / CentOS 10 (RPM, `x86_64` only), MAGE is
+available as a prebuilt `memgraph-mage` package, so you don't have to build it
+from source.
+
+<Steps>
+
+{<h3 className="custom-header">Install Memgraph</h3>}
+
+Install the Memgraph package first — the `memgraph-mage` package depends on a
+matching `memgraph` package of the same version. Follow the
+[Ubuntu](/getting-started/install-memgraph/ubuntu) or
+[CentOS](/getting-started/install-memgraph/centos) installation guide.
+
+{<h3 className="custom-header">Download the MAGE package</h3>}
+
+Download the `memgraph-mage` package that matches your Memgraph version and distro
+from the [direct download
+links](/getting-started/install-memgraph/direct-download-links). For example:
+
+```shell
+# Ubuntu 24.04
+sudo wget https://download.memgraph.com/memgraph-mage/v3.11.0/ubuntu-24.04/memgraph-mage_3.11.0-1_amd64.deb
+# CentOS 9
+sudo wget https://download.memgraph.com/memgraph-mage/v3.11.0/centos-9/memgraph-mage-3.11.0-1.centos-9.x86_64.rpm
+```
+
+CUDA and cuGraph variants are also available for Ubuntu — see the download links page.
+
+{<h3 className="custom-header">Install MAGE</h3>}
+
+Install the package with your distribution's package manager so its dependencies
+are resolved:
+
+```shell
+# Ubuntu (DEB)
+sudo apt install ./memgraph-mage_3.11.0-1_amd64.deb
+# CentOS (RPM)
+sudo dnf install ./memgraph-mage-3.11.0-1.centos-9.x86_64.rpm
+```
+
+<Callout type="info">
+
+During installation the package downloads and installs the Python dependencies
+the MAGE query modules need, so the machine needs network access.
+
+</Callout>
+
+{<h3 className="custom-header">Restart Memgraph</h3>}
+
+Restart Memgraph so the newly installed modules are loaded:
+
+```shell
+sudo systemctl restart memgraph
+```
+
+</Steps>
 
 ## Linux
 

--- a/pages/advanced-algorithms/install-mage.mdx
+++ b/pages/advanced-algorithms/install-mage.mdx
@@ -76,9 +76,9 @@ links](/getting-started/install-memgraph/direct-download-links). For example:
 
 ```shell
 # Ubuntu 24.04
-wget https://download.memgraph.com/memgraph-mage/v3.11.0/ubuntu-24.04/memgraph-mage_3.11.0-1_amd64.deb
+wget https://download.memgraph.com/memgraph-mage/v3.12.0/ubuntu-24.04/memgraph-mage_3.12.0-1_amd64.deb
 # CentOS 9
-wget https://download.memgraph.com/memgraph-mage/v3.11.0/centos-9/memgraph-mage-3.11.0-1.centos-9.x86_64.rpm
+wget https://download.memgraph.com/memgraph-mage/v3.12.0/centos-9/memgraph-mage-3.12.0-1.centos-9.x86_64.rpm
 ```
 
 CUDA and cuGraph variants are also available for Ubuntu — see the download links page.
@@ -90,9 +90,9 @@ are resolved:
 
 ```shell
 # Ubuntu (DEB)
-sudo apt install ./memgraph-mage_3.11.0-1_amd64.deb
+sudo apt install ./memgraph-mage_3.12.0-1_amd64.deb
 # CentOS (RPM)
-sudo dnf install ./memgraph-mage-3.11.0-1.centos-9.x86_64.rpm
+sudo dnf install ./memgraph-mage-3.12.0-1.centos-9.x86_64.rpm
 ```
 
 <Callout type="info">

--- a/pages/getting-started/install-memgraph/direct-download-links.mdx
+++ b/pages/getting-started/install-memgraph/direct-download-links.mdx
@@ -21,12 +21,12 @@ See [Debugging Memgraph](/database-management/debugging) for details.
 </Callout>
 
 ## Docker
-- [https://download.memgraph.com/memgraph/v3.11.0/docker/memgraph-3.11.0-docker.tar.gz](https://download.memgraph.com/memgraph/v3.11.0/docker/memgraph-3.11.0-docker.tar.gz)
-- [https://download.memgraph.com/memgraph/v3.11.0/docker-aarch64/memgraph-3.11.0-docker.tar.gz](https://download.memgraph.com/memgraph/v3.11.0/docker-aarch64/memgraph-3.11.0-docker.tar.gz)
-- [https://download.memgraph.com/memgraph/v3.11.0/docker-relwithdebinfo/memgraph-3.11.0-relwithdebinfo-docker.tar.gz](https://download.memgraph.com/memgraph/v3.11.0/docker-relwithdebinfo/memgraph-3.11.0-relwithdebinfo-docker.tar.gz)
-- [https://download.memgraph.com/memgraph/v3.11.0/docker-aarch64-relwithdebinfo/memgraph-3.11.0-relwithdebinfo-docker.tar.gz](https://download.memgraph.com/memgraph/v3.11.0/docker-aarch64-relwithdebinfo/memgraph-3.11.0-relwithdebinfo-docker.tar.gz)
-- [https://download.memgraph.com/memgraph/v3.11.0/docker-malloc-relwithdebinfo/memgraph-3.11.0-relwithdebinfo-malloc-docker.tar.gz](https://download.memgraph.com/memgraph/v3.11.0/docker-malloc-relwithdebinfo/memgraph-3.11.0-relwithdebinfo-malloc-docker.tar.gz)
-- [https://download.memgraph.com/memgraph/v3.11.0/docker-malloc-aarch64-relwithdebinfo/memgraph-3.11.0-relwithdebinfo-malloc-docker.tar.gz](https://download.memgraph.com/memgraph/v3.11.0/docker-malloc-aarch64-relwithdebinfo/memgraph-3.11.0-relwithdebinfo-malloc-docker.tar.gz)
+- [https://download.memgraph.com/memgraph/v3.12.0/docker/memgraph-3.12.0-docker.tar.gz](https://download.memgraph.com/memgraph/v3.12.0/docker/memgraph-3.12.0-docker.tar.gz)
+- [https://download.memgraph.com/memgraph/v3.12.0/docker-aarch64/memgraph-3.12.0-docker.tar.gz](https://download.memgraph.com/memgraph/v3.12.0/docker-aarch64/memgraph-3.12.0-docker.tar.gz)
+- [https://download.memgraph.com/memgraph/v3.12.0/docker-relwithdebinfo/memgraph-3.12.0-relwithdebinfo-docker.tar.gz](https://download.memgraph.com/memgraph/v3.12.0/docker-relwithdebinfo/memgraph-3.12.0-relwithdebinfo-docker.tar.gz)
+- [https://download.memgraph.com/memgraph/v3.12.0/docker-aarch64-relwithdebinfo/memgraph-3.12.0-relwithdebinfo-docker.tar.gz](https://download.memgraph.com/memgraph/v3.12.0/docker-aarch64-relwithdebinfo/memgraph-3.12.0-relwithdebinfo-docker.tar.gz)
+- [https://download.memgraph.com/memgraph/v3.12.0/docker-malloc-relwithdebinfo/memgraph-3.12.0-relwithdebinfo-malloc-docker.tar.gz](https://download.memgraph.com/memgraph/v3.12.0/docker-malloc-relwithdebinfo/memgraph-3.12.0-relwithdebinfo-malloc-docker.tar.gz)
+- [https://download.memgraph.com/memgraph/v3.12.0/docker-malloc-aarch64-relwithdebinfo/memgraph-3.12.0-relwithdebinfo-malloc-docker.tar.gz](https://download.memgraph.com/memgraph/v3.12.0/docker-malloc-aarch64-relwithdebinfo/memgraph-3.12.0-relwithdebinfo-malloc-docker.tar.gz)
 
 ## Linux
 
@@ -34,67 +34,76 @@ Memgraph can be run on the Linux distributions listed below. Each main package h
 a matching `memgraph-debuginfo` package containing its debug symbols.
 
 ### CentOS
-- [https://download.memgraph.com/memgraph/v3.11.0/centos-9/memgraph-3.11.0_1-1.x86_64.rpm](https://download.memgraph.com/memgraph/v3.11.0/centos-9/memgraph-3.11.0_1-1.x86_64.rpm)
-- [https://download.memgraph.com/memgraph/v3.11.0/centos-9/memgraph-debuginfo-3.11.0_1-1.x86_64.rpm](https://download.memgraph.com/memgraph/v3.11.0/centos-9/memgraph-debuginfo-3.11.0_1-1.x86_64.rpm)
-- [https://download.memgraph.com/memgraph/v3.11.0/centos-10/memgraph-3.11.0_1-1.x86_64.rpm](https://download.memgraph.com/memgraph/v3.11.0/centos-10/memgraph-3.11.0_1-1.x86_64.rpm)
-- [https://download.memgraph.com/memgraph/v3.11.0/centos-10/memgraph-debuginfo-3.11.0_1-1.x86_64.rpm](https://download.memgraph.com/memgraph/v3.11.0/centos-10/memgraph-debuginfo-3.11.0_1-1.x86_64.rpm)
+- [https://download.memgraph.com/memgraph/v3.12.0/centos-9/memgraph-3.12.0_1-1.x86_64.rpm](https://download.memgraph.com/memgraph/v3.12.0/centos-9/memgraph-3.12.0_1-1.x86_64.rpm)
+- [https://download.memgraph.com/memgraph/v3.12.0/centos-9/memgraph-debuginfo-3.12.0_1-1.x86_64.rpm](https://download.memgraph.com/memgraph/v3.12.0/centos-9/memgraph-debuginfo-3.12.0_1-1.x86_64.rpm)
+- [https://download.memgraph.com/memgraph/v3.12.0/centos-10/memgraph-3.12.0_1-1.x86_64.rpm](https://download.memgraph.com/memgraph/v3.12.0/centos-10/memgraph-3.12.0_1-1.x86_64.rpm)
+- [https://download.memgraph.com/memgraph/v3.12.0/centos-10/memgraph-debuginfo-3.12.0_1-1.x86_64.rpm](https://download.memgraph.com/memgraph/v3.12.0/centos-10/memgraph-debuginfo-3.12.0_1-1.x86_64.rpm)
 
 ### Debian
-- [https://download.memgraph.com/memgraph/v3.11.0/debian-12/memgraph_3.11.0-1_amd64.deb](https://download.memgraph.com/memgraph/v3.11.0/debian-12/memgraph_3.11.0-1_amd64.deb)
-- [https://download.memgraph.com/memgraph/v3.11.0/debian-12/memgraph-debuginfo_3.11.0-1_amd64.deb](https://download.memgraph.com/memgraph/v3.11.0/debian-12/memgraph-debuginfo_3.11.0-1_amd64.deb)
-- [https://download.memgraph.com/memgraph/v3.11.0/debian-12-aarch64/memgraph_3.11.0-1_arm64.deb](https://download.memgraph.com/memgraph/v3.11.0/debian-12-aarch64/memgraph_3.11.0-1_arm64.deb)
-- [https://download.memgraph.com/memgraph/v3.11.0/debian-12-aarch64/memgraph-debuginfo_3.11.0-1_arm64.deb](https://download.memgraph.com/memgraph/v3.11.0/debian-12-aarch64/memgraph-debuginfo_3.11.0-1_arm64.deb)
-- [https://download.memgraph.com/memgraph/v3.11.0/debian-13/memgraph_3.11.0-1_amd64.deb](https://download.memgraph.com/memgraph/v3.11.0/debian-13/memgraph_3.11.0-1_amd64.deb)
-- [https://download.memgraph.com/memgraph/v3.11.0/debian-13/memgraph-debuginfo_3.11.0-1_amd64.deb](https://download.memgraph.com/memgraph/v3.11.0/debian-13/memgraph-debuginfo_3.11.0-1_amd64.deb)
-- [https://download.memgraph.com/memgraph/v3.11.0/debian-13-aarch64/memgraph_3.11.0-1_arm64.deb](https://download.memgraph.com/memgraph/v3.11.0/debian-13-aarch64/memgraph_3.11.0-1_arm64.deb)
-- [https://download.memgraph.com/memgraph/v3.11.0/debian-13-aarch64/memgraph-debuginfo_3.11.0-1_arm64.deb](https://download.memgraph.com/memgraph/v3.11.0/debian-13-aarch64/memgraph-debuginfo_3.11.0-1_arm64.deb)
+- [https://download.memgraph.com/memgraph/v3.12.0/debian-12/memgraph_3.12.0-1_amd64.deb](https://download.memgraph.com/memgraph/v3.12.0/debian-12/memgraph_3.12.0-1_amd64.deb)
+- [https://download.memgraph.com/memgraph/v3.12.0/debian-12/memgraph-debuginfo_3.12.0-1_amd64.deb](https://download.memgraph.com/memgraph/v3.12.0/debian-12/memgraph-debuginfo_3.12.0-1_amd64.deb)
+- [https://download.memgraph.com/memgraph/v3.12.0/debian-12-aarch64/memgraph_3.12.0-1_arm64.deb](https://download.memgraph.com/memgraph/v3.12.0/debian-12-aarch64/memgraph_3.12.0-1_arm64.deb)
+- [https://download.memgraph.com/memgraph/v3.12.0/debian-12-aarch64/memgraph-debuginfo_3.12.0-1_arm64.deb](https://download.memgraph.com/memgraph/v3.12.0/debian-12-aarch64/memgraph-debuginfo_3.12.0-1_arm64.deb)
+- [https://download.memgraph.com/memgraph/v3.12.0/debian-13/memgraph_3.12.0-1_amd64.deb](https://download.memgraph.com/memgraph/v3.12.0/debian-13/memgraph_3.12.0-1_amd64.deb)
+- [https://download.memgraph.com/memgraph/v3.12.0/debian-13/memgraph-debuginfo_3.12.0-1_amd64.deb](https://download.memgraph.com/memgraph/v3.12.0/debian-13/memgraph-debuginfo_3.12.0-1_amd64.deb)
+- [https://download.memgraph.com/memgraph/v3.12.0/debian-13-aarch64/memgraph_3.12.0-1_arm64.deb](https://download.memgraph.com/memgraph/v3.12.0/debian-13-aarch64/memgraph_3.12.0-1_arm64.deb)
+- [https://download.memgraph.com/memgraph/v3.12.0/debian-13-aarch64/memgraph-debuginfo_3.12.0-1_arm64.deb](https://download.memgraph.com/memgraph/v3.12.0/debian-13-aarch64/memgraph-debuginfo_3.12.0-1_arm64.deb)
 
 ### Fedora
-- [https://download.memgraph.com/memgraph/v3.11.0/fedora-42/memgraph-3.11.0_1-1.x86_64.rpm](https://download.memgraph.com/memgraph/v3.11.0/fedora-42/memgraph-3.11.0_1-1.x86_64.rpm)
-- [https://download.memgraph.com/memgraph/v3.11.0/fedora-42/memgraph-debuginfo-3.11.0_1-1.x86_64.rpm](https://download.memgraph.com/memgraph/v3.11.0/fedora-42/memgraph-debuginfo-3.11.0_1-1.x86_64.rpm)
-- [https://download.memgraph.com/memgraph/v3.11.0/fedora-42-aarch64/memgraph-3.11.0_1-1.aarch64.rpm](https://download.memgraph.com/memgraph/v3.11.0/fedora-42-aarch64/memgraph-3.11.0_1-1.aarch64.rpm)
-- [https://download.memgraph.com/memgraph/v3.11.0/fedora-42-aarch64/memgraph-debuginfo-3.11.0_1-1.aarch64.rpm](https://download.memgraph.com/memgraph/v3.11.0/fedora-42-aarch64/memgraph-debuginfo-3.11.0_1-1.aarch64.rpm)
+- [https://download.memgraph.com/memgraph/v3.12.0/fedora-42/memgraph-3.12.0_1-1.x86_64.rpm](https://download.memgraph.com/memgraph/v3.12.0/fedora-42/memgraph-3.12.0_1-1.x86_64.rpm)
+- [https://download.memgraph.com/memgraph/v3.12.0/fedora-42/memgraph-debuginfo-3.12.0_1-1.x86_64.rpm](https://download.memgraph.com/memgraph/v3.12.0/fedora-42/memgraph-debuginfo-3.12.0_1-1.x86_64.rpm)
+- [https://download.memgraph.com/memgraph/v3.12.0/fedora-42-aarch64/memgraph-3.12.0_1-1.aarch64.rpm](https://download.memgraph.com/memgraph/v3.12.0/fedora-42-aarch64/memgraph-3.12.0_1-1.aarch64.rpm)
+- [https://download.memgraph.com/memgraph/v3.12.0/fedora-42-aarch64/memgraph-debuginfo-3.12.0_1-1.aarch64.rpm](https://download.memgraph.com/memgraph/v3.12.0/fedora-42-aarch64/memgraph-debuginfo-3.12.0_1-1.aarch64.rpm)
 
 ### Rocky
-- [https://download.memgraph.com/memgraph/v3.11.0/rocky-10/memgraph-3.11.0_1-1.x86_64.rpm](https://download.memgraph.com/memgraph/v3.11.0/rocky-10/memgraph-3.11.0_1-1.x86_64.rpm)
-- [https://download.memgraph.com/memgraph/v3.11.0/rocky-10/memgraph-debuginfo-3.11.0_1-1.x86_64.rpm](https://download.memgraph.com/memgraph/v3.11.0/rocky-10/memgraph-debuginfo-3.11.0_1-1.x86_64.rpm)
+- [https://download.memgraph.com/memgraph/v3.12.0/rocky-10/memgraph-3.12.0_1-1.x86_64.rpm](https://download.memgraph.com/memgraph/v3.12.0/rocky-10/memgraph-3.12.0_1-1.x86_64.rpm)
+- [https://download.memgraph.com/memgraph/v3.12.0/rocky-10/memgraph-debuginfo-3.12.0_1-1.x86_64.rpm](https://download.memgraph.com/memgraph/v3.12.0/rocky-10/memgraph-debuginfo-3.12.0_1-1.x86_64.rpm)
 
 ### Red Hat
-- [https://download.memgraph.com/memgraph/v3.11.0/centos-9/memgraph-3.11.0_1-1.x86_64.rpm](https://download.memgraph.com/memgraph/v3.11.0/centos-9/memgraph-3.11.0_1-1.x86_64.rpm)
-- [https://download.memgraph.com/memgraph/v3.11.0/centos-9/memgraph-debuginfo-3.11.0_1-1.x86_64.rpm](https://download.memgraph.com/memgraph/v3.11.0/centos-9/memgraph-debuginfo-3.11.0_1-1.x86_64.rpm)
+- [https://download.memgraph.com/memgraph/v3.12.0/centos-9/memgraph-3.12.0_1-1.x86_64.rpm](https://download.memgraph.com/memgraph/v3.12.0/centos-9/memgraph-3.12.0_1-1.x86_64.rpm)
+- [https://download.memgraph.com/memgraph/v3.12.0/centos-9/memgraph-debuginfo-3.12.0_1-1.x86_64.rpm](https://download.memgraph.com/memgraph/v3.12.0/centos-9/memgraph-debuginfo-3.12.0_1-1.x86_64.rpm)
 
 ### Ubuntu
-- [https://download.memgraph.com/memgraph/v3.11.0/ubuntu-22.04/memgraph_3.11.0-1_amd64.deb](https://download.memgraph.com/memgraph/v3.11.0/ubuntu-22.04/memgraph_3.11.0-1_amd64.deb)
-- [https://download.memgraph.com/memgraph/v3.11.0/ubuntu-22.04/memgraph-debuginfo_3.11.0-1_amd64.deb](https://download.memgraph.com/memgraph/v3.11.0/ubuntu-22.04/memgraph-debuginfo_3.11.0-1_amd64.deb)
-- [https://download.memgraph.com/memgraph/v3.11.0/ubuntu-24.04/memgraph_3.11.0-1_amd64.deb](https://download.memgraph.com/memgraph/v3.11.0/ubuntu-24.04/memgraph_3.11.0-1_amd64.deb)
-- [https://download.memgraph.com/memgraph/v3.11.0/ubuntu-24.04/memgraph-debuginfo_3.11.0-1_amd64.deb](https://download.memgraph.com/memgraph/v3.11.0/ubuntu-24.04/memgraph-debuginfo_3.11.0-1_amd64.deb)
-- [https://download.memgraph.com/memgraph/v3.11.0/ubuntu-24.04-aarch64/memgraph_3.11.0-1_arm64.deb](https://download.memgraph.com/memgraph/v3.11.0/ubuntu-24.04-aarch64/memgraph_3.11.0-1_arm64.deb)
-- [https://download.memgraph.com/memgraph/v3.11.0/ubuntu-24.04-aarch64/memgraph-debuginfo_3.11.0-1_arm64.deb](https://download.memgraph.com/memgraph/v3.11.0/ubuntu-24.04-aarch64/memgraph-debuginfo_3.11.0-1_arm64.deb)
+- [https://download.memgraph.com/memgraph/v3.12.0/ubuntu-22.04/memgraph_3.12.0-1_amd64.deb](https://download.memgraph.com/memgraph/v3.12.0/ubuntu-22.04/memgraph_3.12.0-1_amd64.deb)
+- [https://download.memgraph.com/memgraph/v3.12.0/ubuntu-22.04/memgraph-debuginfo_3.12.0-1_amd64.deb](https://download.memgraph.com/memgraph/v3.12.0/ubuntu-22.04/memgraph-debuginfo_3.12.0-1_amd64.deb)
+- [https://download.memgraph.com/memgraph/v3.12.0/ubuntu-24.04/memgraph_3.12.0-1_amd64.deb](https://download.memgraph.com/memgraph/v3.12.0/ubuntu-24.04/memgraph_3.12.0-1_amd64.deb)
+- [https://download.memgraph.com/memgraph/v3.12.0/ubuntu-24.04/memgraph-debuginfo_3.12.0-1_amd64.deb](https://download.memgraph.com/memgraph/v3.12.0/ubuntu-24.04/memgraph-debuginfo_3.12.0-1_amd64.deb)
+- [https://download.memgraph.com/memgraph/v3.12.0/ubuntu-24.04-aarch64/memgraph_3.12.0-1_arm64.deb](https://download.memgraph.com/memgraph/v3.12.0/ubuntu-24.04-aarch64/memgraph_3.12.0-1_arm64.deb)
+- [https://download.memgraph.com/memgraph/v3.12.0/ubuntu-24.04-aarch64/memgraph-debuginfo_3.12.0-1_arm64.deb](https://download.memgraph.com/memgraph/v3.12.0/ubuntu-24.04-aarch64/memgraph-debuginfo_3.12.0-1_arm64.deb)
 
 # MAGE direct download links
 
 ## Docker
 
-- [MAGE Docker amd64 (release)](https://download.memgraph.com/memgraph-mage/v3.11.0/docker/mage-3.11.0.tar.gz)
-- [MAGE Docker arm64 (release)](https://download.memgraph.com/memgraph-mage/v3.11.0/docker-aarch64/mage-3.11.0-arm64.tar.gz)
-- [MAGE Docker amd64 (relwithdebinfo)](https://download.memgraph.com/memgraph-mage/v3.11.0/docker-relwithdebinfo/mage-3.11.0-relwithdebinfo.tar.gz)
-- [MAGE Docker arm64 (relwithdebinfo)](https://download.memgraph.com/memgraph-mage/v3.11.0/docker-aarch64-relwithdebinfo/mage-3.11.0-arm64-relwithdebinfo.tar.gz)
-- [MAGE Docker amd64 (malloc)](https://download.memgraph.com/memgraph-mage/v3.11.0/docker-malloc/mage-3.11.0-malloc.tar.gz)
-- [MAGE Docker amd64 (relwithdebinfo-malloc)](https://download.memgraph.com/memgraph-mage/v3.11.0/docker-malloc-relwithdebinfo/mage-3.11.0-relwithdebinfo-malloc.tar.gz)
-- [MAGE Docker arm64 (relwithdebinfo-malloc)](https://download.memgraph.com/memgraph-mage/v3.11.0/docker-malloc-aarch64-relwithdebinfo/mage-3.11.0-arm64-relwithdebinfo-malloc.tar.gz)
-- [MAGE Docker amd64 (relwithdebinfo-cuda)](https://download.memgraph.com/memgraph-mage/v3.11.0/docker-relwithdebinfo-cuda/mage-3.11.0-relwithdebinfo-cuda.tar.gz)
-- [MAGE Docker amd64 (relwithdebinfo-cugraph)](https://download.memgraph.com/memgraph-mage/v3.11.0/docker-relwithdebinfo-cugraph/mage-3.11.0-relwithdebinfo-cugraph.tar.gz)
+- [MAGE Docker amd64 (release)](https://download.memgraph.com/memgraph-mage/v3.12.0/docker/mage-3.12.0.tar.gz)
+- [MAGE Docker arm64 (release)](https://download.memgraph.com/memgraph-mage/v3.12.0/docker-aarch64/mage-3.12.0-arm64.tar.gz)
+- [MAGE Docker amd64 (relwithdebinfo)](https://download.memgraph.com/memgraph-mage/v3.12.0/docker-relwithdebinfo/mage-3.12.0-relwithdebinfo.tar.gz)
+- [MAGE Docker arm64 (relwithdebinfo)](https://download.memgraph.com/memgraph-mage/v3.12.0/docker-aarch64-relwithdebinfo/mage-3.12.0-arm64-relwithdebinfo.tar.gz)
+- [MAGE Docker amd64 (malloc)](https://download.memgraph.com/memgraph-mage/v3.12.0/docker-malloc/mage-3.12.0-malloc.tar.gz)
+- [MAGE Docker amd64 (relwithdebinfo-malloc)](https://download.memgraph.com/memgraph-mage/v3.12.0/docker-malloc-relwithdebinfo/mage-3.12.0-relwithdebinfo-malloc.tar.gz)
+- [MAGE Docker arm64 (relwithdebinfo-malloc)](https://download.memgraph.com/memgraph-mage/v3.12.0/docker-malloc-aarch64-relwithdebinfo/mage-3.12.0-arm64-relwithdebinfo-malloc.tar.gz)
+- [MAGE Docker amd64 (relwithdebinfo-cuda)](https://download.memgraph.com/memgraph-mage/v3.12.0/docker-relwithdebinfo-cuda/mage-3.12.0-relwithdebinfo-cuda.tar.gz)
+- [MAGE Docker amd64 (relwithdebinfo-cugraph)](https://download.memgraph.com/memgraph-mage/v3.12.0/docker-relwithdebinfo-cugraph/mage-3.12.0-relwithdebinfo-cugraph.tar.gz)
 
 
 ## Ubuntu 24.04
 
 These packages require the Memgraph packages to be installed first. The standard package installs with the CPU-only version of PyTorch. The CUDA and cuGraph versions use the CUDA-enabled version of PyTorch; the cuGraph version also requires cuGraph and CUDA Toolkit to be installed. The `memgraph-mage-debuginfo` package ships the debug symbols for the matching standard package.
 
-- [MAGE Ubuntu 24.04 amd64](https://download.memgraph.com/memgraph-mage/v3.11.0/ubuntu-24.04/memgraph-mage_3.11.0-1_amd64.deb)
-- [MAGE Ubuntu 24.04 arm64](https://download.memgraph.com/memgraph-mage/v3.11.0/ubuntu-24.04/memgraph-mage_3.11.0-1_arm64.deb)
-- [MAGE Ubuntu 24.04 amd64 (debuginfo)](https://download.memgraph.com/memgraph-mage/v3.11.0/ubuntu-24.04/memgraph-mage-debuginfo_3.11.0-1_amd64.deb)
-- [MAGE Ubuntu 24.04 arm64 (debuginfo)](https://download.memgraph.com/memgraph-mage/v3.11.0/ubuntu-24.04/memgraph-mage-debuginfo_3.11.0-1_arm64.deb)
-- [MAGE Ubuntu 24.04 amd64 (cuda)](https://download.memgraph.com/memgraph-mage/v3.11.0/ubuntu-24.04/memgraph-mage_3.11.0-1_amd64-cuda.deb)
-- [MAGE Ubuntu 24.04 amd64 (cuda debuginfo)](https://download.memgraph.com/memgraph-mage/v3.11.0/ubuntu-24.04/memgraph-mage-debuginfo_3.11.0-1_amd64-cuda.deb)
-- [MAGE Ubuntu 24.04 amd64 (cugraph)](https://download.memgraph.com/memgraph-mage/v3.11.0/ubuntu-24.04/memgraph-mage_3.11.0-1_amd64-cugraph.deb)
-- [MAGE Ubuntu 24.04 amd64 (cugraph debuginfo)](https://download.memgraph.com/memgraph-mage/v3.11.0/ubuntu-24.04/memgraph-mage-debuginfo_3.11.0-1_amd64-cugraph.deb)
+- [MAGE Ubuntu 24.04 amd64](https://download.memgraph.com/memgraph-mage/v3.12.0/ubuntu-24.04/memgraph-mage_3.12.0-1_amd64.deb)
+- [MAGE Ubuntu 24.04 arm64](https://download.memgraph.com/memgraph-mage/v3.12.0/ubuntu-24.04/memgraph-mage_3.12.0-1_arm64.deb)
+- [MAGE Ubuntu 24.04 amd64 (debuginfo)](https://download.memgraph.com/memgraph-mage/v3.12.0/ubuntu-24.04/memgraph-mage-debuginfo_3.12.0-1_amd64.deb)
+- [MAGE Ubuntu 24.04 arm64 (debuginfo)](https://download.memgraph.com/memgraph-mage/v3.12.0/ubuntu-24.04/memgraph-mage-debuginfo_3.12.0-1_arm64.deb)
+- [MAGE Ubuntu 24.04 amd64 (cuda)](https://download.memgraph.com/memgraph-mage/v3.12.0/ubuntu-24.04/memgraph-mage_3.12.0-1_amd64-cuda.deb)
+- [MAGE Ubuntu 24.04 amd64 (cuda debuginfo)](https://download.memgraph.com/memgraph-mage/v3.12.0/ubuntu-24.04/memgraph-mage-debuginfo_3.12.0-1_amd64-cuda.deb)
+- [MAGE Ubuntu 24.04 amd64 (cugraph)](https://download.memgraph.com/memgraph-mage/v3.12.0/ubuntu-24.04/memgraph-mage_3.12.0-1_amd64-cugraph.deb)
+- [MAGE Ubuntu 24.04 amd64 (cugraph debuginfo)](https://download.memgraph.com/memgraph-mage/v3.12.0/ubuntu-24.04/memgraph-mage-debuginfo_3.12.0-1_amd64-cugraph.deb)
+
+## CentOS
+
+These packages require the matching Memgraph package to be installed first. The package installs its Python dependencies during installation, so the target machine needs network access. The `memgraph-mage-debuginfo` package ships the debug symbols for the matching standard package. CentOS is `x86_64` only.
+
+- [MAGE CentOS 9 amd64](https://download.memgraph.com/memgraph-mage/v3.12.0/centos-9/memgraph-mage-3.12.0-1.centos-9.x86_64.rpm)
+- [MAGE CentOS 9 amd64 (debuginfo)](https://download.memgraph.com/memgraph-mage/v3.12.0/centos-9/memgraph-mage-debuginfo-3.12.0-1.centos-9.x86_64.rpm)
+- [MAGE CentOS 10 amd64](https://download.memgraph.com/memgraph-mage/v3.12.0/centos-10/memgraph-mage-3.12.0-1.centos-10.x86_64.rpm)
+- [MAGE CentOS 10 amd64 (debuginfo)](https://download.memgraph.com/memgraph-mage/v3.12.0/centos-10/memgraph-mage-debuginfo-3.12.0-1.centos-10.x86_64.rpm)


### PR DESCRIPTION
### Release note

- Added a section in the "Install MAGE" page to show how to install CentOS/Ubuntu packages.
- Updated direct download links with links to CentOS 9 and 10 builds of MAGE and bumped all versions to `3.12.0`.

### Related product PRs

PRs from product repo this doc page is related to: 

https://github.com/memgraph/memgraph/pull/4289

### Checklist:

- [x] Add appropriate milestone (current release cycle)
- [x] Add `bugfix` or `feature` label, based on the product PR type you're documenting
- [x] Make sure all relevant tech details are documented
    - [ ] Update reference pages (e.g. [clauses](https://memgraph.com/docs/querying/clauses), [functions](https://memgraph.com/docs/querying/functions), [flags](https://memgraph.com/docs/database-management/configuration#list-of-configuration-flags), [experimental](https://memgraph.com/docs/database-management/experimental-features), [monitoring](https://memgraph.com/docs/database-management/monitoring), [Cypher differences](https://memgraph.com/docs/querying/differences-in-cypher-implementations))
    - [ ] Search for the feature you are working on (mentions) and make updates if needed
    - [x] Provide a basic example of usage
    - [ ] In case your feature is an Enterprise one, list it under [ME page](https://memgraph.com/docs/database-management/enabling-memgraph-enterprise) and mark its page with Enterprise ([example](https://memgraph.com/docs/database-management/authentication-and-authorization/role-based-access-control)).
- [ ] Check all content with Grammarly
- [x] Perform a self-review of my code
- [x] The build passes locally
- [x] My changes generate no new warnings or errors