### PR TITLE
docs: add map.get and map.merge_list; align map functions on null/coercion behavior

### DIFF
--- a/pages/advanced-algorithms/available-algorithms/map.mdx
+++ b/pages/advanced-algorithms/available-algorithms/map.mdx
@@ -181,8 +181,8 @@ This function is equivalent to **apoc.map.merge**.
 
 {<h4 className="custom-header"> Input: </h4>}
 
-- `first: mgp.Nullable[Map]` ➡ A map containing key-value pairs that need to be merged with another map.
-- `second: mgp.Nullable[Map]` ➡ The second map containing key-value pairs that need to be merged with the key-values from the first map.
+- `map1: mgp.Nullable[Map]` ➡ The first map to merge (a node or relationship may be passed; its properties are used).
+- `map2: mgp.Nullable[Map]` ➡ The second map to merge. On a key conflict, its value takes precedence.
 
 {<h4 className="custom-header"> Output: </h4>}
 
@@ -201,6 +201,40 @@ RETURN map.merge({a: "b", c: "d"}, {e: "f", g: "h"}) AS merged;
 | merged                                 |
 +----------------------------------------+
 | {a: "b", c: "d", e: "f", g: "h"}       |
++----------------------------------------+
+```
+
+### `merge_list()`
+
+Merges a list of maps into a single map. Keys are merged left to right, so when
+the same key appears in more than one map, the value from the last map wins. An
+empty list yields an empty map.
+
+<Callout type="info">
+This function is equivalent to **apoc.map.mergeList**.
+</Callout>
+
+{<h4 className="custom-header"> Input: </h4>}
+
+- `maps: List[Map]` ➡ The maps to merge (each element may be a node or relationship, whose properties are used).
+
+{<h4 className="custom-header"> Output: </h4>}
+
+- `Map` ➡ The merged map.
+
+{<h4 className="custom-header"> Usage: </h4>}
+
+The following query merges a list of maps:
+
+```cypher
+RETURN map.merge_list([{a: 1}, {a: 2, b: 3}]) AS merged;
+```
+
+```plaintext
++----------------------------------------+
+| merged                                 |
++----------------------------------------+
+| {a: 2, b: 3}                           |
 +----------------------------------------+
 ```
 
@@ -270,8 +304,12 @@ RETURN map.from_lists(["key","key2"],[1,2]) AS result;
 ### `from_values()`
 
 Returns a map from the given list of values. The list has the format: `[key1,
-value1, key2, value2]`. If the key is not convertible to a string, the function
-throws `ValueException`.
+value1, key2, value2]`. Keys are converted to strings; a pair whose key is
+`null` is skipped (its value is ignored).
+
+<Callout type="info">
+This function is equivalent to **apoc.map.fromValues**.
+</Callout>
 
 {<h4 className="custom-header"> Input: </h4>}
 
@@ -300,13 +338,18 @@ RETURN map.from_values(["day", "sunny", 5, 6]) AS map;
 ### `set_key()`
 
 Updates the value at the position `key` in a map. If the key doesn't exist,
-the function will insert it.
+the function will insert it. A `null` map is treated as empty and a `null` key
+is a no-op (the map is returned unchanged).
+
+<Callout type="info">
+This function is equivalent to **apoc.map.setKey**.
+</Callout>
 
 {<h4 className="custom-header"> Input: </h4>}
 
-- `map: Map` ➡ The map that will be modified.
-- `key: string` ➡ The key of a certain key-value pair that needs to have a new value.
-- `value: any` ➡ The new value of a certain key-value pair.
+- `map: mgp.Nullable[Map]` ➡ The map that will be modified (a node or relationship may be passed; its properties are used).
+- `key: mgp.Nullable[string]` ➡ The key to add or update; a `null` key leaves the map unchanged.
+- `value: any` ➡ The new value of the key-value pair.
 
 {<h4 className="custom-header"> Output: </h4>}
 
@@ -326,6 +369,44 @@ RETURN map.set_key({name:"Ivan",country:"Croatia"}, "name", "Matija") AS map;
 +-------------------------------------------+
 | {"country": "Croatia", "name": "Matija"}  |
 +-------------------------------------------+
