### PR TITLE
Add supply chain attestations and SBOM to Docker images

### DIFF
--- a/pages/getting-started/install-memgraph/docker.mdx
+++ b/pages/getting-started/install-memgraph/docker.mdx
@@ -115,6 +115,86 @@ image tags you can use to install Memgraph with.
 
 
 
+## Verify image signatures and attestations
+
+<Callout type="info">
+Image signing and supply-chain attestations are available for the
+`memgraph/memgraph` and `memgraph/memgraph-mage` images from version **3.12.0**
+onwards. Earlier releases are not signed, so `cosign verify` will report no
+signatures for them.
+</Callout>
+
+From 3.12.0, Memgraph publishes its Docker images with
+[Sigstore](https://www.sigstore.dev/) `cosign` signatures and attaches two
+supply-chain attestations to each image:
+
+- a **CycloneDX SBOM** (software bill of materials), and
+- **SLSA build provenance**.
+
+Signing is *keyless*, so verification checks *who* signed — Memgraph's release
+workflow running in GitHub Actions — rather than a static public key.
+
+{<h3 className="custom-header">Install cosign</h3>}
+
+Follow the [cosign installation
+guide](https://docs.sigstore.dev/cosign/system_config/installation/). For
+example, on Linux (amd64):
+
+```bash
+curl -fsSL -o cosign https://github.com/sigstore/cosign/releases/latest/download/cosign-linux-amd64
+chmod +x cosign && sudo mv cosign /usr/local/bin/
+```
+
+{<h3 className="custom-header">Verify the image signature</h3>}
+
+Replace `<version>` with the tag you are verifying (for example `3.12.0`). Use
+`memgraph/memgraph-mage` in place of `memgraph/memgraph` to verify the MAGE
+image:
+
+```bash
+cosign verify \
+  --certificate-identity-regexp '^https://github\.com/memgraph/memgraph/\.github/workflows/promote_rc_release\.yml@' \
+  --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
+  memgraph/memgraph:<version>
+```
+
+A successful run prints a report confirming that the cosign claims, the
+transparency-log entry, and the code-signing certificate were all validated. If
+the image is unsigned or the signing identity does not match, cosign exits with
+an error such as `no matching signatures`.
+
+The two `--certificate-*` flags are the trust anchor: they require the signature
+to come from Memgraph's release workflow (`promote_rc_release.yml` in the
+`memgraph/memgraph` repository) running in GitHub Actions.
+
+{<h3 className="custom-header">Inspect the SBOM and provenance</h3>}
+
+The following commands verify the attestation *and* extract its contents; they
+pipe through [`jq`](https://jqlang.github.io/jq/) and `base64`.
+
+Verify and save the CycloneDX SBOM to a file:
+
+```bash
+cosign verify-attestation --type cyclonedx \
+  --certificate-identity-regexp '^https://github\.com/memgraph/memgraph/\.github/workflows/promote_rc_release\.yml@' \
+  --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
+  memgraph/memgraph:<version> \
+  | jq -r '.payload' | base64 -d | jq '.predicate' > sbom.cdx.json
+```
+
+Verify the SLSA build provenance:
+
+```bash
+cosign verify-attestation --type slsaprovenance \
+  --certificate-identity-regexp '^https://github\.com/memgraph/memgraph/\.github/workflows/promote_rc_release\.yml@' \
+  --certificate-oidc-issuer 'https://token.actions.githubusercontent.com' \
+  memgraph/memgraph:<version>
+```
+
+<Callout type="info">
+Verification is keyless, so `cosign` needs network access to Sigstore's Fulcio
+and Rekor services.
+</Callout>
 
 ## Using Docker Compose 
 


### PR DESCRIPTION
### Release note

Added instructions on how to verify the Docker images and how to get the SBOM from them.

### Related product PRs

PRs from product repo this doc page is related to: 
https://github.com/memgraph/memgraph/pull/4337

### Checklist:

- [x] Add appropriate milestone (current release cycle)
- [x] Add `bugfix` or `feature` label, based on the product PR type you're documenting
- [x] Make sure all relevant tech details are documented
    - [ ] Update reference pages (e.g. [clauses](https://memgraph.com/docs/querying/clauses), [functions](https://memgraph.com/docs/querying/functions), [flags](https://memgraph.com/docs/database-management/configuration#list-of-configuration-flags), [experimental](https://memgraph.com/docs/database-management/experimental-features), [monitoring](https://memgraph.com/docs/database-management/monitoring), [Cypher differences](https://memgraph.com/docs/querying/differences-in-cypher-implementations))
    - [ ] Search for the feature you are working on (mentions) and make updates if needed
    - [x] Provide a basic example of usage
    - [ ] In case your feature is an Enterprise one, list it under [ME page](https://memgraph.com/docs/database-management/enabling-memgraph-enterprise) and mark its page with Enterprise ([example](https://memgraph.com/docs/database-management/authentication-and-authorization/role-based-access-control)).
- [x] Check all content with Grammarly
- [x] Perform a self-review of my code
- [x] The build passes locally
- [x] My changes generate no new warnings or errors