### PR TITLE
docs: add convert module JSON conversion functions

### DIFF
--- a/pages/advanced-algorithms/available-algorithms.mdx
+++ b/pages/advanced-algorithms/available-algorithms.mdx
@@ -174,8 +174,10 @@ Running `SHOW QUERY CALLABLE MAPPINGS` requires the `CONFIG` privilege.
 | apoc.coll.sum | Calculates the sum of listed elements | [collections.sum()](/advanced-algorithms/available-algorithms/collections#sum) |
 | apoc.coll.partition | Partitions the input list into sub-lists of the specified size | [collections.partition()](/advanced-algorithms/available-algorithms/collections#partition) |
 | apoc.convert.toTree | Converts values into tree structures | [convert_c.to_tree()](/advanced-algorithms/available-algorithms/convert_c#to_tree) |
-| apoc.convert.fromJsonList | Converts a JSON string representation of a list into an actual list object | [json_util.from_json_list()](/advanced-algorithms/available-algorithms/json_util#from_json_list) |
-| apoc.convert.toJson | Converts any value to its JSON string representation | [json_util.to_json()](/advanced-algorithms/available-algorithms/json_util#to_json) |
+| apoc.convert.fromJsonList | Converts a JSON string representation of a list into an actual list object | [convert.from_json_list()](/advanced-algorithms/available-algorithms/convert#from_json_list) |
+| apoc.convert.fromJsonMap | Converts a JSON string representation of a map into an actual map object | [convert.from_json_map()](/advanced-algorithms/available-algorithms/convert#from_json_map) |
+| apoc.convert.toJson | Converts any value to its JSON string representation | [convert.to_json()](/advanced-algorithms/available-algorithms/convert#to_json) |
+| apoc.convert.toMap | Converts a value into a map | [convert.to_map()](/advanced-algorithms/available-algorithms/convert#to_map) |
 | apoc.create.node | Creates a single node with specified labels and properties | [create.node()](/advanced-algorithms/available-algorithms/create#node) |
 | apoc.create.nodes | Creates multiple nodes with specified labels and properties | [create.nodes()](/advanced-algorithms/available-algorithms/create#nodes) |
 | apoc.create.removeProperties | Removes properties from nodes | [create.remove_properties()](/advanced-algorithms/available-algorithms/create#remove_properties) |

--- a/pages/advanced-algorithms/available-algorithms/convert.mdx
+++ b/pages/advanced-algorithms/available-algorithms/convert.mdx
@@ -63,3 +63,176 @@ The output shows the parsed object:
    "city": "New York"
 }
 ```
+
+### `from_json_map()`
+
+Parses a JSON-object string into a map. An optional `path` selects a nested part
+of the document before conversion; the selected value must be a JSON object.
+
+{<h4 className="custom-header"> Input: </h4>}
+
+- `map: String` ➡ The JSON string to parse. A `null` value returns `null`.
+- `path: String` (default `""`) ➡ An optional selector for a nested part of the
+  document (see [Path option](#path-option)).
+
+{<h4 className="custom-header"> Output: </h4>}
+
+- `Map` ➡ The parsed map. Returns `null` when the input is `null`, when the path
+  does not resolve, or when the selected value is JSON `null`. An error is raised
+  when the input (or selected value) is not a JSON object.
+
+{<h4 className="custom-header"> Usage: </h4>}
+
+```cypher
+RETURN convert.from_json_map('{"name": "GDS"}') AS result;
+```
+
+```json
+{ "name": "GDS" }
+```
+
+Select a nested object with `path`:
+
+```cypher
+RETURN convert.from_json_map('{"a": 1, "b": {"c": 2, "d": [10, 20]}}', '$.b') AS result;
+```
+
+```json
+{ "c": 2, "d": [10, 20] }
+```
+
+To read a single value out of the parsed map, index it with Cypher instead of
+using `path`:
+
+```cypher
+RETURN convert.from_json_map('{"mode": "fast"}')['mode'] AS result;
+```
+
+```text
+"fast"
+```
+
+### `from_json_list()`
+
+Parses a JSON-array string into a list. An optional `path` selects a nested part
+of the document before conversion; the selected value must be a JSON array.
+
+{<h4 className="custom-header"> Input: </h4>}
+
+- `list: String` ➡ The JSON string to parse. A `null` value returns `null`.
+- `path: String` (default `""`) ➡ An optional selector for a nested part of the
+  document (see [Path option](#path-option)).
+
+{<h4 className="custom-header"> Output: </h4>}
+
+- `List` ➡ The parsed list. Returns `null` when the input is `null`, when the
+  path does not resolve, or when the selected value is JSON `null`. An error is
+  raised when the input (or selected value) is not a JSON array.
+
+{<h4 className="custom-header"> Usage: </h4>}
+
+```cypher
+RETURN convert.from_json_list('[1, 2, 3]') AS result;
+```
+
+```json
+[1, 2, 3]
+```
+
+Select a nested array with `path`:
+
+```cypher
+RETURN convert.from_json_list('{"a": [1, 2, 3]}', '$.a') AS result;
+```
+
+```json
+[1, 2, 3]
+```
+
+### Path option
+
+`from_json_map()` and `from_json_list()` accept an optional `path` that selects a
+nested part of the JSON document before conversion.
+
+| Syntax | Meaning | Example (on `{"a": 1, "b": {"c": 2, "e": [10, 20]}}`) |
+| ------ | ------- | ----------------------------------------------------- |
+| `$` / empty / `null` | The whole document | `$` selects the whole object |
+| `.key` | Object key step | `$.b` selects `{"c": 2, "e": [10, 20]}` |
+| `['key']` or `["key"]` | Quoted key step, for keys with dots, spaces or special characters | `$['b']` selects `{"c": 2, "e": [10, 20]}` |
+| `[index]` | Array element, 0-based | `$.b.e[1]` selects `20` |
+
+Steps chain left to right (`$.b.e[0]` selects `10`), and a leading `$` is
+optional (`a.b` is equivalent to `$.a.b`). Wildcards (`$.e[*]`), recursive
+descent (`$..x`), filter expressions and array slices are not supported and raise
+an error. A path that does not resolve, or that resolves to JSON `null`, returns
+`null`.
+
+### `to_map()`
+
+Converts a value into a map.
+
+{<h4 className="custom-header"> Input: </h4>}
+
+- `value: Any` ➡ The value to convert.
+
+{<h4 className="custom-header"> Output: </h4>}
+
+- `Map` ➡ A map is returned unchanged, a node or relationship is returned as its
+  property map, and `null` or any other value returns `null`.
+
+{<h4 className="custom-header"> Usage: </h4>}
+
+```cypher
+CREATE (n:Person {id: 4, name: 'z'})
+RETURN convert.to_map(n) AS result;
+```
+
+```json
+{ "id": 4, "name": "z" }
+```
+
+### `to_json()`
+
+Serializes any value into a JSON string.
+
+{<h4 className="custom-header"> Input: </h4>}
+
+- `value: Any` ➡ The value to serialize.
+
+{<h4 className="custom-header"> Output: </h4>}
+
+- `String` ➡ The JSON string representation of the value.
+
+Scalars, lists and maps are serialized directly. Graph and spatial-temporal
+values use a structured form:
+
+- **Node** ➡ `{id, type: "node", labels, properties}`; `labels` and `properties`
+  are omitted when empty.
+- **Relationship** ➡ `{id, type: "relationship", label, start, end, properties}`,
+  where `start` and `end` are full node objects.
+- **Path** ➡ a flat array `[node, relationship, node, ...]`.
+- **Point** ➡ `{crs, x, y, z}` for cartesian points, `{crs, longitude, latitude,
+  height}` for geographic points.
+- **Temporal** ➡ the canonical string form (for example `"2020-01-02"` for a
+  date, ISO-8601 period for a duration).
+
+{<h4 className="custom-header"> Usage: </h4>}
+
+```cypher
+RETURN convert.to_json({a: 1, b: 'x', c: [1, 2], d: null}) AS result;
+```
+
+```text
+{"a":1,"b":"x","c":[1,2],"d":null}
+```
+
+Serialize a node:
+
+```cypher
+CREATE (n:Person:Human {name: 'Ana', age: 30})
+RETURN convert.to_json(n) AS result;
+```
+
+```text
+{"id":"0","type":"node","labels":["Human","Person"],"properties":{"name":"Ana","age":30}}
+```

--- a/pages/advanced-algorithms/available-algorithms/convert.mdx
+++ b/pages/advanced-algorithms/available-algorithms/convert.mdx
@@ -69,6 +69,10 @@ The output shows the parsed object:
 Parses a JSON-object string into a map. An optional `path` selects a nested part
 of the document before conversion; the selected value must be a JSON object.
 
+<Callout type="info">
+This function is equivalent to **apoc.convert.fromJsonMap**.
+</Callout>
+
 {<h4 className="custom-header"> Input: </h4>}
 
 - `map: String` ➡ The JSON string to parse. A `null` value returns `null`.
@@ -116,6 +120,10 @@ RETURN convert.from_json_map('{"mode": "fast"}')['mode'] AS result;
 
 Parses a JSON-array string into a list. An optional `path` selects a nested part
 of the document before conversion; the selected value must be a JSON array.
+
+<Callout type="info">
+This function is equivalent to **apoc.convert.fromJsonList**.
+</Callout>
 
 {<h4 className="custom-header"> Input: </h4>}
 
@@ -171,6 +179,10 @@ an error. A path that does not resolve, or that resolves to JSON `null`, returns
 
 Converts a value into a map.
 
+<Callout type="info">
+This function is equivalent to **apoc.convert.toMap**.
+</Callout>
+
 {<h4 className="custom-header"> Input: </h4>}
 
 - `map: Any` ➡ The value to convert.
@@ -194,6 +206,10 @@ RETURN convert.to_map(n) AS result;
 ### `to_json()`
 
 Serializes any value into a JSON string.
+
+<Callout type="info">
+This function is equivalent to **apoc.convert.toJson**.
+</Callout>
 
 {<h4 className="custom-header"> Input: </h4>}
 

--- a/pages/advanced-algorithms/available-algorithms/convert.mdx
+++ b/pages/advanced-algorithms/available-algorithms/convert.mdx
@@ -173,7 +173,7 @@ Converts a value into a map.
 
 {<h4 className="custom-header"> Input: </h4>}
 
-- `value: Any` ➡ The value to convert.
+- `map: Any` ➡ The value to convert.
 
 {<h4 className="custom-header"> Output: </h4>}
 
@@ -209,12 +209,16 @@ values use a structured form:
 - **Node** ➡ `{id, type: "node", labels, properties}`; `labels` and `properties`
   are omitted when empty.
 - **Relationship** ➡ `{id, type: "relationship", label, start, end, properties}`,
-  where `start` and `end` are full node objects.
+  where `start` and `end` are full node objects; `properties` is omitted when empty.
 - **Path** ➡ a flat array `[node, relationship, node, ...]`.
 - **Point** ➡ `{crs, x, y, z}` for cartesian points, `{crs, longitude, latitude,
   height}` for geographic points.
 - **Temporal** ➡ the canonical string form (for example `"2020-01-02"` for a
-  date, ISO-8601 period for a duration).
+  date, an ISO-8601 period with a fixed six-digit fractional-second field for a
+  duration, e.g. `"P1DT2H3M4.500000S"`).
+
+Object keys are serialized in alphabetical order, and the order of the `labels`
+array follows the node's internal label IDs, so it is not guaranteed.
 
 {<h4 className="custom-header"> Usage: </h4>}
 
@@ -234,5 +238,5 @@ RETURN convert.to_json(n) AS result;
 ```
 
 ```text
-{"id":"0","type":"node","labels":["Human","Person"],"properties":{"name":"Ana","age":30}}
+{"id":"0","labels":["Person","Human"],"properties":{"age":30,"name":"Ana"},"type":"node"}
 ```

--- a/pages/advanced-algorithms/available-algorithms/convert.mdx
+++ b/pages/advanced-algorithms/available-algorithms/convert.mdx
@@ -173,7 +173,8 @@ an error. A path that does not resolve, or that resolves to JSON `null`, returns
 
 ### `to_map()`
 
-Converts a value into a map.
+Returns a map unchanged, or a node or relationship as its property map. Any
+other value — such as an integer, string or list — returns `null`.
 
 <Callout type="info">
 This function is equivalent to **apoc.convert.toMap**.

--- a/pages/advanced-algorithms/available-algorithms/convert.mdx
+++ b/pages/advanced-algorithms/available-algorithms/convert.mdx
@@ -202,7 +202,7 @@ RETURN convert.to_map(n) AS result;
 
 ### `to_json()`
 
-Serializes any value into a JSON string.
+Serializes a value into a JSON string.
 
 <Callout type="info">
 This function is equivalent to **apoc.convert.toJson**.
@@ -232,6 +232,9 @@ values use a structured form:
 
 Object keys are serialized in alphabetical order, and the order of the `labels`
 array follows the node's internal label IDs, so it is not guaranteed.
+
+Null, boolean, numeric, string, list, map, node, relationship, path, point and
+temporal values are all supported. Serializing an enum value raises an error.
 
 {<h4 className="custom-header"> Usage: </h4>}
 

--- a/pages/advanced-algorithms/available-algorithms/convert.mdx
+++ b/pages/advanced-algorithms/available-algorithms/convert.mdx
@@ -54,14 +54,10 @@ Use the following query to convert a JSON string to an object:
 RETURN convert.str2object('{"name": "Alice", "age": 30, "city": "New York"}') AS result;
 ```
 
-The output shows the parsed object:
+The output shows the parsed map:
 
-```json
-{
-   "name": "Alice",
-   "age": 30,
-   "city": "New York"
-}
+```plaintext
+{name: "Alice", age: 30, city: "New York"}
 ```
 
 ### `from_json_map()`
@@ -91,8 +87,8 @@ This function is equivalent to **apoc.convert.fromJsonMap**.
 RETURN convert.from_json_map('{"name": "GDS"}') AS result;
 ```
 
-```json
-{ "name": "GDS" }
+```plaintext
+{name: "GDS"}
 ```
 
 Select a nested object with `path`:
@@ -101,8 +97,8 @@ Select a nested object with `path`:
 RETURN convert.from_json_map('{"a": 1, "b": {"c": 2, "d": [10, 20]}}', '$.b') AS result;
 ```
 
-```json
-{ "c": 2, "d": [10, 20] }
+```plaintext
+{c: 2, d: [10, 20]}
 ```
 
 To read a single value out of the parsed map, index it with Cypher instead of
@@ -143,7 +139,7 @@ This function is equivalent to **apoc.convert.fromJsonList**.
 RETURN convert.from_json_list('[1, 2, 3]') AS result;
 ```
 
-```json
+```plaintext
 [1, 2, 3]
 ```
 
@@ -153,7 +149,7 @@ Select a nested array with `path`:
 RETURN convert.from_json_list('{"a": [1, 2, 3]}', '$.a') AS result;
 ```
 
-```json
+```plaintext
 [1, 2, 3]
 ```
 
@@ -199,8 +195,8 @@ CREATE (n:Person {id: 4, name: 'z'})
 RETURN convert.to_map(n) AS result;
 ```
 
-```json
-{ "id": 4, "name": "z" }
+```plaintext
+{id: 4, name: "z"}
 ```
 
 ### `to_json()`

--- a/pages/advanced-algorithms/available-algorithms/json_util.mdx
+++ b/pages/advanced-algorithms/available-algorithms/json_util.mdx
@@ -28,15 +28,20 @@ and if it is a map, the module loads it as a single value.
 | **Implementation**  | Python     |
 | **Parallelism**     | sequential |
 
+<Callout type="info">
+The `from_json_list` and `to_json` functions are also provided by the C++
+[`convert`](/advanced-algorithms/available-algorithms/convert) module, which is
+the implementation the `apoc.convert.*` names map to. Prefer the `convert`
+versions ([`convert.from_json_list`](/advanced-algorithms/available-algorithms/convert#from_json_list),
+[`convert.to_json`](/advanced-algorithms/available-algorithms/convert#to_json)):
+`json_util` is implemented in Python and its output can differ slightly.
+</Callout>
+
 ## Functions
 
 ### `from_json_list()`
 
 Converts a JSON string representation of a list into an actual list object.
-
-<Callout type="info">
-This function is equivalent to **apoc.convert.fromJsonList**.
-</Callout>
 
 {<h4 className="custom-header"> Input: </h4>}
 
@@ -67,10 +72,6 @@ Results:
 ### `to_json()`
 
 Converts any value to its JSON string representation.
-
-<Callout type="info">
-This function is equivalent to **apoc.convert.toJson**.
-</Callout>
 
 {<h4 className="custom-header"> Input: </h4>}
 

--- a/pages/advanced-algorithms/available-algorithms/json_util.mdx
+++ b/pages/advanced-algorithms/available-algorithms/json_util.mdx
@@ -28,20 +28,17 @@ and if it is a map, the module loads it as a single value.
 | **Implementation**  | Python     |
 | **Parallelism**     | sequential |
 
-<Callout type="info">
-The `from_json_list` and `to_json` functions are also provided by the C++
-[`convert`](/advanced-algorithms/available-algorithms/convert) module, which is
-the implementation the `apoc.convert.*` names map to. Prefer the `convert`
-versions ([`convert.from_json_list`](/advanced-algorithms/available-algorithms/convert#from_json_list),
-[`convert.to_json`](/advanced-algorithms/available-algorithms/convert#to_json)):
-`json_util` is implemented in Python and its output can differ slightly.
-</Callout>
-
 ## Functions
 
 ### `from_json_list()`
 
 Converts a JSON string representation of a list into an actual list object.
+
+<Callout type="info">
+Prefer the C++ [`convert.from_json_list`](/advanced-algorithms/available-algorithms/convert#from_json_list),
+which is what `apoc.convert.fromJsonList` maps to. This Python version can
+produce slightly different output.
+</Callout>
 
 {<h4 className="custom-header"> Input: </h4>}
 
@@ -72,6 +69,12 @@ Results:
 ### `to_json()`
 
 Converts any value to its JSON string representation.
+
+<Callout type="info">
+Prefer the C++ [`convert.to_json`](/advanced-algorithms/available-algorithms/convert#to_json),
+which is what `apoc.convert.toJson` maps to. This Python version can produce
+slightly different output.
+</Callout>
 
 {<h4 className="custom-header"> Input: </h4>}
 


### PR DESCRIPTION
### Release note

Documented the `convert` module's new JSON/map conversion functions — `convert.from_json_map`, `convert.from_json_list`, `convert.to_map` and `convert.to_json` — including the optional `path` selector and its supported syntax, and the structured `to_json` output for nodes, relationships, paths, points and temporals.

### Related product PRs

PRs from product repo this doc page is related to:
memgraph/memgraph#4443

### Checklist:

- [x] Add appropriate milestone (current release cycle)
- [x] Add `bugfix` or `feature` label, based on the product PR type you're documenting
- [ ] Make sure all relevant tech details are documented
    - [x] Update reference pages (e.g. [clauses](https://memgraph.com/docs/querying/clauses), [functions](https://memgraph.com/docs/querying/functions), [flags](https://memgraph.com/docs/database-management/configuration#list-of-configuration-flags), [experimental](https://memgraph.com/docs/database-management/experimental-features), [monitoring](https://memgraph.com/docs/database-management/monitoring), [Cypher differences](https://memgraph.com/docs/querying/differences-in-cypher-implementations))
    - [ ] Search for the feature you are working on (mentions) and make updates if needed
    - [x] Provide a basic example of usage
    - [ ] In case your feature is an Enterprise one, list it under [ME page](https://memgraph.com/docs/database-management/enabling-memgraph-enterprise) and mark its page with Enterprise ([example](https://memgraph.com/docs/database-management/authentication-and-authorization/role-based-access-control)).
- [ ] Check all content with Grammarly
- [ ] Perform a self-review of my code
- [ ] The build passes locally
- [ ] My changes generate no new warnings or errors