### PR TITLE
Add MemGQL v0.7.0

### DIFF
--- a/pages/memgraph-zero/memgql/changelog.mdx
+++ b/pages/memgraph-zero/memgql/changelog.mdx
@@ -5,10 +5,41 @@ description: MemGQL release notes
 
 # MemGQL Changelog
 
-## MemGQL v0.6.4 - TBD
+## MemGQL v0.7.0 - July 5th, 2026
+
+### ⚠️ Behavior changes
+
+- **The `info-queries-only` log level is removed.** `--log-level=info-queries-only`
+  now fails at startup with the list of valid levels. Use `--log-level=DEBUG` to see
+  queries and their transpiled output; plain `INFO` no longer logs query traffic.
+- **The log file now honors `--log-level`.** Previously the `--log-file` mirror
+  received every line regardless of the console level; now both destinations get the
+  same threshold-filtered stream.
 
 ### ✨ New features & Improvements
 
+- **Memgraph as a query-driven cache.** A catalog graph can now be cached in a
+  Memgraph instance — aimed at data-warehouse connectors (Iceberg first) where a
+  table is too large to materialize wholesale and every federated query otherwise
+  re-scans it from object storage. Enable it per graph with a `CACHE CONNECTOR`
+  clause:
+  ```gql
+  ADD CONNECTOR mg TYPE memgraph URI 'memgraph:7687';
+  ADD GRAPH events ON CONNECTOR ice MAPPING warehouse READ ONLY
+      CACHE CONNECTOR mg TTL 3600 MAX_BYTES 8G;
+  ```
+  The cache is **populated by query execution itself** (populate-on-read): the
+  first read of a scope tees it into Memgraph (cache MISS), and later queries whose
+  scans are covered are served entirely from Memgraph (cache HIT) with no source
+  I/O. Because the cached data is a real graph in Memgraph, queries over cached
+  scopes gain Memgraph's full capability profile — variable-length expand,
+  quantified patterns, graph algorithms — even when the source connector can't
+  express them. Toggle at runtime with `ALTER GRAPH <g> SET CACHE CONNECTOR …` /
+  `ALTER GRAPH <g> REMOVE CACHE`, and inspect with `SHOW GRAPH CACHES`. `TTL` is in
+  seconds; `MAX_BYTES` accepts a `K`/`M`/`G`/`T` binary suffix. Currently validated
+  with Iceberg sources; the mechanism generalizes to the other warehouse
+  connectors. See
+  [Multiple Graphs → Caching](/memgraph-zero/memgql/multiple-graphs#caching-a-graph-in-memgraph).
 - **Cross-backend piping.** Federated queries move far less data. When one side of a
   two-backend query is selective — it carries a literal property filter
   (`{name: 'Memgraph'}`), a `LIMIT`, or a bounded `CALL` — MemGQL runs that side
@@ -21,13 +52,11 @@ description: MemGQL release notes
   [Multiple Graphs](/memgraph-zero/memgql/multiple-graphs#piping-fetching-only-what-joins).
 - **Inline-map references across backends.** A property inside a node's inline map can
   now reference a binding from another `MATCH` part — and it pipes:
-
   ```gql
   MATCH (e:Employee)
   MATCH (i:Invoice {employee_id: e.id})
   RETURN e.name, i.total;
   ```
-
   Previously this join had to be spelled as `WHERE i.employee_id = e.id`. Works
   USE-free (each part routes by its own labels) and with multiple keys
   (`{country: o.country, city: o.city}`).
@@ -39,13 +68,11 @@ description: MemGQL release notes
   SQL backend and is registered in
   [`multi` mode](/memgraph-zero/memgql/multiple-graphs) with an ADO-style
   connection string:
-
   ```gql
   ADD CONNECTOR mssql TYPE sqlserver
       URI 'Server=localhost,1433;Database=test;User Id=sa;Password=…;TrustServerCertificate=true'
       MAPPING social;
   ```
-
   There is no standalone `CONNECTOR_TYPE=sqlserver` environment mode yet — SQL Server
   is multi-mode only. Works today: matching and filters, aggregates
   (incl. `COUNT(DISTINCT …)`), arithmetic, `CASE`, `COALESCE` / `NULLIF`, string
@@ -61,15 +88,6 @@ description: MemGQL release notes
   (case-insensitive). A level also emits everything more severe. Incoming queries and
   the generated Cypher / SQL are logged at `DEBUG`. See
   [Reference](/memgraph-zero/memgql/reference#logging).
-
-### ⚠️ Behavior changes
-
-- **The `info-queries-only` log level is removed.** `--log-level=info-queries-only`
-  now fails at startup with the list of valid levels. Use `--log-level=DEBUG` to see
-  queries and their transpiled output; plain `INFO` no longer logs query traffic.
-- **The log file now honors `--log-level`.** Previously the `--log-file` mirror
-  received every line regardless of the console level; now both destinations get the
-  same threshold-filtered stream.
 
 ## MemGQL v0.6.3 - June 21st, 2026
 

--- a/pages/memgraph-zero/memgql/changelog.mdx
+++ b/pages/memgraph-zero/memgql/changelog.mdx
@@ -5,6 +5,72 @@ description: MemGQL release notes
 
 # MemGQL Changelog
 
+## MemGQL v0.6.4 - TBD
+
+### ✨ New features & Improvements
+
+- **Cross-backend piping.** Federated queries move far less data. When one side of a
+  two-backend query is selective — it carries a literal property filter
+  (`{name: 'Memgraph'}`), a `LIMIT`, or a bounded `CALL` — MemGQL runs that side
+  first and uses its join keys to fetch only the matching rows from the other
+  backend, instead of pulling the whole table and joining locally. Results are
+  identical; queries that join a small, filtered set against a large remote table
+  get faster. If the selective side matches nothing, the other backend isn't queried
+  at all. Piping applies to backends registered as catalog graphs (`ADD GRAPH`) and
+  falls back to the previous behavior whenever it can't apply. See
+  [Multiple Graphs](/memgraph-zero/memgql/multiple-graphs#piping-fetching-only-what-joins).
+- **Inline-map references across backends.** A property inside a node's inline map can
+  now reference a binding from another `MATCH` part — and it pipes:
+
+  ```gql
+  MATCH (e:Employee)
+  MATCH (i:Invoice {employee_id: e.id})
+  RETURN e.name, i.total;
+  ```
+
+  Previously this join had to be spelled as `WHERE i.employee_id = e.id`. Works
+  USE-free (each part routes by its own labels) and with multiple keys
+  (`{country: o.country, city: o.city}`).
+- **SQL Server connector.** New `sqlserver` connector type (aliases: `mssql`,
+  `sql_server`, `sql-server`) translates GQL to T-SQL. The driver is
+  [tiberius](https://crates.io/crates/tiberius), a pure-Rust TDS
+  implementation: no ODBC or driver install needed. It uses the same
+  [mapping](/memgraph-zero/memgql/reference#mapping-schema) format as every other
+  SQL backend and is registered in
+  [`multi` mode](/memgraph-zero/memgql/multiple-graphs) with an ADO-style
+  connection string:
+
+  ```gql
+  ADD CONNECTOR mssql TYPE sqlserver
+      URI 'Server=localhost,1433;Database=test;User Id=sa;Password=…;TrustServerCertificate=true'
+      MAPPING social;
+  ```
+
+  There is no standalone `CONNECTOR_TYPE=sqlserver` environment mode yet — SQL Server
+  is multi-mode only. Works today: matching and filters, aggregates
+  (incl. `COUNT(DISTINCT …)`), arithmetic, `CASE`, `COALESCE` / `NULLIF`, string
+  predicates, `IN`, `OPTIONAL MATCH`, `WITH` pipelines (incl. whole-node carry-through),
+  `UNION`, and typed whole-node / whole-relationship projections. See the
+  [SQL Server connector page](/memgraph-zero/memgql/connect/sqlserver) for setup and
+  for what's not there yet (variable-length paths, `collect()`, map projections).
+- **`ADD GRAPH IF NOT EXISTS`.** Re-registering an existing graph with the new
+  `IF NOT EXISTS` clause succeeds as a no-op instead of erroring — for re-runnable
+  setup scripts. Plain `ADD GRAPH` still errors on a duplicate name.
+- **Log levels.** `--log-level` now accepts the standard severity ladder:
+  `CRITICAL`, `ERROR`, `WARNING`, `INFO` (default), `DEBUG`, `TRACE`
+  (case-insensitive). A level also emits everything more severe. Incoming queries and
+  the generated Cypher / SQL are logged at `DEBUG`. See
+  [Reference](/memgraph-zero/memgql/reference#logging).
+
+### ⚠️ Behavior changes
+
+- **The `info-queries-only` log level is removed.** `--log-level=info-queries-only`
+  now fails at startup with the list of valid levels. Use `--log-level=DEBUG` to see
+  queries and their transpiled output; plain `INFO` no longer logs query traffic.
+- **The log file now honors `--log-level`.** Previously the `--log-file` mirror
+  received every line regardless of the console level; now both destinations get the
+  same threshold-filtered stream.
+
 ## MemGQL v0.6.3 - June 21st, 2026
 
 ### ✨ New features & Improvements

--- a/pages/memgraph-zero/memgql/complete.mdx
+++ b/pages/memgraph-zero/memgql/complete.mdx
@@ -102,7 +102,7 @@ Save the following as `docker-compose.yml`:
 ```yaml
 services:
   memgql:
-    image: ${MEMGQL_IMAGE:-memgraph/memgql:0.6.3}
+    image: ${MEMGQL_IMAGE:-memgraph/memgql:0.6.4}
     container_name: memgql
     ports:
       - "7688:7688"

--- a/pages/memgraph-zero/memgql/complete.mdx
+++ b/pages/memgraph-zero/memgql/complete.mdx
@@ -102,7 +102,7 @@ Save the following as `docker-compose.yml`:
 ```yaml
 services:
   memgql:
-    image: ${MEMGQL_IMAGE:-memgraph/memgql:0.6.4}
+    image: ${MEMGQL_IMAGE:-memgraph/memgql:0.7.0}
     container_name: memgql
     ports:
       - "7688:7688"

--- a/pages/memgraph-zero/memgql/connect/_meta.ts
+++ b/pages/memgraph-zero/memgql/connect/_meta.ts
@@ -7,5 +7,6 @@ export default {
   "oracle": "to Oracle",
   "postgres": "to PostgreSQL",
   "mysql": "to MySQL",
+  "sqlserver": "to SQL Server",
   "pinot": "to Pinot",
 }

--- a/pages/memgraph-zero/memgql/connect/sqlserver.mdx
+++ b/pages/memgraph-zero/memgql/connect/sqlserver.mdx
@@ -1,0 +1,184 @@
+---
+title: SQL Server
+description: Connect MemGQL to Microsoft SQL Server.
+---
+
+# SQL Server
+
+The SQL Server connector (type `sqlserver`; `mssql`, `sql_server`, and
+`sql-server` are accepted aliases) translates GQL queries into T-SQL. It
+requires a [mapping file](/memgraph-zero/memgql/reference#mapping-schema) that
+maps graph patterns to relational tables — the same format as every other SQL
+backend.
+
+The driver is [tiberius](https://crates.io/crates/tiberius), a **pure-Rust**
+implementation of the TDS wire protocol. No ODBC driver or system packages are
+required at build or runtime.
+
+SQL Server is available in
+[`multi` mode](/memgraph-zero/memgql/multiple-graphs) only — there is no
+standalone `CONNECTOR_TYPE=sqlserver` environment mode yet. You register it at
+runtime with `ADD CONNECTOR … TYPE sqlserver`, as shown below.
+
+## 1. Start SQL Server
+
+```bash
+docker network create memgql-net
+
+docker run -d --rm \
+    --name sqlserver-dev \
+    --network memgql-net \
+    -p 1433:1433 \
+    --env ACCEPT_EULA=Y \
+    --env MSSQL_SA_PASSWORD='Memgraph!2024' \
+    --env MSSQL_PID=Developer \
+    mcr.microsoft.com/mssql/server:2022-latest
+```
+
+SQL Server takes ~20 seconds to accept connections. Then create a working
+database:
+
+```bash
+docker exec sqlserver-dev /opt/mssql-tools18/bin/sqlcmd \
+    -S localhost -U sa -P 'Memgraph!2024' -C \
+    -Q "IF DB_ID('test') IS NULL CREATE DATABASE [test]"
+```
+
+## 2. Seed data
+
+```bash
+docker exec -i sqlserver-dev /opt/mssql-tools18/bin/sqlcmd \
+    -S localhost -U sa -P 'Memgraph!2024' -C -b -d test << 'SQL'
+CREATE TABLE persons (
+    id   INT IDENTITY(1,1) PRIMARY KEY,
+    name NVARCHAR(255) NOT NULL,
+    age  INT
+);
+CREATE TABLE companies (
+    id   INT IDENTITY(1,1) PRIMARY KEY,
+    name NVARCHAR(255) NOT NULL
+);
+CREATE TABLE knows (
+    id      INT IDENTITY(1,1) PRIMARY KEY,
+    from_id INT NOT NULL REFERENCES persons(id),
+    to_id   INT NOT NULL REFERENCES persons(id)
+);
+CREATE TABLE works_at (
+    id         INT IDENTITY(1,1) PRIMARY KEY,
+    person_id  INT NOT NULL REFERENCES persons(id),
+    company_id INT NOT NULL REFERENCES companies(id)
+);
+
+INSERT INTO persons (name, age) VALUES ('Alice', 30), ('Bob', 25);
+INSERT INTO companies (name) VALUES ('Acme Corp');
+INSERT INTO knows (from_id, to_id) VALUES (1, 2);
+INSERT INTO works_at (person_id, company_id) VALUES (1, 1);
+GO
+SQL
+```
+
+## 3. Write the mapping
+
+Save as `mapping.json` — the standard
+[mapping format](/memgraph-zero/memgql/reference#mapping-schema). Declare every
+property you plan to query: in `multi` mode the mapping is also the routing
+schema, and a property that isn't declared is a routing error, not a
+passthrough.
+
+```json
+{
+  "nodes": [
+    {
+      "label": "Person", "table": "persons", "id_column": "id",
+      "properties": { "name": "name", "age": "age" }
+    },
+    {
+      "label": "Company", "table": "companies", "id_column": "id",
+      "properties": { "name": "name" }
+    }
+  ],
+  "edges": [
+    {
+      "rel_type": "KNOWS", "table": "knows", "id_column": "id",
+      "source_column": "from_id", "target_column": "to_id",
+      "source_label": "Person", "target_label": "Person"
+    },
+    {
+      "rel_type": "WORKS_AT", "table": "works_at", "id_column": "id",
+      "source_column": "person_id", "target_column": "company_id",
+      "source_label": "Person", "target_label": "Company"
+    }
+  ]
+}
+```
+
+## 4. Start MemGQL in multi mode
+
+```bash
+docker run --rm \
+    --name memgql \
+    --network memgql-net \
+    --stop-timeout 2 \
+    -p 7688:7688 \
+    --env CONNECTOR_TYPE=multi \
+    --env BOLT_LISTEN_ADDR=0.0.0.0:7688 \
+    -v ./mapping.json:/data/mapping.json \
+    memgraph/memgql:latest
+```
+
+## 5. Connect and register the backend
+
+```bash
+mgconsole --port 7688
+```
+
+```gql
+ADD MAPPING social FROM '/data/mapping.json';
+ADD CONNECTOR ss TYPE sqlserver
+    URI 'Server=sqlserver-dev,1433;Database=test;User Id=sa;Password=Memgraph!2024;TrustServerCertificate=true'
+    MAPPING social;
+CONNECT ss AS ss_conn;
+```
+
+The `URI` is an ADO-style connection string
+(`Server=<host>,<port>;Database=<db>;User Id=<user>;Password=<pass>;…`).
+
+## 6. Query
+
+```gql
+MATCH (p:Person) RETURN p.name, p.age;
+```
+
+```gql
+MATCH (p:Person)-[:WORKS_AT]->(c:Company) RETURN p.name, c.name;
+```
+
+```gql
+MATCH (a:Person)-[:KNOWS]->(b:Person) RETURN a.name, b.name;
+```
+
+## Dialect notes
+
+- Positional bind parameters use SQL Server's native `@P1`, `@P2`, … form.
+- `LIMIT n` / `SKIP m` render as `ORDER BY … OFFSET m ROWS FETCH NEXT n ROWS
+  ONLY`; when the query has no `ORDER BY`, a neutral `ORDER BY (SELECT NULL)`
+  is synthesized because T-SQL requires one for `OFFSET`/`FETCH`.
+- Booleans are emitted as `BIT` (`1`/`0`).
+- `char_length()` / `length()` on a column translate to T-SQL `LEN()`.
+- No `INSERT … RETURNING` — SQL Server's `OUTPUT` clause is used only when the
+  caller needs the auto-generated key.
+
+## Known limitations
+
+- **Variable-length paths** — quantified path patterns (`(){1,3}`) and trail
+  semantics are not available on SQL Server yet and return an actionable error.
+  Use a bounded fixed-hop chain or a Cypher backend.
+- **`collect()`** is not available — there is no portable array aggregate in
+  the T-SQL surface MemGQL emits yet; the query fails with the backend's error.
+- **Map projections** (`RETURN n {.a, .b}`) currently return `NULL` instead of
+  a map (no error is raised) — don't rely on them on this backend.
+- **`INSERT … RETURN`** executes the insert but returns the affected-row count
+  instead of the projected values.
+
+For connector configuration, see
+[Reference](/memgraph-zero/memgql/reference#sql-server-sqlserver).

--- a/pages/memgraph-zero/memgql/features.mdx
+++ b/pages/memgraph-zero/memgql/features.mdx
@@ -5,28 +5,29 @@ description: MemGQL Community and Enterprise feature comparison.
 
 # Features
 
-| Feature                                                                                           | Community | [Enterprise](https://memgraph.com/contact-us) |
-|---------------------------------------------------------------------------------------------------|-----------|-----------------------------------------------|
-| GQL to Cypher translation                                                                         | Yes       | Yes                                           |
-| GQL to SQL translation                                                                            | Yes       | Yes                                           |
-| Bolt protocol                                                                                     | Yes       | Yes                                           |
-| **Connectors**                                                                                    |           |                                               |
-| [Memgraph](/memgraph-zero/memgql/connect/memgraph)                                                | Yes       | Yes                                           |
-| [Neo4j](/memgraph-zero/memgql/connect/neo4j)                                                      | Yes       | Yes                                           |
-| [PostgreSQL](/memgraph-zero/memgql/connect/postgres)                                              | Yes       | Yes                                           |
-| [DuckDB](/memgraph-zero/memgql/connect/duckdb)                                                    | Yes       | Yes                                           |
-| [Iceberg (Trino)](/memgraph-zero/memgql/connect/iceberg#trino-iceberg)                            | Yes       | Yes                                           |
-| [Iceberg (direct/native)](/memgraph-zero/memgql/connect/iceberg#direct-execution-iceberg-direct)  | Yes       | Yes                                           |
-| [ClickHouse](/memgraph-zero/memgql/connect/clickhouse)                                            | Yes       | Yes                                           |
-| [MySQL](/memgraph-zero/memgql/connect/mysql)                                                      | Yes       | Yes                                           |
-| [Pinot](/memgraph-zero/memgql/connect/pinot)                                                      | Yes       | Yes                                           |
-| [Oracle](/memgraph-zero/memgql/connect/oracle)                                                    | Yes       | Yes                                           |
-| [SQL Server](/memgraph-zero/memgql/connect/sqlserver)                                             | Yes       | Yes                                           |
-| **Multi-Connection Mode**                                                                         | Yes       | Yes                                           |
-| Max connectors                                                                                    | 2         | Unlimited                                     |
-| Max simultaneous connections                                                                      | 2         | Unlimited                                     |
-| [Cross-backend joins & composite queries](/memgraph-zero/memgql/multiple-graphs)                  | Yes       | Yes                                           |
-| [Schema-based routing (USE-free queries)](/memgraph-zero/memgql/multiple-graphs#use-free-routing) | Yes       | Yes                                           |
-| **Agentic Capabilities**                                                                          |           |                                               |
-| MCP Server                                                                                        | Yes       | Yes                                           |
-| Structured2Graph Agent to create mappings                                                         | Yes       | Yes                                           |
+| Feature                                                                                                  | Community | [Enterprise](https://memgraph.com/contact-us) |
+|----------------------------------------------------------------------------------------------------------|-----------|-----------------------------------------------|
+| GQL to Cypher translation                                                                                | Yes       | Yes                                           |
+| GQL to SQL translation                                                                                   | Yes       | Yes                                           |
+| Bolt protocol                                                                                            | Yes       | Yes                                           |
+| **Connectors**                                                                                           |           |                                               |
+| [Memgraph](/memgraph-zero/memgql/connect/memgraph)                                                       | Yes       | Yes                                           |
+| [Neo4j](/memgraph-zero/memgql/connect/neo4j)                                                             | Yes       | Yes                                           |
+| [PostgreSQL](/memgraph-zero/memgql/connect/postgres)                                                     | Yes       | Yes                                           |
+| [DuckDB](/memgraph-zero/memgql/connect/duckdb)                                                           | Yes       | Yes                                           |
+| [Iceberg (Trino)](/memgraph-zero/memgql/connect/iceberg#trino-iceberg)                                   | Yes       | Yes                                           |
+| [Iceberg (direct/native)](/memgraph-zero/memgql/connect/iceberg#direct-execution-iceberg-direct)         | Yes       | Yes                                           |
+| [ClickHouse](/memgraph-zero/memgql/connect/clickhouse)                                                   | Yes       | Yes                                           |
+| [MySQL](/memgraph-zero/memgql/connect/mysql)                                                             | Yes       | Yes                                           |
+| [Pinot](/memgraph-zero/memgql/connect/pinot)                                                             | Yes       | Yes                                           |
+| [Oracle](/memgraph-zero/memgql/connect/oracle)                                                           | Yes       | Yes                                           |
+| [SQL Server](/memgraph-zero/memgql/connect/sqlserver)                                                    | Yes       | Yes                                           |
+| **Multi-Connection Mode**                                                                                | Yes       | Yes                                           |
+| Max connectors                                                                                           | 2         | Unlimited                                     |
+| Max simultaneous connections                                                                             | 2         | Unlimited                                     |
+| [Cross-backend joins & composite queries](/memgraph-zero/memgql/multiple-graphs)                         | Yes       | Yes                                           |
+| [Schema-based routing (USE-free queries)](/memgraph-zero/memgql/multiple-graphs#use-free-routing)        | Yes       | Yes                                           |
+| [Query-driven graph cache (Memgraph)](/memgraph-zero/memgql/multiple-graphs#caching-a-graph-in-memgraph) | Yes       | Yes                                           |
+| **Agentic Capabilities**                                                                                 |           |                                               |
+| MCP Server                                                                                               | Yes       | Yes                                           |
+| Structured2Graph Agent to create mappings                                                                | Yes       | Yes                                           |

--- a/pages/memgraph-zero/memgql/features.mdx
+++ b/pages/memgraph-zero/memgql/features.mdx
@@ -21,6 +21,7 @@ description: MemGQL Community and Enterprise feature comparison.
 | [MySQL](/memgraph-zero/memgql/connect/mysql)                                                      | Yes       | Yes                                           |
 | [Pinot](/memgraph-zero/memgql/connect/pinot)                                                      | Yes       | Yes                                           |
 | [Oracle](/memgraph-zero/memgql/connect/oracle)                                                    | Yes       | Yes                                           |
+| [SQL Server](/memgraph-zero/memgql/connect/sqlserver)                                             | Yes       | Yes                                           |
 | **Multi-Connection Mode**                                                                         | Yes       | Yes                                           |
 | Max connectors                                                                                    | 2         | Unlimited                                     |
 | Max simultaneous connections                                                                      | 2         | Unlimited                                     |

--- a/pages/memgraph-zero/memgql/multiple-graphs.mdx
+++ b/pages/memgraph-zero/memgql/multiple-graphs.mdx
@@ -238,7 +238,7 @@ RETURN friend.email AS email, e.item AS item, e.amount AS amount;
 
 ### Piping: fetching only what joins
 
-Since v0.6.4, when one side of a two-backend query is selective — it carries a
+Since v0.7.0, when one side of a two-backend query is selective — it carries a
 literal property filter, a `LIMIT`, or a bounded `CALL` — MemGQL runs that side
 first and uses its join keys to fetch only the matching rows from the other
 backend, instead of pulling the whole table:
@@ -416,9 +416,67 @@ DROP GRAPH analytics;
 DROP GRAPH IF EXISTS analytics;
 ```
 
+## Caching a graph in Memgraph
+
+Since v0.7.0, a graph can be **cached in a Memgraph instance**. This is aimed at
+data-warehouse connectors (Iceberg first) where a table is too large to
+materialize wholesale and every federated query otherwise re-scans it from
+object storage. The cache is **query-driven**: it is populated by execution
+itself (populate-on-read), so only the subgraph your queries actually touch
+lands in Memgraph.
+
+Register a Memgraph connector to hold the cached data, then mark a graph
+cache-enabled with a `CACHE CONNECTOR` clause:
+
+```gql
+-- A Memgraph instance (storage mode IN_MEMORY_ANALYTICAL) holds the cache
+ADD CONNECTOR mg TYPE memgraph URI 'memgraph:7687';
+
+-- Cache the warehouse graph in `mg`, with optional bounds
+ADD GRAPH events ON CONNECTOR ice MAPPING warehouse READ ONLY
+    CACHE CONNECTOR mg TTL 3600 MAX_BYTES 8G;
+
+-- Or enable/disable caching on an already-registered graph
+ALTER GRAPH events SET CACHE CONNECTOR mg TTL 3600 MAX_BYTES 8G;
+ALTER GRAPH events REMOVE CACHE;
+```
+
+`TTL` is in seconds; `MAX_BYTES` accepts a plain byte count or a `K`/`M`/`G`/`T`
+binary suffix (`8G` = 8 × 1024³ bytes).
+
+How it behaves per `USE` part:
+
+- **First read (cache MISS)** — the query runs on the source and the engine
+  *tees* the scanned labels and edge types into the Memgraph cache, recording
+  which scopes it cached.
+- **Later covered read (cache HIT)** — a query whose scans are covered by
+  existing cached scopes is served entirely from Memgraph, with no source I/O.
+- **Capability upgrade** — because cached data is a real graph in Memgraph,
+  queries over cached scopes can use Memgraph's full capability profile
+  (variable-length paths, quantified patterns, graph algorithms) even when the
+  source connector cannot express them:
+
+  ```gql
+  -- iceberg-direct cannot execute a variable-length expand; against the
+  -- Memgraph-resident cache of the same data it just works
+  USE events MATCH (a:Event) (-[:SPAWNED]->())+ (b:Event)
+  RETURN a.event_id, b.event_id;
+  ```
+
+In a cross-connector (multi-`USE`) query, each cache-enabled part is served
+from its cache independently while the other parts run on their own sources.
+
+Inspect what is cached with `SHOW GRAPH CACHES` (returns each cache-enabled
+graph, its cache connector, `TTL`, `MAX_BYTES`, and the number of cached
+fragments). Cache activity is logged at `DEBUG` as `[CACHE] MISS … teeing …`
+and `[CACHE] HIT … serving from cache connector …`.
+
+> **Note:** The query-driven cache is currently validated with Iceberg sources;
+> the mechanism generalizes to the other warehouse connectors.
+
 ## Cross-Graph Query Rules
 
-1. **No pushed joins across backends**: The join itself always executes locally; the engine never pushes join operations across different backends. (Since v0.6.4, [piping](#piping-fetching-only-what-joins) may push the selective side's join keys as a filter so the other side materializes only matching rows.)
+1. **No pushed joins across backends**: The join itself always executes locally; the engine never pushes join operations across different backends. (Since v0.7.0, [piping](#piping-fetching-only-what-joins) may push the selective side's join keys as a filter so the other side materializes only matching rows.)
 
 2. **Property-based join keys**: Join keys must use node/edge properties. Internal IDs are backend-specific and not comparable across connectors.
 

--- a/pages/memgraph-zero/memgql/multiple-graphs.mdx
+++ b/pages/memgraph-zero/memgql/multiple-graphs.mdx
@@ -35,6 +35,9 @@ ADD GRAPH social ON CONNECTOR neo4j_prod GRAPH neo4j;
 ADD GRAPH events ON CONNECTOR clickhouse_logs READ ONLY;
 ADD GRAPH warehouse ON CONNECTOR postgres_dw MAPPING company_mapping READ ONLY;
 ADD GRAPH dev ON CONNECTOR memgraph_dev;
+
+-- No-op if the name is already registered (re-runnable setup scripts)
+ADD GRAPH IF NOT EXISTS social ON CONNECTOR neo4j_prod GRAPH neo4j;
 ```
 
 Each graph entry stores:
@@ -233,6 +236,27 @@ WHERE e.user_email = friend.email AND e.type = 'purchase'
 RETURN friend.email AS email, e.item AS item, e.amount AS amount;
 ```
 
+### Piping: fetching only what joins
+
+Since v0.6.4, when one side of a two-backend query is selective — it carries a
+literal property filter, a `LIMIT`, or a bounded `CALL` — MemGQL runs that side
+first and uses its join keys to fetch only the matching rows from the other
+backend, instead of pulling the whole table:
+
+```gql
+-- {community: 42} makes the Memgraph side selective; only the matching
+-- profiles are fetched from Postgres.
+MATCH (u:User {community: 42})
+MATCH (p:Profile {uid: u.uid})
+RETURN p.name, u.rank ORDER BY u.rank DESC;
+```
+
+Piping is an optimization, not a semantic change — results are identical with
+or without it. It engages for backends registered as catalog graphs
+(`ADD GRAPH`); when it doesn't apply, MemGQL pulls both sides and joins
+locally. If the selective side matches nothing, the other backend is never
+queried.
+
 ## Composite Queries Across Graphs
 
 The GQL standard defines composite expressions combining query branches with `UNION`, `INTERSECT`, and `EXCEPT`. Each branch can target a different graph.
@@ -394,7 +418,7 @@ DROP GRAPH IF EXISTS analytics;
 
 ## Cross-Graph Query Rules
 
-1. **No pushed joins across backends**: Cross-graph joins always materialize both sides locally and hash-join. The engine never pushes join operations across different backends.
+1. **No pushed joins across backends**: The join itself always executes locally; the engine never pushes join operations across different backends. (Since v0.6.4, [piping](#piping-fetching-only-what-joins) may push the selective side's join keys as a filter so the other side materializes only matching rows.)
 
 2. **Property-based join keys**: Join keys must use node/edge properties. Internal IDs are backend-specific and not comparable across connectors.
 

--- a/pages/memgraph-zero/memgql/reference.mdx
+++ b/pages/memgraph-zero/memgql/reference.mdx
@@ -9,8 +9,8 @@ What works today, split by backend category. "Cypher backends" means
 Memgraph and Neo4j (translation is largely passthrough); "SQL backends"
 means PostgreSQL, MySQL and DuckDB.
 
-ClickHouse, Apache Iceberg, and Apache Pinot are also supported as
-connectors but with a narrower verified surface. See each connector's page for the exact list of features each one
+SQL Server, ClickHouse, Apache Iceberg, and Apache Pinot are also supported
+as connectors but with a narrower verified surface. See each connector's page for the exact list of features each one
 supports.
 
 | Feature                                                            | Cypher backends | SQL backends |
@@ -26,10 +26,10 @@ supports.
 | `MATCH (n)-[r:R]->(m)` typed edge expansion                        | ✓               | ✓            |
 | Untyped edge `()-[]->(b)` (union over types)                       | ✓               | ✗            |
 | `UNION` / `UNION ALL` / `UNION DISTINCT`                           | ✓               | ✓            |
-| `INTERSECT` / `EXCEPT`                                             | ✗               | ✗            |
+| `INTERSECT` / `EXCEPT`                                             | ✓               | ✓            |
 | Quantified path `(){m,n}` — bounded                                | ✓               | ✓            |
 | Quantified path `(){m,}` — unbounded                               | ✓               | ✗            |
-| Shortest-path (`ALL SHORTEST` / `ANY SHORTEST` / `SHORTEST k`) | ✓ | ✗               | ✗            |
+| Shortest-path (`ALL SHORTEST` / `ANY SHORTEST` / `SHORTEST k`)    | ✓               | ✗            |
 | Whole-node `RETURN n` / whole-relationship `RETURN r`              | ✓               | ✓            |
 | Map projections `RETURN n {.id, .title}`                           | ✓               | ✓            |
 | Connection-less `RETURN 1` / `RETURN 1 + 2` (liveness)            | ✓               | ✓            |
@@ -59,6 +59,9 @@ supports.
 - **`FOR x IN [...]` (UNWIND-style) on SQL backends** returns an
   actionable error pointing users at running the query on a Cypher
   backend. The form is still accepted natively on Cypher backends.
+- **`DETACH DELETE` on SQL backends** currently executes as a plain `DELETE` —
+  relationship rows are not detached. It deletes a node that has no relationship
+  rows and otherwise surfaces the backend's constraint error; don't rely on it.
 - **Path variables on variable-length patterns** —
   `MATCH p = (a){1,3}(b) RETURN p` is not yet supported on SQL backends.
   Drop the `p =` binding (or query a Cypher backend) and `RETURN` the
@@ -67,7 +70,7 @@ supports.
 ## Graph Management Query Syntax
 
 ```
-ADD GRAPH <name> ON CONNECTOR <connector>
+ADD GRAPH [IF NOT EXISTS] <name> ON CONNECTOR <connector>
     [GRAPH <remote_name>]
     [MAPPING <mapping_name>]
     [READ ONLY];
@@ -86,6 +89,10 @@ ALTER GRAPH <name> SET GRAPH <remote_name>;
 ALTER GRAPH <name> SET MAPPING <mapping_name>;
 ALTER GRAPH <name> REMOVE MAPPING;
 ```
+
+`ADD GRAPH IF NOT EXISTS` succeeds as a no-op when the name is already
+registered — for re-runnable setup scripts; plain `ADD GRAPH` errors on a
+duplicate name.
 
 ```
 SHOW SCHEMA [FOR <graph>];   -- unified routing index: labels, rel-types, properties
@@ -125,31 +132,40 @@ for property-level introspection. See
 
 ### Logging
 
-MemGQL writes log lines to the console (stdout/stderr) and, in parallel, to a
-log file. Both destinations are configured via CLI flags on the Bolt server
-binary.
+MemGQL writes log lines to the console (stdout for most levels, stderr for
+`ERROR` and `CRITICAL`) and, in parallel, to a log file. Both destinations
+receive the same stream, filtered by `--log-level`. Both are configured via
+CLI flags on the Bolt server binary.
 
 #### CLI Flags
 
-| Flag                   | Default            | Description                                                  |
-|------------------------|--------------------|--------------------------------------------------------------|
-| `--log-level=<LEVEL>`  | `info`             | Console logging verbosity (see levels below)                 |
-| `--log-file=<PATH>`    | `bolt_server.log`  | File to mirror all log output to (always written, regardless of `--log-level`) |
+| Flag                   | Default            | Description                                          |
+|------------------------|--------------------|------------------------------------------------------|
+| `--log-level=<LEVEL>`  | `INFO`             | Logging verbosity for console and file (see below)   |
+| `--log-file=<PATH>`    | `bolt_server.log`  | File to mirror the (level-filtered) log output to    |
 
 #### Log Levels
 
-| Level                | Console output                                                                  |
-|----------------------|---------------------------------------------------------------------------------|
-| `info`               | Full logging: connections, incoming queries, transpiled output, results, state changes |
-| `info-queries-only`  | Only the incoming GQL query and its transpiled output (Cypher / SQL)            |
+Levels form a severity ladder — picking a level also emits everything more
+severe. Values are case-insensitive (`--log-level=debug` and
+`--log-level=DEBUG` are the same; `WARN` is accepted for `WARNING`).
 
-`info` is the most verbose level today. There is no `debug` or `trace`. The
-`RUST_LOG` environment variable is not consulted.
+| Level      | What it adds                                                          |
+|------------|-----------------------------------------------------------------------|
+| `CRITICAL` | Critical failures only                                                |
+| `ERROR`    | + errors                                                              |
+| `WARNING`  | + warnings                                                            |
+| `INFO`     | + connections, state changes, lifecycle events (**default**)          |
+| `DEBUG`    | + incoming queries and their transpiled Cypher / SQL                  |
+| `TRACE`    | + plan and per-row execution detail                                   |
 
-The log file always receives every log line — including queries, errors, and
-state changes — independent of the console `--log-level`. To silence the
-console while keeping a full file record, use `--log-level=info-queries-only`
-and tail the log file separately.
+An unknown level fails at startup with an actionable error listing the valid
+values. The `RUST_LOG` environment variable is not consulted.
+
+To see query traffic and what MemGQL translates it into, run with
+`--log-level=DEBUG`. The `info-queries-only` value from earlier releases was
+removed in v0.6.4 — see the
+[changelog](/memgraph-zero/memgql/changelog).
 
 ### Enterprise License
 
@@ -174,6 +190,7 @@ connections.
 | `postgres`     | GQL -> SQL         | PostgreSQL                       |
 | `mysql`        | GQL -> SQL         | MySQL 8.0+                       |
 | `oracle`       | GQL -> SQL         | Oracle 19c+ (incl. Free 23ai)    |
+| `sqlserver`    | GQL -> SQL         | Microsoft SQL Server (multi mode only) |
 | `duckdb`       | GQL -> SQL         | DuckDB (embedded)                |
 | `clickhouse`   | GQL -> SQL         | ClickHouse                       |
 | `iceberg`        | GQL -> SQL                | Iceberg via Trino              |
@@ -227,6 +244,22 @@ pure-Rust implementation of Oracle's TNS wire protocol, pooled via
 / Instant Client is required at build or runtime — the bundled Docker image
 ships only the bolt server binary plus TLS roots, and local builds work on
 macOS, Linux, and Windows without any extra system packages.
+
+#### SQL Server (`sqlserver`)
+
+SQL Server has no standalone environment-variable mode — `CONNECTOR_TYPE=sqlserver`
+is not supported. Register it at runtime in
+[`multi` mode](/memgraph-zero/memgql/multiple-graphs) with an ADO-style
+connection string:
+
+```gql
+ADD CONNECTOR mssql TYPE sqlserver
+    URI 'Server=localhost,1433;Database=test;User Id=sa;Password=YourPassword;TrustServerCertificate=true'
+    MAPPING <mapping>;
+```
+
+`mssql`, `sql_server`, and `sql-server` are accepted aliases for the `sqlserver`
+type. See the [SQL Server connector page](/memgraph-zero/memgql/connect/sqlserver).
 
 #### DuckDB (`duckdb`)
 
@@ -301,7 +334,7 @@ queries against it.
 
 | Field        | Type                    | Required | Description |
 |--------------|-------------------------|----------|-------------|
-| `label`      | string                  | yes      | GQL node label (e.g. `"Person"`). Looked up case-insensitively. |
+| `label`      | string                  | yes      | GQL node label (e.g. `"Person"`). Matched exactly (case-sensitive). |
 | `table`      | string                  | yes      | Backend table or view name backing this label. |
 | `id_column`  | string                  | yes      | Primary key column. Surfaces as GQL `id(n)` and is used to join across edges. |
 | `properties` | object (string→string)  | no       | Map from GQL property name → backend column name. Properties not listed here pass through with the same name (`p.name` → column `name`). |
@@ -316,7 +349,7 @@ Connector-specific fields:
 
 | Field            | Type                    | Required | Description |
 |------------------|-------------------------|----------|-------------|
-| `rel_type`       | string                  | yes      | GQL relationship type (e.g. `"KNOWS"`). Looked up case-insensitively. |
+| `rel_type`       | string                  | yes      | GQL relationship type (e.g. `"KNOWS"`). Matched exactly (case-sensitive). |
 | `table`          | string                  | yes      | Junction or association table backing this edge type. |
 | `id_column`      | string                  | yes      | Per-edge primary key. **Required since v0.6.** Carried through the recursive CTE's visited-edge set to enforce trail semantics on variable-length traversal. |
 | `source_column`  | string                  | yes      | FK column pointing to the source node's `id_column`. |

--- a/pages/memgraph-zero/memgql/reference.mdx
+++ b/pages/memgraph-zero/memgql/reference.mdx
@@ -73,7 +73,8 @@ supports.
 ADD GRAPH [IF NOT EXISTS] <name> ON CONNECTOR <connector>
     [GRAPH <remote_name>]
     [MAPPING <mapping_name>]
-    [READ ONLY];
+    [READ ONLY]
+    [CACHE CONNECTOR <cache_connector> [TTL <secs>] [MAX_BYTES <n>[K|M|G|T]]];
 
 CREATE GRAPH <name>
     [{ <gql_schema_body> } | ANY]
@@ -88,11 +89,21 @@ ALTER GRAPH <name> SET CONNECTOR <connector>;
 ALTER GRAPH <name> SET GRAPH <remote_name>;
 ALTER GRAPH <name> SET MAPPING <mapping_name>;
 ALTER GRAPH <name> REMOVE MAPPING;
+ALTER GRAPH <name> SET CACHE CONNECTOR <cache_connector> [TTL <secs>] [MAX_BYTES <n>[K|M|G|T]];
+ALTER GRAPH <name> REMOVE CACHE;
+
+SHOW GRAPH CACHES;   -- graph, cache_connector, ttl_secs, max_bytes, fragment count
 ```
 
 `ADD GRAPH IF NOT EXISTS` succeeds as a no-op when the name is already
 registered — for re-runnable setup scripts; plain `ADD GRAPH` errors on a
 duplicate name.
+
+`CACHE CONNECTOR` makes a graph **cache-enabled**: its scans are populated into
+a Memgraph cache connector on first read, and later covered queries are served
+from that cache — see [Multiple Graphs → Caching](/memgraph-zero/memgql/multiple-graphs#caching-a-graph-in-memgraph).
+`TTL` is in seconds; `MAX_BYTES` accepts a plain byte count or a `K`/`M`/`G`/`T`
+binary suffix (e.g. `8G`).
 
 ```
 SHOW SCHEMA [FOR <graph>];   -- unified routing index: labels, rel-types, properties
@@ -164,7 +175,7 @@ values. The `RUST_LOG` environment variable is not consulted.
 
 To see query traffic and what MemGQL translates it into, run with
 `--log-level=DEBUG`. The `info-queries-only` value from earlier releases was
-removed in v0.6.4 — see the
+removed in v0.7.0 — see the
 [changelog](/memgraph-zero/memgql/changelog).
 
 ### Enterprise License

--- a/pages/memgraph-zero/memgql/use-cases/public-private.mdx
+++ b/pages/memgraph-zero/memgql/use-cases/public-private.mdx
@@ -62,7 +62,7 @@ MemGQL, and a one-shot init container:
 cat > docker-compose.yml << 'EOF'
 services:
   memgql:
-    image: ${MEMGQL_IMAGE:-memgraph/memgql:0.6.3}
+    image: ${MEMGQL_IMAGE:-memgraph/memgql:0.6.4}
     ports:
       - "7688:7688"
     environment:

--- a/pages/memgraph-zero/memgql/use-cases/public-private.mdx
+++ b/pages/memgraph-zero/memgql/use-cases/public-private.mdx
@@ -62,7 +62,7 @@ MemGQL, and a one-shot init container:
 cat > docker-compose.yml << 'EOF'
 services:
   memgql:
-    image: ${MEMGQL_IMAGE:-memgraph/memgql:0.6.4}
+    image: ${MEMGQL_IMAGE:-memgraph/memgql:0.7.0}
     ports:
       - "7688:7688"
     environment:


### PR DESCRIPTION
Release docs for MemGQL `0.7.0`.

## What this enables

- **Cross-backend piping** — a "Piping: fetching only what joins" section in Multiple Graphs (what gets faster and when it applies, incl. the catalog-graph `ADD GRAPH` condition), plus the changelog entry with the inline-map join spelling (`MATCH (i:Invoice {employee_id: e.id})`).
- **SQL Server connector** — new `connect/sqlserver.mdx` page (multi-mode `ADD CONNECTOR … TYPE sqlserver` with an ADO connection string), listed in features and nav, with a config section in the reference.
- **`ADD GRAPH IF NOT EXISTS`** — grammar + semantics in the reference, example in Multiple Graphs, changelog.
- **Log levels** — reference logging section rewritten for the `CRITICAL…TRACE` ladder; `info-queries-only` removal and the now-filtered log file are called out as behavior changes.
- Docker image pins bumped to 0.6.4 (`complete.mdx`, public-private use case).
- **Memgraph as the caching layer**.