### PR TITLE
docs: add text.compare_cleaned function to text module

### DIFF
--- a/pages/advanced-algorithms/available-algorithms.mdx
+++ b/pages/advanced-algorithms/available-algorithms.mdx
@@ -208,6 +208,7 @@ Running `SHOW QUERY CALLABLE MAPPINGS` requires the `CONFIG` privilege.
 | apoc.text.format | Formats strings using the C++ fmt library | [text.format()](/advanced-algorithms/available-algorithms/text#format) |
 | apoc.text.replace | Replaces substrings matching regex with replacement | [text.replace()](/advanced-algorithms/available-algorithms/text#replace) |
 | apoc.text.regReplace | Replaces substrings matching regex with replacement | [text.regReplace()](/advanced-algorithms/available-algorithms/text#regreplace) |
+| apoc.text.compareCleaned | Compares two strings for equality after normalization | [text.compare_cleaned()](/advanced-algorithms/available-algorithms/text#compare_cleaned) |
 | apoc.util.md5 | Gets MD5 hash of concatenated string representations | [util_module.md5()](/advanced-algorithms/available-algorithms/util_module#md5) |
 | apoc.util.validatePredicate | Raises exception if predicate yields true with parameter interpolation | [mgps.validate_predicate()](/advanced-algorithms/available-algorithms/mgps#validate_predicate) |
 | db.awaitIndexes | No-op compatibility shim for clients that wait for index creation (e.g. the Neo4j Spark connector) | [mgps.await_indexes()](/advanced-algorithms/available-algorithms/mgps#await_indexes) |

--- a/pages/advanced-algorithms/available-algorithms/text.mdx
+++ b/pages/advanced-algorithms/available-algorithms/text.mdx
@@ -297,3 +297,46 @@ Result:
 | 1      |
 +--------+
 ```
+
+### `compare_cleaned()`
+
+Compares two strings for equality after normalizing each one: keeping only ASCII
+letters and digits, converting them to lowercase, and dropping everything else
+(accents, punctuation, whitespace, and non-ASCII characters).
+
+<Callout type="info">
+This function is equivalent to **apoc.text.compareCleaned**.
+</Callout>
+
+<Callout type="info">
+Normalization is limited to ASCII and performs no Unicode folding, so accented
+and non-ASCII letters are dropped rather than reduced to a base letter. For
+example, `café` cleans to `caf` and is therefore not equal to `cafe`.
+</Callout>
+
+{<h4 className="custom-header"> Input: </h4>}
+
+- `text1: string` ➡ The first string to normalize and compare. A `null` value results in `false`.
+- `text2: string` ➡ The second string to normalize and compare. A `null` value results in `false`.
+
+{<h4 className="custom-header"> Output: </h4>}
+
+- `boolean` ➡ `true` if the two normalized strings are equal, and `false` otherwise.
+
+{<h4 className="custom-header"> Usage: </h4>}
+
+Use the following query to compare two strings while ignoring case and punctuation:
+
+```cypher
+RETURN text.compare_cleaned("Hello, World!", "hello world") AS result;
+```
+
+Result:
+
+```plaintext
++--------+
+| result |
++--------+
+| true   |
++--------+
+```


### PR DESCRIPTION
### Release note

Documented the new `text.compare_cleaned(text1, text2)` function in the MAGE `text` module: compares two strings for equality after normalization (keeps only ASCII letters and digits, lowercased; drops everything else), with `NULL` arguments returning `false`.

### Related product PRs

PRs from product repo this doc page is related to:
memgraph/memgraph#4435

### Checklist:

- [x] Add appropriate milestone (current release cycle)
- [x] Add `bugfix` or `feature` label, based on the product PR type you're documenting
- [x] Make sure all relevant tech details are documented
    - [x] Update reference pages (e.g. [clauses](https://memgraph.com/docs/querying/clauses), [functions](https://memgraph.com/docs/querying/functions), [flags](https://memgraph.com/docs/database-management/configuration#list-of-configuration-flags), [experimental](https://memgraph.com/docs/database-management/experimental-features), [monitoring](https://memgraph.com/docs/database-management/monitoring), [Cypher differences](https://memgraph.com/docs/querying/differences-in-cypher-implementations))
    - [x] Search for the feature you are working on (mentions) and make updates if needed
    - [x] Provide a basic example of usage
    - [ ] In case your feature is an Enterprise one, list it under [ME page](https://memgraph.com/docs/database-management/enabling-memgraph-enterprise) and mark its page with Enterprise ([example](https://memgraph.com/docs/database-management/authentication-and-authorization/role-based-access-control)).
- [ ] Check all content with Grammarly
- [x] Perform a self-review of my code
- [ ] The build passes locally
- [x] My changes generate no new warnings or errors