### PR TITLE
MemGQL: connectors + schema-graph model docs

### DIFF
--- a/pages/memgraph-zero/memgql/_meta.ts
+++ b/pages/memgraph-zero/memgql/_meta.ts
@@ -3,6 +3,7 @@ export default {
   "use-cases": "Use Cases",
   "features": "Features",
   "connect": "Connect",
+  "schema-file": "Schema File",
   "multiple-graphs": "Multiple Graphs",
   "complete": "Docker Compose",
   "reference": "Reference",

--- a/pages/memgraph-zero/memgql/changelog.mdx
+++ b/pages/memgraph-zero/memgql/changelog.mdx
@@ -5,6 +5,37 @@ description: MemGQL release notes
 
 # MemGQL Changelog
 
+## Unreleased
+
+### ⚠️ Breaking changes
+
+- **New graph model: connectors + schema graphs.** A **connector** is now a pure
+  connection and a **graph** is a mapping (`vertices` + `edges`) laid over one or
+  more connectors. Register a connection with `ADD CONNECTOR`, then define a graph
+  with `CREATE GRAPH <name> FROM '<json>'` / `FROM FILE '<path>'`, or boot the
+  whole catalog from a single [`--schema`](/memgraph-zero/memgql/schema-file) file.
+- **New mapping format.** Mappings use `vertices` / `edges` with
+  `mappedTableSource` (relational) or `mappedGraphSource` (native), `metaFields`
+  (`id` / `from` / `to`), and `attributes`. The legacy `nodes` / `edges` format
+  (`id_column`, `source_label`, `rel_type`) is no longer accepted — loading it
+  raises an actionable error pointing at the new format.
+- **Removed statements.** `ADD GRAPH … ON CONNECTOR`, `UNADD GRAPH`,
+  `ALTER GRAPH SET CONNECTOR / GRAPH / MAPPING`, `ADD MAPPING` / `DROP MAPPING`,
+  and the connection-scoped `CONNECT … AS`, `DISCONNECT`, `USE CONNECTION`, and
+  `SET DEFAULT CONNECTION` are gone. Register connectors + graphs instead and
+  query by graph name (`USE <graph>`) or USE-free.
+
+### ✨ New features & Improvements
+
+- **Query graphs without `USE`.** [USE-free routing](/memgraph-zero/memgql/multiple-graphs#use-free-routing)
+  infers the target graph from the labels, relationship types, and declared
+  properties a query mentions; ambiguity is an actionable error. Explicit
+  `USE <graph>` remains the override.
+- **Caching engages under USE-free routing.** A cache-enabled graph is populated
+  and served whether a part is pinned with `USE` or routed by label. Re-issuing
+  `ALTER GRAPH … SET CACHE` now drops stale fragments, so re-pointing the cache
+  can't serve a stale result.
+
 ## MemGQL v0.7.0 - July 5th, 2026
 
 ### ⚠️ Behavior changes

--- a/pages/memgraph-zero/memgql/complete.mdx
+++ b/pages/memgraph-zero/memgql/complete.mdx
@@ -60,37 +60,26 @@ CREATE TABLE users (
 );
 
 CREATE TABLE friend_of (
+    id SERIAL PRIMARY KEY,
     user_id INTEGER NOT NULL REFERENCES users(id),
     friend_id INTEGER NOT NULL REFERENCES users(id),
-    PRIMARY KEY (user_id, friend_id)
+    UNIQUE (user_id, friend_id)
 );
 ```
 
-**`pg_mapping.json`** — tells MemGQL how tables map to graph labels:
+**`pg_mapping.json`** — a graph mapping body (`vertices` + `edges`) that maps the
+tables to graph labels on the `pg` connector:
 
 ```json
 {
-  "nodes": [
-    {
-      "label": "User",
-      "table": "users",
-      "id_column": "id",
-      "properties": {
-        "name": "name",
-        "email": "email"
-      }
-    }
+  "vertices": [
+    { "label": "User",
+      "mappedTableSource": { "connector": "pg", "table": "users", "metaFields": { "id": "id" } },
+      "attributes": [ { "name": "name" }, { "name": "email" } ] }
   ],
   "edges": [
-    {
-      "rel_type": "FRIEND_OF",
-      "table": "friend_of",
-      "id_column": "id",
-      "source_column": "user_id",
-      "target_column": "friend_id",
-      "source_label": "User",
-      "target_label": "User"
-    }
+    { "label": "FRIEND_OF", "from": "User", "to": "User",
+      "mappedTableSource": { "connector": "pg", "table": "friend_of", "metaFields": { "id": "id", "from": "user_id", "to": "friend_id" } } }
   ]
 }
 ```
@@ -136,10 +125,8 @@ services:
       - -c
       - |
         echo "ADD CONNECTOR mg TYPE memgraph URI 'memgraph:7687' GRAPH memgraph;" | mgconsole --host memgql --port 7688 &&
-        echo "CONNECT mg AS mg_conn;" | mgconsole --host memgql --port 7688 &&
-        echo "ADD MAPPING pg_social FROM '/mappings/pg_mapping.json';" | mgconsole --host memgql --port 7688 &&
-        echo "ADD CONNECTOR pg TYPE postgres URI 'host=postgres user=postgres password=postgres dbname=postgres' MAPPING pg_social;" | mgconsole --host memgql --port 7688 &&
-        echo "CONNECT pg AS pg_conn;" | mgconsole --host memgql --port 7688 &&
+        echo "ADD CONNECTOR pg TYPE postgres URI 'host=postgres user=postgres password=postgres dbname=postgres';" | mgconsole --host memgql --port 7688 &&
+        echo "CREATE GRAPH social FROM FILE '/mappings/pg_mapping.json';" | mgconsole --host memgql --port 7688 &&
         echo "MemGQL bootstrap complete."
     depends_on:
       memgql:
@@ -256,13 +243,21 @@ container registers both connectors and exits — this is expected.
 mgconsole --port 7688
 ```
 
-Both the Memgraph and PostgreSQL connectors are already registered and
-connected by the `memgql-init` service. You can start querying right away.
+The `mg` and `pg` connectors and the `social` graph (over PostgreSQL) are
+already registered by the `memgql-init` service. We add the native Memgraph
+graph below, then query each by its labels — routing picks the graph, so no
+`USE` is required.
 
 ### Seed Memgraph with developers
 
+Register a native graph over the Memgraph connector, then insert developers (the
+`Developer` label routes to `dev`):
+
 ```gql
-SET DEFAULT CONNECTION mg_conn;
+CREATE GRAPH dev FROM '{
+  "vertices": [ { "label": "Developer", "mappedGraphSource": { "connector": "mg" } } ],
+  "edges":    [ { "label": "FOLLOWS", "from": "Developer", "to": "Developer", "mappedGraphSource": { "connector": "mg" } } ]
+}';
 ```
 
 ```gql
@@ -289,11 +284,7 @@ MATCH (a:Developer)-[:FOLLOWS]->(b:Developer) RETURN a.name, b.name;
 
 ### Seed PostgreSQL with users
 
-Switch to the PostgreSQL connection and insert users:
-
-```gql
-SET DEFAULT CONNECTION pg_conn;
-```
+Insert users — the `User` label routes to the `social` graph (PostgreSQL):
 
 ```gql
 INSERT (alice:User {name: "Alice", email: "alice@example.com"});
@@ -321,17 +312,17 @@ MATCH (u:User)-[:FRIEND_OF]->(f:User) RETURN u.name, f.name;
 
 ### Query across both backends
 
-Each connection is queried independently — MemGQL routes the query to
-the right backend based on the `USE CONNECTION` clause:
+Each query routes to the right backend by the labels it mentions (or pin it
+with an explicit `USE <graph>`):
 
 ```gql
-USE CONNECTION mg_conn
+USE dev
   MATCH (d:Developer)-[:FOLLOWS]->(f:Developer)
   RETURN d.name AS source, "FOLLOWS" AS rel, f.name AS target;
 ```
 
 ```gql
-USE CONNECTION pg_conn
+USE social
   MATCH (u:User)-[:FRIEND_OF]->(f:User)
   RETURN u.name AS source, "FRIEND_OF" AS rel, f.name AS target;
 ```

--- a/pages/memgraph-zero/memgql/connect/oracle.mdx
+++ b/pages/memgraph-zero/memgql/connect/oracle.mdx
@@ -129,7 +129,7 @@ MATCH (a:Person)-[:KNOWS]->(b:Person) RETURN a.name, b.name;
   this is bind-variable based and the planner stays bind-agnostic; the executor
   uses it only when the caller needs the auto-generated key.
 - Identifiers from the mapping file are emitted unquoted, so Oracle's
-  default UPPERCASE folding applies — match your mapping `table` / `id_column`
+  default UPPERCASE folding applies — match your mapping's `table` and column
   spellings to your physical schema accordingly.
 
 ## Multi-connection mode
@@ -138,10 +138,9 @@ Inside `CONNECTOR_TYPE=multi`, register Oracle the same way as any other
 backend:
 
 ```gql
-ADD MAPPING social FROM '/data/mapping.json';
-ADD CONNECTOR ora TYPE oracle URI 'oracle://system:oracle@oracle-dev:1521/FREEPDB1' MAPPING social;
-CONNECT ora AS ora_conn;
-USE CONNECTION ora_conn MATCH (n:Person) RETURN n.name LIMIT 5;
+ADD CONNECTOR ora TYPE oracle URI 'oracle://system:oracle@oracle-dev:1521/FREEPDB1';
+CREATE GRAPH social FROM FILE '/data/mapping.json';
+USE social MATCH (n:Person) RETURN n.name LIMIT 5;
 ```
 
 For environment variables, see [Reference](../reference.mdx#oracle-oracle).

--- a/pages/memgraph-zero/memgql/connect/sqlserver.mdx
+++ b/pages/memgraph-zero/memgql/connect/sqlserver.mdx
@@ -87,27 +87,17 @@ passthrough.
 
 ```json
 {
-  "nodes": [
-    {
-      "label": "Person", "table": "persons", "id_column": "id",
-      "properties": { "name": "name", "age": "age" }
-    },
-    {
-      "label": "Company", "table": "companies", "id_column": "id",
-      "properties": { "name": "name" }
-    }
+  "vertices": [
+    { "label": "Person",  "mappedTableSource": { "connector": "ss", "table": "persons", "metaFields": { "id": "id" } },
+      "attributes": [ { "name": "name" }, { "name": "age", "type": "Int" } ] },
+    { "label": "Company", "mappedTableSource": { "connector": "ss", "table": "companies", "metaFields": { "id": "id" } },
+      "attributes": [ { "name": "name" } ] }
   ],
   "edges": [
-    {
-      "rel_type": "KNOWS", "table": "knows", "id_column": "id",
-      "source_column": "from_id", "target_column": "to_id",
-      "source_label": "Person", "target_label": "Person"
-    },
-    {
-      "rel_type": "WORKS_AT", "table": "works_at", "id_column": "id",
-      "source_column": "person_id", "target_column": "company_id",
-      "source_label": "Person", "target_label": "Company"
-    }
+    { "label": "KNOWS", "from": "Person", "to": "Person",
+      "mappedTableSource": { "connector": "ss", "table": "knows", "metaFields": { "id": "id", "from": "from_id", "to": "to_id" } } },
+    { "label": "WORKS_AT", "from": "Person", "to": "Company",
+      "mappedTableSource": { "connector": "ss", "table": "works_at", "metaFields": { "id": "id", "from": "person_id", "to": "company_id" } } }
   ]
 }
 ```
@@ -133,11 +123,10 @@ mgconsole --port 7688
 ```
 
 ```gql
-ADD MAPPING social FROM '/data/mapping.json';
 ADD CONNECTOR ss TYPE sqlserver
-    URI 'Server=sqlserver-dev,1433;Database=test;User Id=sa;Password=Memgraph!2024;TrustServerCertificate=true'
-    MAPPING social;
-CONNECT ss AS ss_conn;
+    URI 'Server=sqlserver-dev,1433;Database=test;User Id=sa;Password=Memgraph!2024;TrustServerCertificate=true';
+CREATE GRAPH social FROM FILE '/data/mapping.json';
+USE social MATCH (n:Person) RETURN n.name LIMIT 5;
 ```
 
 The `URI` is an ADO-style connection string

--- a/pages/memgraph-zero/memgql/multiple-graphs.mdx
+++ b/pages/memgraph-zero/memgql/multiple-graphs.mdx
@@ -11,13 +11,13 @@ If you want a running stack to try these queries against, the [Docker Compose - 
 
 ## Where the catalog DSL works
 
-The catalog statements (`ADD CONNECTOR`, `ADD GRAPH`, `SHOW GRAPHS`, `SHOW CONNECTORS`, `DROP GRAPH`, `USE <graph>`, …) are available in **`CONNECTOR_TYPE=multi`** mode. Single-backend modes (`memgraph-gql`, `neo4j-gql`, `postgres`, `mysql`, `oracle`, `duckdb`, `clickhouse`, `iceberg`, `pinot`) connect to one backend configured via env vars and don't expose the catalog.
+The catalog statements (`ADD CONNECTOR`, `CREATE GRAPH`, `SHOW GRAPHS`, `SHOW CONNECTORS`, `DROP GRAPH`, `USE <graph>`, …) are available in **`CONNECTOR_TYPE=multi`** mode. Single-backend modes (`memgraph-gql`, `neo4j-gql`, `postgres`, `mysql`, `oracle`, `duckdb`, `clickhouse`, `iceberg`, `pinot`) connect to one backend configured via env vars and don't expose the catalog.
 
 | Statement | `multi` | Cypher single-backend | SQL single-backend |
 |---|---|---|---|
 | `SHOW GRAPHS` / `SHOW CONNECTORS` / `SHOW MAPPINGS` | ✓ | ✗ | ✗ |
 | `SHOW SCHEMA` / `REFRESH SCHEMA` | ✓ | ✗ | ✗ |
-| `ADD CONNECTOR` / `ADD GRAPH` / `CONNECT` | ✓ | ✗ | ✗ |
+| `ADD CONNECTOR` / `CREATE GRAPH … FROM` / `PING` | ✓ | ✗ | ✗ |
 | `CREATE GRAPH <x>` | ✓ (catalog entry) | ✓ (forwarded as `CREATE DATABASE <x>`) | ✗ |
 | `DROP GRAPH <x>` | ✓ | ✗ | ✗ |
 | `TRUNCATE <x>` | ✓ | ✓ (forwarded as `MATCH (n) DETACH DELETE n`) | ✗ |
@@ -27,25 +27,30 @@ If you need graph management today, run MemGQL in `multi` mode.
 
 ## Graph Registration
 
-Before querying across graphs, register them in the catalog using `ADD GRAPH` or `CREATE GRAPH`:
+Register connectors first, then define graphs over them. A **connector** is a
+connection; a **graph** is a mapping (`vertices` + `edges`) laid over one or more
+connectors.
 
 ```gql
--- Register existing graphs on different backends
-ADD GRAPH social ON CONNECTOR neo4j_prod GRAPH neo4j;
-ADD GRAPH events ON CONNECTOR clickhouse_logs READ ONLY;
-ADD GRAPH warehouse ON CONNECTOR postgres_dw MAPPING company_mapping READ ONLY;
-ADD GRAPH dev ON CONNECTOR memgraph_dev;
+-- 1. Register connectors (connections only)
+ADD CONNECTOR neo4j_prod      TYPE neo4j      URI 'bolt://neo4j:7687' USER 'neo4j' PASSWORD 'secret' GRAPH neo4j;
+ADD CONNECTOR clickhouse_logs TYPE clickhouse URI 'http://clickhouse:8123';
+ADD CONNECTOR postgres_dw     TYPE postgres   URI 'postgresql://pg:5432/dw';
 
--- No-op if the name is already registered (re-runnable setup scripts)
-ADD GRAPH IF NOT EXISTS social ON CONNECTOR neo4j_prod GRAPH neo4j;
+-- 2. Define graphs over them (mapping body from a file, or inline JSON)
+CREATE GRAPH social    FROM FILE '/data/social.graph.json';
+CREATE GRAPH events    FROM FILE '/data/events.graph.json';
+CREATE GRAPH warehouse FROM FILE '/data/warehouse.graph.json';
+
+-- read-only access where you want it
+ALTER GRAPH events    SET READ ONLY;
+ALTER GRAPH warehouse SET READ ONLY;
 ```
 
-Each graph entry stores:
-- **Name**: Local catalog identifier
-- **Connector**: Which connector hosts this graph
-- **Remote graph**: Backend-specific graph/database name (optional)
-- **Mapping**: Schema mapping for relational connectors (optional)
-- **Access mode**: `READ WRITE` (default) or `READ ONLY`
+Each graph carries a name, its per-connector mapping (`vertices` / `edges` — see
+the [Schema File](/memgraph-zero/memgql/schema-file) page), and an access mode
+(`READ WRITE` default, or `READ ONLY`). A single graph may span several
+connectors.
 
 ## Single Graph Queries
 
@@ -103,11 +108,9 @@ Routing is strict and deterministic:
   Disambiguate by referencing a property or relationship type that exists in
   only one of them, or add an explicit `USE`.
 - **Explicit `USE` always wins** and bypasses inference entirely.
-- **Session defaults never tie-break.** A sticky `default_connection` (from
-  `SET DEFAULT CONNECTION`) does not resolve an otherwise-ambiguous query.
-- **No-signal queries** like `MATCH (n) RETURN n` (no label, rel-type, or
-  property to route by) fall back to today's default-connection behavior
-  unchanged.
+- **No-signal queries** — `MATCH (n) RETURN n` with no label, relationship
+  type, or property to route by — have nothing to infer from; pin them with an
+  explicit `USE <graph>`.
 
 Identifier matching is **exact**: `:person` does not match a mapping (or
 introspected schema) that declares `Person`. Routing, translation, and the
@@ -253,7 +256,7 @@ RETURN p.name, u.rank ORDER BY u.rank DESC;
 
 Piping is an optimization, not a semantic change — results are identical with
 or without it. It engages for backends registered as catalog graphs
-(`ADD GRAPH`); when it doesn't apply, MemGQL pulls both sides and joins
+(via `CREATE GRAPH`); when it doesn't apply, MemGQL pulls both sides and joins
 locally. If the selective side matches nothing, the other backend is never
 queried.
 
@@ -371,50 +374,46 @@ and properties used for routing — use [`SHOW SCHEMA`](#schema-discovery).
 
 ## Graph Lifecycle Management
 
-### Creating Graphs
+### Creating graphs
 
-`CREATE GRAPH` both registers the graph and creates it on the remote backend:
+`CREATE GRAPH … FROM` registers a graph from a mapping body — inline JSON or a
+file — and auto-connects the connectors it references:
 
 ```gql
--- Create an empty graph on a specific backend
-CREATE GRAPH analytics ON CONNECTOR memgraph_dev;
+-- from a file
+CREATE GRAPH analytics FROM FILE '/data/analytics.graph.json';
 
--- Create with a GQL schema
-CREATE GRAPH typed_graph {
-    NODE Person ({name STRING, age INT}),
-    EDGE KNOWS ()-[]->()
-} ON CONNECTOR neo4j_prod;
+-- or inline
+CREATE GRAPH social FROM '{
+  "vertices": [ { "label": "User", "mappedGraphSource": { "connector": "neo4j_prod" } } ],
+  "edges":    [ { "label": "FOLLOWS", "from": "User", "to": "User", "mappedGraphSource": { "connector": "neo4j_prod" } } ]
+}';
 ```
 
-### Modifying Graphs
+See the [Schema File](/memgraph-zero/memgql/schema-file) page for the mapping
+body format.
+
+### Modifying graphs
 
 ```gql
 -- Change access mode
 ALTER GRAPH social SET READ ONLY;
 ALTER GRAPH social SET READ WRITE;
-
--- Rebind to a different connector (e.g., failover)
-ALTER GRAPH social SET CONNECTOR neo4j_staging;
-
--- Change the remote graph name
-ALTER GRAPH social SET GRAPH production_db;
-
--- Attach or change a mapping
-ALTER GRAPH knowledge SET MAPPING updated_mapping;
-ALTER GRAPH knowledge REMOVE MAPPING;
 ```
 
-### Removing Graphs
+A graph's mapping is fixed at creation. To change it, drop and re-create the
+graph with the new body (`DROP GRAPH`, then `CREATE GRAPH … FROM`).
+
+### Removing graphs
 
 ```gql
--- Remove from catalog only (remote graph is untouched)
-UNADD GRAPH social;
-UNADD GRAPH IF EXISTS social;
-
--- Remove from catalog AND drop on backend
-DROP GRAPH analytics;
-DROP GRAPH IF EXISTS analytics;
+DROP GRAPH social;
+DROP GRAPH IF EXISTS social;
 ```
+
+`DROP GRAPH` removes the graph from the catalog; the backend data is untouched.
+Connectors are removed separately with `DROP CONNECTOR` (refused while a graph
+still references the connector).
 
 ## Caching a graph in Memgraph
 
@@ -426,25 +425,31 @@ itself (populate-on-read), so only the subgraph your queries actually touch
 lands in Memgraph.
 
 Register a Memgraph connector to hold the cached data, then mark a graph
-cache-enabled with a `CACHE CONNECTOR` clause:
+cache-enabled with `ALTER GRAPH … SET CACHE`:
 
 ```gql
 -- A Memgraph instance (storage mode IN_MEMORY_ANALYTICAL) holds the cache
 ADD CONNECTOR mg TYPE memgraph URI 'memgraph:7687';
 
--- Cache the warehouse graph in `mg`, with optional bounds
-ADD GRAPH events ON CONNECTOR ice MAPPING warehouse READ ONLY
-    CACHE CONNECTOR mg TTL 3600 MAX_BYTES 8G;
+-- A warehouse graph that reads from Iceberg (connectors registered earlier)
+CREATE GRAPH events FROM FILE '/data/events.graph.json';
 
--- Or enable/disable caching on an already-registered graph
+-- Enable caching in `mg`, with optional bounds
 ALTER GRAPH events SET CACHE CONNECTOR mg TTL 3600 MAX_BYTES 8G;
+
+-- Disable caching (and drop the cached fragments)
 ALTER GRAPH events REMOVE CACHE;
 ```
+
+The cache connector must be a Memgraph-type connector. Re-issuing `SET CACHE`
+drops any fragments already recorded, so re-pointing the cache never serves a
+stale result.
 
 `TTL` is in seconds; `MAX_BYTES` accepts a plain byte count or a `K`/`M`/`G`/`T`
 binary suffix (`8G` = 8 × 1024³ bytes).
 
-How it behaves per `USE` part:
+The cache engages per routed part — whether the part is pinned with `USE` or
+routed USE-free by its labels:
 
 - **First read (cache MISS)** — the query runs on the source and the engine
   *tees* the scanned labels and edge types into the Memgraph cache, recording
@@ -463,8 +468,9 @@ How it behaves per `USE` part:
   RETURN a.event_id, b.event_id;
   ```
 
-In a cross-connector (multi-`USE`) query, each cache-enabled part is served
-from its cache independently while the other parts run on their own sources.
+In a cross-backend query — split by explicit `USE` **or** routed USE-free by
+label — each cache-enabled part is served from its cache independently while the
+other parts run on their own sources.
 
 Inspect what is cached with `SHOW GRAPH CACHES` (returns each cache-enabled
 graph, its cache connector, `TTL`, `MAX_BYTES`, and the number of cached
@@ -496,10 +502,12 @@ ADD CONNECTOR neo4j_prod TYPE neo4j URI 'bolt://neo4j:7687' USER 'neo4j' PASSWOR
 ADD CONNECTOR pg_warehouse TYPE postgres URI 'postgresql://pg:5432/dw';
 ADD CONNECTOR ch_logs TYPE clickhouse URI 'http://clickhouse:8123';
 
--- 2. Register graphs
-ADD GRAPH social ON CONNECTOR neo4j_prod GRAPH neo4j;
-ADD GRAPH warehouse ON CONNECTOR pg_warehouse MAPPING company_mapping READ ONLY;
-ADD GRAPH events ON CONNECTOR ch_logs READ ONLY;
+-- 2. Define graphs over the connectors (mapping bodies live in files)
+CREATE GRAPH social    FROM FILE '/data/social.graph.json';
+CREATE GRAPH warehouse FROM FILE '/data/warehouse.graph.json';
+CREATE GRAPH events    FROM FILE '/data/events.graph.json';
+ALTER GRAPH warehouse SET READ ONLY;
+ALTER GRAPH events    SET READ ONLY;
 
 -- 3. Single-graph queries
 USE social MATCH (p:Person) RETURN p.name LIMIT 5;
@@ -519,7 +527,7 @@ UNION
 USE warehouse MATCH (e:Employee) RETURN e.email AS email;
 
 -- 6. Cleanup
-UNADD GRAPH social;
-UNADD GRAPH warehouse;
-UNADD GRAPH events;
+DROP GRAPH social;
+DROP GRAPH warehouse;
+DROP GRAPH events;
 ```

--- a/pages/memgraph-zero/memgql/quick-start.mdx
+++ b/pages/memgraph-zero/memgql/quick-start.mdx
@@ -149,48 +149,40 @@ environment variables and connector-specific settings.
 ## Mapping File
 
 Relational connectors (PostgreSQL, MySQL, Oracle, DuckDB, ClickHouse, Iceberg, and
-Apache Pinot) and multi-connection mode require a JSON mapping file that defines
-how graph patterns map to relational tables. Node labels map to tables and edge types map to association tables,
-allowing GQL patterns like `MATCH (p:Person)-[:WORKS_AT]->(c:Company)` to be
-translated into SQL JOINs.
+Apache Pinot) use a JSON mapping that defines how graph patterns map to
+relational tables: node labels map to tables (`vertices`) and edge types to
+association tables (`edges`), so a pattern like
+`MATCH (p:Person)-[:WORKS_AT]->(c:Company)` translates into SQL joins. In
+single-connector mode the mapping is a bare `{ "vertices": …, "edges": … }` body
+— the connector comes from the environment, so `mappedTableSource` omits it. See
+the [Schema File](/memgraph-zero/memgql/schema-file) page for the full field
+reference.
 
 Create a mapping file:
 
 ```bash
 cat > mapping.json << 'EOF'
 {
-  "nodes": [
+  "vertices": [
     {
       "label": "Person",
-      "table": "persons",
-      "id_column": "id",
-      "properties": { "name": "name", "age": "age" }
+      "mappedTableSource": { "table": "persons", "metaFields": { "id": "id" } },
+      "attributes": [ { "name": "name" }, { "name": "age", "type": "Int" } ]
     },
     {
       "label": "Company",
-      "table": "companies",
-      "id_column": "id",
-      "properties": { "name": "name" }
+      "mappedTableSource": { "table": "companies", "metaFields": { "id": "id" } },
+      "attributes": [ { "name": "name" } ]
     }
   ],
   "edges": [
     {
-      "rel_type": "KNOWS",
-      "table": "knows",
-      "id_column": "id",
-      "source_column": "from_id",
-      "target_column": "to_id",
-      "source_label": "Person",
-      "target_label": "Person"
+      "label": "KNOWS", "from": "Person", "to": "Person",
+      "mappedTableSource": { "table": "knows", "metaFields": { "id": "id", "from": "from_id", "to": "to_id" } }
     },
     {
-      "rel_type": "WORKS_AT",
-      "table": "works_at",
-      "id_column": "id",
-      "source_column": "person_id",
-      "target_column": "company_id",
-      "source_label": "Person",
-      "target_label": "Company"
+      "label": "WORKS_AT", "from": "Person", "to": "Company",
+      "mappedTableSource": { "table": "works_at", "metaFields": { "id": "id", "from": "person_id", "to": "company_id" } }
     }
   ]
 }
@@ -220,52 +212,55 @@ docker run --rm \
     memgraph/memgql:latest
 ```
 
-### 2. Connect and manage backends
+### 2. Register connectors and graphs
 
 ```bash
 mgconsole --port 7688
 ```
 
-Add connectors and establish connections:
+A connector is a connection; a graph is a mapping laid over connectors:
 
 ```gql
-ADD CONNECTOR mg TYPE memgraph URI 'memgraph-dev:7687' GRAPH memgraph;
-CONNECT mg AS mg_conn;
+-- connectors (GRAPH selects the Cypher database on Memgraph / Neo4j)
+ADD CONNECTOR mg  TYPE memgraph URI 'memgraph-dev:7687' GRAPH memgraph;
+ADD CONNECTOR neo TYPE neo4j    URI 'neo4j-dev:7687'    GRAPH neo4j;
 
-ADD CONNECTOR neo TYPE neo4j URI 'neo4j-dev:7687' GRAPH neo4j;
-CONNECT neo AS neo_conn;
+-- a graph over a connector (mapping body from a file, or inline JSON)
+CREATE GRAPH knowledge FROM FILE '/data/knowledge.graph.json';
 ```
 
-### 3. Route queries to specific connections
+### 3. Query graphs by name
 
 ```gql
-USE CONNECTION mg_conn MATCH (n) RETURN n.name LIMIT 5;
-USE CONNECTION neo_conn MATCH (n) RETURN n.name LIMIT 5;
+-- pin the query to a graph
+USE knowledge MATCH (n:Person) RETURN n.name LIMIT 5;
+
+-- or USE-free: routing picks the graph by the labels the query mentions
+MATCH (n:Person) RETURN n.name LIMIT 5;
 ```
 
 ### 4. Introspection
 
 ```gql
 SHOW CONNECTORS;
-SHOW CONNECTIONS;
+SHOW GRAPHS;
 SHOW MAPPINGS;
-PING mg_conn;
+SHOW SCHEMA;
+PING mg;
 ```
 
 ### 5. Adding relational backends
 
 Relational connectors (PostgreSQL, MySQL, Oracle, DuckDB, ClickHouse, Iceberg, and
-Apache Pinot) require a mapping that defines how graph patterns map to tables:
+Apache Pinot) map tables into a graph via the [mapping file](#mapping-file):
 
 ```gql
-ADD MAPPING social FROM '/data/mapping.json';
-ADD CONNECTOR pg TYPE postgres USER 'postgres' PASSWORD 'postgres' DATABASE 'postgres' MAPPING social;
-CONNECT pg AS pg_conn;
-USE CONNECTION pg_conn MATCH (n:Person) RETURN n.name LIMIT 5;
+ADD CONNECTOR pg TYPE postgres URI 'postgresql://postgres:postgres@postgres-dev:5432/postgres';
+CREATE GRAPH store FROM FILE '/data/mapping.json';
+USE store MATCH (n:Person) RETURN n.name LIMIT 5;
 ```
 
-Pinot can also run as a single backend with the alias requested by deployment
-environments that use connection naming:
+Pinot can also run as a single backend via the `CONNECTION_TYPE` alias:
 
 ```bash
 CONNECTION_TYPE=pinot PINOT_URL=http://localhost:8099 cargo run --bin bolt_server
@@ -274,25 +269,24 @@ CONNECTION_TYPE=pinot PINOT_URL=http://localhost:8099 cargo run --bin bolt_serve
 ### 6. Cleanup
 
 ```gql
-DISCONNECT pg_conn;
+DROP GRAPH store;
 DROP CONNECTOR pg;
-DROP MAPPING social;
 ```
 
 ### MemGQL Statements Reference
 
-| Statement                                          | Description                           |
-|----------------------------------------------------|---------------------------------------|
-| `ADD MAPPING <name> FROM '<file>'`                 | Load a graph mapping from a JSON file |
-| `DROP MAPPING <name>`                              | Remove a mapping                      |
-| `ADD CONNECTOR <name> TYPE <type> [options...]`    | Register a backend connector          |
-| `DROP CONNECTOR <name>`                            | Remove a connector                    |
-| `CONNECT <connector> AS <name> [DEFAULT]`          | Establish a named connection          |
-| `DISCONNECT <name>`                                | Close a connection                    |
-| `PING <connection>`                                | Test a connection is alive            |
-| `USE CONNECTION <name> <query>`                    | Route a query to a specific connection|
-| `SET DEFAULT CONNECTOR <name>`                     | Set session default connector         |
-| `SET DEFAULT CONNECTION <name>`                    | Set session default connection        |
-| `SHOW CONNECTORS`                                  | List registered connectors            |
-| `SHOW CONNECTIONS`                                 | List active connections               |
-| `SHOW MAPPINGS`                                    | List loaded mappings                  |
+| Statement                                                | Description                              |
+|----------------------------------------------------------|------------------------------------------|
+| `ADD CONNECTOR <name> TYPE <type> [options...]`          | Register a backend connector (connection)|
+| `DROP CONNECTOR <name>`                                  | Remove a connector                       |
+| `CREATE GRAPH <name> FROM '<json>' \| FROM FILE '<path>'`| Define a graph (mapping) over connectors |
+| `DROP GRAPH [IF EXISTS] <name>`                          | Remove a graph                           |
+| `ALTER GRAPH <name> SET READ ONLY \| READ WRITE`         | Toggle a graph's access mode             |
+| `ALTER GRAPH <name> SET CACHE CONNECTOR <mg> [...]`      | Cache a graph in Memgraph                |
+| `USE <graph> <query>`                                    | Route a query to a named graph           |
+| `PING <connector>`                                       | Test a connector is alive                |
+| `SHOW CONNECTORS` / `SHOW CONNECTIONS`                   | List connectors / live connections       |
+| `SHOW GRAPHS` / `SHOW GRAPH <name>`                      | List graphs / one graph's details        |
+| `SHOW MAPPINGS`                                          | List per-graph mappings                  |
+| `SHOW SCHEMA` / `REFRESH SCHEMA`                         | Routing index / re-introspect            |
+| `EXPORT SCHEMA [TO '<path>']`                            | Export the catalog as JSON               |

--- a/pages/memgraph-zero/memgql/reference.mdx
+++ b/pages/memgraph-zero/memgql/reference.mdx
@@ -70,44 +70,54 @@ supports.
 ## Graph Management Query Syntax
 
 ```
-ADD GRAPH [IF NOT EXISTS] <name> ON CONNECTOR <connector>
-    [GRAPH <remote_name>]
-    [MAPPING <mapping_name>]
-    [READ ONLY]
-    [CACHE CONNECTOR <cache_connector> [TTL <secs>] [MAX_BYTES <n>[K|M|G|T]]];
+-- Connectors (connections only)
+ADD CONNECTOR <name> TYPE <type>
+    [URI '<uri>'] [PATH '<path>']
+    [USER '<user>'] [PASSWORD '<pass>']
+    [CATALOG '<catalog>'] [SCHEMA '<schema>'] [GRAPH '<db>'];
+DROP CONNECTOR <name>;
+PING <connector>;
 
-CREATE GRAPH <name>
-    [{ <gql_schema_body> } | ANY]
-    ON CONNECTOR <connector>;
-
-UNADD GRAPH [IF EXISTS] <name>;
+-- Graphs (mappings over connectors)
+CREATE GRAPH <name> FROM '<json>';        -- inline { "vertices": …, "edges": … } body
+CREATE GRAPH <name> FROM FILE '<path>';   -- same body from a file
 DROP GRAPH [IF EXISTS] <name>;
-
 ALTER GRAPH <name> SET READ ONLY;
 ALTER GRAPH <name> SET READ WRITE;
-ALTER GRAPH <name> SET CONNECTOR <connector>;
-ALTER GRAPH <name> SET GRAPH <remote_name>;
-ALTER GRAPH <name> SET MAPPING <mapping_name>;
-ALTER GRAPH <name> REMOVE MAPPING;
+
+-- Query-driven cache
 ALTER GRAPH <name> SET CACHE CONNECTOR <cache_connector> [TTL <secs>] [MAX_BYTES <n>[K|M|G|T]];
 ALTER GRAPH <name> REMOVE CACHE;
-
 SHOW GRAPH CACHES;   -- graph, cache_connector, ttl_secs, max_bytes, fragment count
 ```
 
-`ADD GRAPH IF NOT EXISTS` succeeds as a no-op when the name is already
-registered — for re-runnable setup scripts; plain `ADD GRAPH` errors on a
-duplicate name.
+A connector is a **connection only** — it carries no graph shape. `GRAPH <db>`
+selects the Cypher database on Memgraph / Neo4j (it is not a mapping). Re-adding
+a connector replaces its config; `DROP CONNECTOR` is refused while a graph still
+references it.
 
-`CACHE CONNECTOR` makes a graph **cache-enabled**: its scans are populated into
-a Memgraph cache connector on first read, and later covered queries are served
-from that cache — see [Multiple Graphs → Caching](/memgraph-zero/memgql/multiple-graphs#caching-a-graph-in-memgraph).
+`CREATE GRAPH … FROM` registers a graph from a `{ "vertices": …, "edges": … }`
+body and auto-connects the connectors it references. The mapping format is
+documented on the [Schema File](/memgraph-zero/memgql/schema-file) page; the same
+body loads at boot via `--schema`.
+
+`SET CACHE CONNECTOR` makes a graph **cache-enabled**: touched labels and edge
+types are copied into the Memgraph cache connector on first read, and later
+covered queries are served from that cache — see
+[Multiple Graphs → Caching](/memgraph-zero/memgql/multiple-graphs#caching-a-graph-in-memgraph).
 `TTL` is in seconds; `MAX_BYTES` accepts a plain byte count or a `K`/`M`/`G`/`T`
 binary suffix (e.g. `8G`).
 
 ```
-SHOW SCHEMA [FOR <graph>];   -- unified routing index: labels, rel-types, properties
-REFRESH SCHEMA;              -- re-introspect live Cypher connections (Memgraph/Neo4j)
+-- Introspection
+SHOW CONNECTORS;                 -- registered connectors
+SHOW CONNECTIONS;                -- live connections
+SHOW GRAPHS [ON CONNECTOR <c>];  -- registered graphs (name, connector(s), type, access, counts)
+SHOW GRAPH <name>;               -- one graph's details
+SHOW MAPPINGS;                   -- per-graph mappings
+SHOW SCHEMA [FOR <graph>];       -- unified routing index: labels, rel-types, properties
+EXPORT SCHEMA [TO '<path>'];     -- merged catalog as canonical schema JSON (round-trippable)
+REFRESH SCHEMA;                  -- re-introspect live Cypher connections (Memgraph/Neo4j)
 ```
 
 ```
@@ -265,8 +275,9 @@ connection string:
 
 ```gql
 ADD CONNECTOR mssql TYPE sqlserver
-    URI 'Server=localhost,1433;Database=test;User Id=sa;Password=YourPassword;TrustServerCertificate=true'
-    MAPPING <mapping>;
+    URI 'Server=localhost,1433;Database=test;User Id=sa;Password=YourPassword;TrustServerCertificate=true';
+-- then map it into a graph
+CREATE GRAPH sales FROM FILE '/data/sales.graph.json';
 ```
 
 `mssql`, `sql_server`, and `sql-server` are accepted aliases for the `sqlserver`
@@ -327,87 +338,20 @@ S3 path-style access is always enabled (`s3.path-style-access=true`).
 
 ## Mapping Schema
 
-The graph mapping file is a JSON document with two top-level arrays:
-`nodes` and `edges`. MemGQL loads it either from the path in `MAPPING_FILE`
-at startup or via the `ADD MAPPING <name> FROM '<path>'` statement at
-runtime — both paths apply the same validation. A mapping with any
-required field missing is rejected before the server begins serving
-queries against it.
+A graph's mapping declares its `vertices` and `edges` — labels and relationship
+types mapped to backend tables (via `metaFields` and `attributes`) or to native
+graph sources. The full format, with field tables and worked examples, lives on
+the [Schema File](/memgraph-zero/memgql/schema-file) page.
 
-```json
-{
-  "nodes": [ /* NodeMapping objects */ ],
-  "edges": [ /* EdgeMapping objects */ ]
-}
-```
+The same mapping body is used everywhere a graph is defined:
 
-### Node mapping fields
+- **`--schema=<path>`** at boot — connectors + graphs in one file.
+- **`CREATE GRAPH <name> FROM '<json>'`** / **`FROM FILE '<path>'`** at runtime.
+- **`MAPPING_FILE`** in single-connector mode — a bare `{ "vertices": …, "edges": … }`
+  body (the connector comes from the environment).
 
-| Field        | Type                    | Required | Description |
-|--------------|-------------------------|----------|-------------|
-| `label`      | string                  | yes      | GQL node label (e.g. `"Person"`). Matched exactly (case-sensitive). |
-| `table`      | string                  | yes      | Backend table or view name backing this label. |
-| `id_column`  | string                  | yes      | Primary key column. Surfaces as GQL `id(n)` and is used to join across edges. |
-| `properties` | object (string→string)  | no       | Map from GQL property name → backend column name. Properties not listed here pass through with the same name (`p.name` → column `name`). |
-
-Connector-specific fields:
-
-- **Iceberg** also accepts `catalog` and `schema_name` to fully qualify the
-  table reference (defaults: `"iceberg"`, `"default"`).
-- **ClickHouse** also accepts `database` (default: `"default"`).
-
-### Edge mapping fields
-
-| Field            | Type                    | Required | Description |
-|------------------|-------------------------|----------|-------------|
-| `rel_type`       | string                  | yes      | GQL relationship type (e.g. `"KNOWS"`). Matched exactly (case-sensitive). |
-| `table`          | string                  | yes      | Junction or association table backing this edge type. |
-| `id_column`      | string                  | yes      | Per-edge primary key. **Required since v0.6.** Carried through the recursive CTE's visited-edge set to enforce trail semantics on variable-length traversal. |
-| `source_column`  | string                  | yes      | FK column pointing to the source node's `id_column`. |
-| `target_column`  | string                  | yes      | FK column pointing to the target node's `id_column`. |
-| `source_label`   | string                  | yes      | Label of the source node (must match a `label` declared in `nodes`). |
-| `target_label`   | string                  | yes      | Label of the target node. |
-| `properties`     | object (string→string)  | no       | Map from GQL property name → column name on the edge table. |
-
-Connector-specific fields are the same as for nodes (`catalog` / `schema_name`
-for Iceberg; `database` for ClickHouse).
-
-### Example
-
-```json
-{
-  "nodes": [
-    {
-      "label": "Person",
-      "table": "persons",
-      "id_column": "id",
-      "properties": { "name": "full_name", "age": "age" }
-    },
-    {
-      "label": "Company",
-      "table": "companies",
-      "id_column": "id"
-    }
-  ],
-  "edges": [
-    {
-      "rel_type": "KNOWS",
-      "table": "knows",
-      "id_column": "id",
-      "source_column": "from_id",
-      "target_column": "to_id",
-      "source_label": "Person",
-      "target_label": "Person"
-    },
-    {
-      "rel_type": "WORKS_AT",
-      "table": "works_at",
-      "id_column": "id",
-      "source_column": "person_id",
-      "target_column": "company_id",
-      "source_label": "Person",
-      "target_label": "Company"
-    }
-  ]
-}
-```
+A mapping with a required field missing — for example a relational edge without
+`metaFields.from` / `metaFields.to` — is rejected before the server serves
+queries against it. The legacy `nodes` / `id_column` / `rel_type` format is no
+longer accepted; loading it raises an actionable error pointing at the new
+format.

--- a/pages/memgraph-zero/memgql/schema-file.mdx
+++ b/pages/memgraph-zero/memgql/schema-file.mdx
@@ -1,0 +1,312 @@
+---
+title: Schema File
+description: Boot MemGQL from a single JSON file that declares connectors and the named graphs mapped over them.
+---
+
+# Schema File
+
+MemGQL federates one or more backends behind a single Bolt endpoint and exposes
+them as **named graphs** you query with GQL / openCypher. A schema file is the
+one place that declares both halves of that setup:
+
+> **A connector is a connection. A graph is a mapping laid over connectors.
+> You query graphs; routing figures out which backend to hit.**
+
+Everything in the file can also be created at runtime with
+[DDL](/memgraph-zero/memgql/reference#graph-management-query-syntax); the schema
+file is the boot-time equivalent, and runtime changes persist back to it.
+
+## Booting from a schema file
+
+```bash
+bolt_server --schema=/path/to/schema.json
+```
+
+Every connector connects and every graph registers at boot — no `CONNECT`, no
+`USE` required to start querying. `SCHEMA_FILE=<path>` is honored as an
+alternative to the flag. Runtime DDL writes the updated catalog back to this
+file atomically, so a restart reloads the same state with no replay
+(credentials are kept on disk but masked in `EXPORT SCHEMA`).
+
+The file is validated at boot: a malformed mapping — a relational edge missing
+`metaFields.from` / `metaFields.to`, or the legacy `nodes` / `id_column` format —
+is rejected with an actionable error before the server starts serving.
+
+The file has two top-level sections:
+
+```json
+{
+  "connectors": [ ],
+  "graphs":     [ ]
+}
+```
+
+## A minimal schema
+
+The smallest useful file is one connector and one vertex — a label mapped to a
+table by its primary-key column:
+
+```json
+{
+  "connectors": [
+    { "name": "pg", "type": "postgres", "connection": { "uri": "postgresql://demo:demo@localhost:5432/demo" } }
+  ],
+  "graphs": [
+    {
+      "name": "store",
+      "vertices": [
+        { "label": "Product",
+          "mappedTableSource": { "connector": "pg", "table": "products", "metaFields": { "id": "pid" } },
+          "attributes": [ { "name": "pid", "type": "Int" }, { "name": "title" } ] }
+      ]
+    }
+  ]
+}
+```
+
+Boot it, then query the label by name — no `USE` required:
+
+```gql
+MATCH (p:Product) RETURN p.title LIMIT 5;
+```
+
+The sections below are the full field reference for each block.
+
+## `connectors`
+
+A connector is a **pure connection** — how to reach a backend, and nothing about
+graph shape. `catalogs` is accepted as an alias for `connectors`.
+
+```json
+{
+  "connectors": [
+    {
+      "name": "pg",
+      "type": "postgres",
+      "connection": {
+        "uri": "postgresql://user:pass@host:5432/db"
+      }
+    }
+  ]
+}
+```
+
+| Field        | Required | Description |
+|--------------|----------|-------------|
+| `name`       | yes      | Referenced by graphs and DDL. |
+| `type`       | yes      | Backend type (see below). |
+| `connection` | yes      | A **native** connection block (see fields below). JDBC-style keys (`jdbc`, `driverClass`, …) are rejected. |
+
+Every `connection` field is optional — supply what a given backend needs:
+
+| `connection` field | Used for |
+|--------------------|----------|
+| `uri`              | Connection string for the backend. |
+| `user` / `password`| Credentials (override / complement the URI). |
+| `database`         | Database name. |
+| `schema`           | Middle namespace (PostgreSQL schema, MySQL / ClickHouse database, Iceberg schema). |
+| `catalog`          | Native root for three-level backends (Iceberg catalog, SQL Server database). |
+| `path`             | File-backed backends (DuckDB). |
+
+**Supported `type` values:** `memgraph`, `neo4j`, `postgres` (`postgresql`),
+`mysql`, `sqlserver`, `oracle`, `duckdb`, `iceberg`, `iceberg-direct`,
+`clickhouse`, `pinot`.
+
+## `graphs`
+
+Each graph is a set of `vertices` and `edges` laid over the shared connectors. A
+single graph may span **several** connectors.
+
+```json
+{
+  "graphs": [
+    { "name": "store", "vertices": [ ], "edges": [ ] }
+  ]
+}
+```
+
+> **Single-graph shorthand:** put `vertices` / `edges` at the top level instead
+> of a `graphs` block and you get one implicit graph named `default`.
+
+### Vertices
+
+A vertex maps a **label** to a backend source. Exactly one source kind is set:
+
+- **`mappedTableSource`** — a relational table (PostgreSQL, MySQL, Oracle,
+  SQL Server, DuckDB, ClickHouse, Iceberg). Rows become nodes.
+- **`mappedGraphSource`** — a native graph backend (Memgraph / Neo4j). Queries
+  pass through as Cypher; only the connector is declared.
+
+```json
+{
+  "label": "Customer",
+  "mappedTableSource": {
+    "connector": "pg",
+    "schema": "public",
+    "table": "customers",
+    "metaFields": { "id": "cid" }
+  },
+  "attributes": [
+    { "name": "cid",   "type": "Int" },
+    { "name": "name",  "column": "full_name" },
+    { "name": "email", "type": "String" }
+  ]
+}
+```
+
+```json
+{
+  "label": "User",
+  "mappedGraphSource": { "connector": "mg" },
+  "attributes": [
+    { "name": "uid", "type": "Int" },
+    { "name": "handle" }
+  ]
+}
+```
+
+| Field | Source kind | Description |
+|-------|-------------|-------------|
+| `mappedTableSource.connector` | relational | Connector name (alias `catalog`). |
+| `mappedTableSource.schema`    | relational | Optional middle namespace (PostgreSQL schema, etc.). |
+| `mappedTableSource.table`     | relational | The backing table. |
+| `mappedTableSource.metaFields.id` | relational | Primary-key column — the node's identity and the join key for edges. |
+| `mappedGraphSource.connector` | native      | Connector name (Memgraph / Neo4j); the query passes through as Cypher. |
+
+### Edges
+
+An edge maps a **relationship type** between two labels. Relational edges name
+the foreign-key columns via `metaFields.from` / `metaFields.to`; native-graph
+edges pass through.
+
+```json
+{
+  "label": "PURCHASED",
+  "from": "Customer",
+  "to": "Product",
+  "mappedTableSource": {
+    "connector": "pg",
+    "table": "orders",
+    "metaFields": { "id": "oid", "from": "cid", "to": "pid" }
+  },
+  "attributes": [ { "name": "qty", "type": "Int" } ]
+}
+```
+
+```json
+{ "label": "FOLLOWS", "from": "User", "to": "User", "mappedGraphSource": { "connector": "mg" } }
+```
+
+A relational edge adds two more `metaFields` on top of `id`:
+
+| `metaFields` key | Description |
+|------------------|-------------|
+| `id`   | The edge row's own key. |
+| `from` | Foreign-key column pointing at the **source** vertex's id column. |
+| `to`   | Foreign-key column pointing at the **target** vertex's id column. |
+
+`from` and `to` are **required** on relational edges — they define the traversal
+`(from)-[:LABEL]->(to)`. Loading fails with an actionable error if either is
+missing. Native-graph edges (`mappedGraphSource`) need only `from` / `to`
+labels; the traversal is resolved by the backend.
+
+### Attributes
+
+`attributes` declare the properties a label exposes.
+
+| Field    | Required | Description |
+|----------|----------|-------------|
+| `name`   | yes      | The GQL property name. |
+| `column` | no       | The backing column (defaults to `name`), e.g. property `name` ← column `full_name`. |
+| `type`   | no       | Recorded, not enforced at query time (default `String`). |
+
+Allowed `type` values: `Boolean`, `Byte`, `Short`, `Int`, `Long`, `HugeInt`,
+`Float`, `Double`, `Decimal`, `String`, `Date`, `DateTime`.
+
+`attributes` are optional and need not be exhaustive: a property you don't list
+still resolves to a same-named column at query time (`p.sku` → column `sku`).
+Declare the ones you want to **rename** (`column`), give a **type**, or **route
+by** USE-free.
+
+> **Note:** For USE-free routing to match a query by property (e.g.
+> `WHERE c.email = …`), the property must be a declared `attribute`. Route by
+> label / relationship type, or add an explicit `USE`, when a property is not
+> declared. See [USE-free routing](/memgraph-zero/memgql/multiple-graphs#use-free-routing).
+
+## Complete example
+
+One engine over **Memgraph** (a social graph) and **PostgreSQL** (a store),
+sharing a `uid` / `cid` id space so you can query each on its own or join across
+them.
+
+```json
+{
+  "connectors": [
+    { "name": "mg", "type": "memgraph", "connection": { "uri": "bolt://localhost:7687" } },
+    { "name": "pg", "type": "postgres", "connection": { "uri": "postgresql://demo:demo@localhost:5432/demo" } }
+  ],
+  "graphs": [
+    {
+      "name": "social",
+      "vertices": [
+        { "label": "User",
+          "mappedGraphSource": { "connector": "mg" },
+          "attributes": [ { "name": "uid", "type": "Int" }, { "name": "handle" }, { "name": "name" } ] }
+      ],
+      "edges": [
+        { "label": "FOLLOWS", "from": "User", "to": "User", "mappedGraphSource": { "connector": "mg" } }
+      ]
+    },
+    {
+      "name": "store",
+      "vertices": [
+        { "label": "Customer",
+          "mappedTableSource": { "connector": "pg", "table": "customers", "metaFields": { "id": "cid" } },
+          "attributes": [ { "name": "cid", "type": "Int" }, { "name": "name", "column": "full_name" }, { "name": "email" } ] },
+        { "label": "Product",
+          "mappedTableSource": { "connector": "pg", "table": "products", "metaFields": { "id": "pid" } },
+          "attributes": [ { "name": "pid", "type": "Int" }, { "name": "title" }, { "name": "price", "type": "Double" } ] }
+      ],
+      "edges": [
+        { "label": "PURCHASED", "from": "Customer", "to": "Product",
+          "mappedTableSource": { "connector": "pg", "table": "orders", "metaFields": { "id": "oid", "from": "cid", "to": "pid" } },
+          "attributes": [ { "name": "qty", "type": "Int" } ] }
+      ]
+    }
+  ]
+}
+```
+
+Boot it, then query graphs by name — no `USE` needed:
+
+```gql
+-- USE-free: each label routes to its owning graph / backend
+MATCH (u:User) RETURN u.handle, u.name ORDER BY u.uid LIMIT 5;       -- → social (Memgraph)
+MATCH (c:Customer)-[:PURCHASED]->(p:Product) RETURN c.name, p.title; -- → store  (PostgreSQL)
+
+-- pin a query to a graph explicitly
+USE store MATCH (p:Product) WHERE p.price > 100 RETURN p.title ORDER BY p.price DESC;
+```
+
+The shared `uid` / `cid` id space also lets one query **join across both
+backends**. See [Multiple Graphs](/memgraph-zero/memgql/multiple-graphs) for the
+full query model — USE-free routing, cross-backend joins, and composites — and
+[Reference](/memgraph-zero/memgql/reference#graph-management-query-syntax) for
+the runtime DDL that builds the same catalog live.
+
+## How it works
+
+- **Connector = connection, graph = mapping.** A graph owns a per-connector
+  mapping (keyed internally `<graph>/<connector>`), so one graph can span
+  multiple backends.
+- **USE-free routing.** At boot — and on `REFRESH SCHEMA` — the engine builds a
+  label → source index from the graphs, connectors, and introspected native
+  schemas. A query with no `USE` is routed by the labels (and declared
+  properties) it mentions; ambiguity yields an actionable error rather than a
+  silent guess.
+- **Per-query mapping.** Right before a routed query runs, the target
+  connection's executor is stamped with that graph's mapping, so relational
+  backends translate GQL → SQL against the right tables/columns while native
+  backends pass Cypher straight through.
+- **Cross-backend federation.** When one statement spans graphs, each part runs
+  on its own backend and the results are joined in-engine (hash join).

--- a/pages/memgraph-zero/memgql/use-cases/public-private.mdx
+++ b/pages/memgraph-zero/memgql/use-cases/public-private.mdx
@@ -88,10 +88,7 @@ services:
       - -c
       - |
         echo "ADD CONNECTOR mg TYPE memgraph URI 'memgraph:7687' GRAPH memgraph;" | mgconsole --host memgql --port 7688 &&
-        echo "CONNECT mg AS mg_conn;" | mgconsole --host memgql --port 7688 &&
-        echo "ADD MAPPING pg_social FROM '/mappings/pg_mapping.json';" | mgconsole --host memgql --port 7688 &&
-        echo "ADD CONNECTOR pg TYPE postgres URI 'host=postgres user=postgres password=postgres dbname=postgres' MAPPING pg_social;" | mgconsole --host memgql --port 7688 &&
-        echo "CONNECT pg AS pg_conn;" | mgconsole --host memgql --port 7688 &&
+        echo "ADD CONNECTOR pg TYPE postgres URI 'host=postgres user=postgres password=postgres dbname=postgres';" | mgconsole --host memgql --port 7688 &&
         echo "MemGQL bootstrap complete."
     depends_on:
       memgql:
@@ -159,27 +156,14 @@ Tell MemGQL how the relational tables map to graph labels:
 ```bash
 cat > pg_mapping.json << 'EOF'
 {
-  "nodes": [
-    {
-      "label": "User",
-      "table": "users",
-      "id_column": "id",
-      "properties": {
-        "name": "name",
-        "email": "email"
-      }
-    }
+  "vertices": [
+    { "label": "User",
+      "mappedTableSource": { "connector": "pg", "table": "users", "metaFields": { "id": "id" } },
+      "attributes": [ { "name": "name" }, { "name": "email" } ] }
   ],
   "edges": [
-    {
-      "rel_type": "FRIEND_OF",
-      "table": "friend_of",
-      "id_column": "id",
-      "source_column": "user_id",
-      "target_column": "friend_id",
-      "source_label": "User",
-      "target_label": "User"
-    }
+    { "label": "FRIEND_OF", "from": "User", "to": "User",
+      "mappedTableSource": { "connector": "pg", "table": "friend_of", "metaFields": { "id": "id", "from": "user_id", "to": "friend_id" } } }
   ]
 }
 EOF
@@ -213,8 +197,16 @@ SHOW CONNECTIONS;
 Register graphs in the catalog so they can be referenced by name in composite queries:
 
 ```gql
-ADD GRAPH public ON CONNECTOR mg GRAPH memgraph;
-ADD GRAPH private ON CONNECTOR pg MAPPING pg_social;
+CREATE GRAPH public FROM '{
+  "vertices": [
+    { "label": "Product",  "mappedGraphSource": { "connector": "mg" } },
+    { "label": "Category", "mappedGraphSource": { "connector": "mg" } }
+  ],
+  "edges": [
+    { "label": "IN_CATEGORY", "from": "Product", "to": "Category", "mappedGraphSource": { "connector": "mg" } }
+  ]
+}';
+CREATE GRAPH private FROM FILE '/mappings/pg_mapping.json';
 ```
 
 Verify the graphs:
@@ -225,11 +217,7 @@ SHOW GRAPHS;
 
 ## 7. Seed public data in Memgraph
 
-Insert a public product catalog:
-
-```gql
-SET DEFAULT CONNECTION mg_conn;
-```
+Insert a public product catalog — the `Product` / `Category` labels route to `public`:
 
 ```gql
 INSERT
@@ -255,11 +243,7 @@ MATCH (p:`Product`)-[:IN_CATEGORY]->(c:Category) RETURN p.name, c.name;
 
 ## 8. Seed private data in PostgreSQL
 
-Switch to the private backend and insert customer profiles:
-
-```gql
-SET DEFAULT CONNECTION pg_conn;
-```
+Insert customer profiles — the `User` label routes to `private`:
 
 ```gql
 INSERT (alice:User {name: "Alice", email: "alice@acme.com"});
@@ -314,23 +298,18 @@ locally. Standard GQL composite operators (`UNION`, `UNION ALL`, `INTERSECT`,
 
 ## Cleanup
 
+Clear the seeded data (through the graphs, before dropping them):
+
+```gql
+USE public  MATCH (n) DETACH DELETE n;
+USE private MATCH (n) DETACH DELETE n;
+```
+
 Remove the graph catalog entries:
 
 ```gql
-UNADD GRAPH public;
-UNADD GRAPH private;
-```
-
-Clear the public data:
-
-```gql
-USE CONNECTION mg_conn MATCH (n) DETACH DELETE n;
-```
-
-Clear the private data:
-
-```gql
-USE CONNECTION pg_conn MATCH (n) DETACH DELETE n;
+DROP GRAPH public;
+DROP GRAPH private;
 ```
 
 Stop and remove the stack:


### PR DESCRIPTION
## What this updates

Brings the MemGQL docs in line with the **schema-graph model** (`feat/global-schema` in `memgraph/zero`), which replaces the old connector-bound flow.

Readers now get, matching the engine:

- **Schema File** (new page) — boot from a single `--schema` JSON of `connectors` + `graphs`, using the `vertices` / `edges` / `attributes` / `metaFields` mapping format, with minimal and full examples.
- **Connectors + graphs everywhere** — `ADD CONNECTOR` + `CREATE GRAPH … FROM '<json>' | FROM FILE '<path>'` instead of `ADD GRAPH … ON CONNECTOR` / `ADD MAPPING`.
- **USE-free routing** — query by label; explicit `USE <graph>` is the override.
- **Query-driven cache** via `ALTER GRAPH … SET CACHE` (now noted to engage USE-free too), `SHOW GRAPH CACHES`, `ALTER GRAPH … REMOVE CACHE`.

## Files

- **New:** `schema-file.mdx` (+ nav entry).
- **Rewritten:** `reference.mdx`, `multiple-graphs.mdx`, `quick-start.mdx`, `complete.mdx`, `use-cases/public-private.mdx`, `connect/oracle.mdx`, `connect/sqlserver.mdx`.
- **`changelog.mdx`:** Unreleased breaking-change + new-feature entries.

Removed from the docs: `ADD GRAPH … ON CONNECTOR`, `ADD MAPPING`, `CONNECT … AS`, `USE CONNECTION`, `SET DEFAULT CONNECTION`, `UNADD GRAPH`, `ALTER GRAPH SET CONNECTOR/GRAPH/MAPPING`, and the legacy `nodes` / `id_column` mapping format.