+```
+
+### `get()`
+
+Returns the value stored under `key` in the map. If the key is absent, the
+function returns `value` when it is non-null; otherwise it throws when `fail` is
+`true` (the default) or returns `null` when `fail` is `false`. An existing key
+always wins, even when its stored value is `null`.
+
+<Callout type="info">
+This function is equivalent to **apoc.map.get**.
+</Callout>
+
+{<h4 className="custom-header"> Input: </h4>}
+
+- `map: Map` ➡ The map to look up (a node or relationship may be passed; its properties are used).
+- `key: string` ➡ The key to look up.
+- `value: any (default = null)` ➡ The value returned when the key is absent.
+- `fail: boolean (default = true)` ➡ When `true`, throws if the key is absent and `value` is null; when `false`, returns `null` instead.
+
+{<h4 className="custom-header"> Output: </h4>}
+
+- `any` ➡ The value at `key`, the fallback `value`, or `null`.
+
+{<h4 className="custom-header"> Usage: </h4>}
+
+The following query returns the fallback value because the key is absent:
+
+```cypher
+RETURN map.get({name: "Ivan"}, "country", "unknown", false) AS value;
+```
+
+```plaintext
++----------------------------------------+
+| value                                  |
++----------------------------------------+
+| "unknown"                              |
++----------------------------------------+
 ```
 
 ## Procedures

--- a/pages/advanced-algorithms/available-algorithms/map.mdx
+++ b/pages/advanced-algorithms/available-algorithms/map.mdx
@@ -40,7 +40,7 @@ from any inner maps that are part of the input map.
 
 {<h4 className="custom-header"> Input: </h4>}
 
-- `map: Map` ➡ The map from which the key will be removed.
+- `map: Map` ➡ The map from which the key will be removed (a node or relationship may be passed; its properties are used).
 - `key: string` ➡ The key to be removed from the map.
 - `config: Map default = {recursive: false}` ➡ The config map which supports the
 `recursive` option. The option `recursive` is `false` by default, and should be
@@ -94,7 +94,7 @@ This function is equivalent to **apoc.map.removeKeys**.
 
 {<h4 className="custom-header"> Input: </h4>}
 
-- `map: Map[Any]` ➡ The input map.
+- `map: Map[Any]` ➡ The input map (a node or relationship may be passed; its properties are used).
 - `keys: List[string]` ➡ A list of keys that will be removed.
 - `config: Map default = {recursive: false}` ➡ A config map which supports the
 `recursive` option. The `recursive` option is `false` by default, and should be
@@ -244,7 +244,7 @@ The procedure flattens nested items in the input map.
 
 {<h4 className="custom-header"> Input: </h4>}
 
-- `map: Map[Any]` ➡ The input map that needs to be modified.
+- `map: Map[Any]` ➡ The input map that needs to be modified (a node or relationship may be passed; its properties are used).
 - `delimiter: string (default = ".")` ➡ The delimiter used for flattening.
 
 {<h4 className="custom-header"> Output: </h4>}

--- a/pages/advanced-algorithms/available-algorithms/map.mdx
+++ b/pages/advanced-algorithms/available-algorithms/map.mdx
@@ -349,7 +349,7 @@ This function is equivalent to **apoc.map.setKey**.
 
 - `map: mgp.Nullable[Map]` ➡ The map that will be modified (a node or relationship may be passed; its properties are used).
 - `key: mgp.Nullable[string]` ➡ The key to add or update; a `null` key leaves the map unchanged.
-- `value: any` ➡ The new value of the key-value pair.
+- `value: mgp.Nullable[Any]` ➡ The new value of the key-value pair.
 
 {<h4 className="custom-header"> Output: </h4>}
 


### PR DESCRIPTION
### Release note

Documented the new `map.get` and `map.merge_list` functions in the `map` module, and updated `map.merge`, `map.set_key`, and `map.from_values` to reflect the aligned null handling, node/relationship coercion, and renamed `merge` arguments (`map1`/`map2`).

### Related product PRs

memgraph/memgraph#4417

### Checklist:

- [x] Add appropriate milestone (current release cycle)
- [x] Add `bugfix` or `feature` label, based on the product PR type you're documenting
- [ ] Make sure all relevant tech details are documented
    - [x] Update reference pages (e.g. [clauses](https://memgraph.com/docs/querying/clauses), [functions](https://memgraph.com/docs/querying/functions), [flags](https://memgraph.com/docs/database-management/configuration#list-of-configuration-flags), [experimental](https://memgraph.com/docs/database-management/experimental-features), [monitoring](https://memgraph.com/docs/database-management/monitoring), [Cypher differences](https://memgraph.com/docs/querying/differences-in-cypher-implementations))
    - [ ] Search for the feature you are working on (mentions) and make updates if needed
    - [x] Provide a basic example of usage
    - [ ] In case your feature is an Enterprise one, list it under [ME page](https://memgraph.com/docs/database-management/enabling-memgraph-enterprise) and mark its page with Enterprise ([example](https://memgraph.com/docs/database-management/authentication-and-authorization/role-based-access-control)).
- [ ] Check all content with Grammarly
- [ ] Perform a self-review of my code
- [ ] The build passes locally
- [ ] My changes generate no new warnings or errors
