### PR TITLE
Add public Memgraph docs MCP server documentation

### DIFF
--- a/pages/ai-ecosystem/mcp.mdx
+++ b/pages/ai-ecosystem/mcp.mdx
@@ -354,3 +354,131 @@ Memgraph Lab has become an MCP Client and now has built-in support for MCP serve
 ![mcp-lab](/pages/ai-ecosystem/integrations/lab-mcp.png)
 
 More details about the MCP connection in Memgraph Lab can be found in the [Memgraph Lab](/memgraph-lab/getting-started/features/graphchat#mcp-servers) documentation.
+
+### MCP server for docs
+
+Memgraph provides a public MCP server for its documentation. Connect it to any
+MCP-capable AI assistant to ask questions about Memgraph and get answers
+grounded in the current docs, with sources. There is no API key or sign-in
+required, just one endpoint.
+
+- **Endpoint:** `https://mcp-docs.memgraph.com`
+- **Tool provided:** `search_memgraph_knowledge_sources`
+
+**Claude Code (CLI):**
+
+```bash
+claude mcp add --transport http memgraph-docs https://mcp-docs.memgraph.com
+```
+
+**Cursor** (`~/.cursor/mcp.json` or project `.cursor/mcp.json`):
+
+```json
+{
+  "mcpServers": {
+    "memgraph-docs": {
+      "url": "https://mcp-docs.memgraph.com"
+    }
+  }
+}
+```
+
+**VS Code** (`.vscode/mcp.json`):
+
+```json
+{
+  "servers": {
+    "memgraph-docs": {
+      "type": "http",
+      "url": "https://mcp-docs.memgraph.com"
+    }
+  }
+}
+```
+
+**Claude Desktop and other stdio-only clients** (needs Node.js, via the
+`mcp-remote` bridge):
+
+```json
+{
+  "mcpServers": {
+    "memgraph-docs": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "mcp-remote@latest",
+        "https://mcp-docs.memgraph.com"
+      ]
+    }
+  }
+}
+```
+
+After adding it, restart your client and ask a Memgraph question — the assistant
+pulls the relevant documentation automatically.
+
+<Callout type="info">
+  The assistant answers from the current docs with links, so you can follow up
+  with "show me the exact config" or "give me the full working example" and it
+  will pull the specifics.
+</Callout>
+
+<h4 className="custom-header">Sample prompts to get started</h4>
+
+Once connected, ask your assistant these in plain language. It will call the
+docs server and answer with sources. Copy one, then adapt it to your own schema
+and data.
+
+**Getting started and core querying**
+
+- "How do I install Memgraph with Docker and connect to it from Python?"
+- "I'm coming from Neo4j. What Cypher differences should I know about in
+  Memgraph, and can I reuse my existing queries?"
+- "Show me how to bulk-load a CSV of nodes and relationships efficiently using
+  LOAD CSV."
+- "How do I define indexes and constraints in Memgraph, and when should I add
+  them?"
+
+**Performance and production**
+
+- "Memgraph is in-memory. How do I configure durability with snapshots and WAL
+  so I don't lose data on restart?"
+- "My traversal query is slow. How do I read a query plan with EXPLAIN and
+  PROFILE, and what do I optimize first?"
+- "What's the recommended way to run Memgraph in high availability with
+  replication?"
+- "How much memory will I need for a graph with 50M nodes and 200M
+  relationships, and how do I control memory limits?"
+
+**Graph algorithms and analytics (MAGE)**
+
+- "Which MAGE algorithms are available, and how do I run PageRank and community
+  detection (Louvain) on my graph?"
+- "How do I find the shortest path between two nodes, and how do weighted vs.
+  unweighted shortest path differ?"
+- "How do I write a custom graph algorithm as a Python query module and call it
+  from Cypher?"
+- "Set up a dynamic PageRank that updates as new edges stream in, instead of
+  recomputing each time."
+
+**GraphRAG and AI**
+
+- "How do I build a GraphRAG pipeline on Memgraph? Walk me through schema,
+  ingestion, and retrieval."
+- "How do I use vector search in Memgraph to store embeddings and run similarity
+  queries alongside graph traversals?"
+- "Show me how to combine a vector similarity search with a multi-hop Cypher
+  traversal to ground an LLM answer in my knowledge graph."
+- "What's the best way to model a knowledge graph for retrieval, and how do I
+  keep embeddings in sync as data changes?"
+
+**Art of the possible**
+
+- "Build me a real-time fraud detection pattern: detect when a new transaction
+  closes a suspicious cycle between accounts."
+- "Model a recommendation engine over users, products, and purchases, and write
+  the Cypher to surface 'others also bought' results."
+- "I have a supply chain with suppliers, parts, and factories. Show me how to
+  trace every downstream product affected by one failed supplier."
+- "Design a service dependency graph and query for the blast radius if one
+  service goes down."

--- a/pages/index.mdx
+++ b/pages/index.mdx
@@ -48,6 +48,17 @@ Learn how to utilize Memgraph to migrate and analyze your data.
   />
 </Cards>
 
+Memgraph provides a public MCP server for its documentation. Connect it to any
+MCP-capable AI assistant to ask questions about Memgraph and get answers
+grounded in the current docs, with sources.
+
+<Cards>
+  <Cards.Card
+    title="MCP server for docs"
+    href="/ai-ecosystem/mcp#mcp-server-for-docs"
+  />
+</Cards>
+
 ## Memgraph ecosystem
 
 To get started with Memgraph, explore everything the Memgraph ecosystem offers, including Memgraph Lab, Memgraph Cloud, MAGE graph library and more.


### PR DESCRIPTION
## Summary
- Document the public Memgraph documentation MCP server on `/ai-ecosystem/mcp`, including the endpoint, client setup for Claude Code, Cursor, VS Code, and Claude Desktop, and sample prompts.
- Surface the docs MCP server on the home page with a short description and a link to the new section.


Made with [Cursor](https://cursor.com)