### PR TITLE
docs: clarify minHops in path.subgraph_all/subgraph_nodes

### DIFF
--- a/pages/advanced-algorithms/available-algorithms/path.mdx
+++ b/pages/advanced-algorithms/available-algorithms/path.mdx
@@ -375,7 +375,7 @@ If subgraph is not specified, the algorithm is computed on the entire graph by d
 
  | Name 	             | Type   | Default	| Description 	                                                |
  |-	                   |-	      |-	      |-	                                                            |
- | minHops            | Int 	  | 0	      | The minimum number of hops in the traversal. Set to `0` if the start node should be included in the subgraph, or `1` otherwise. 	|
+ | minHops            | Int 	  | 0	      | The minimum number of hops from the start node for a node to be included in the result. 	|
  | maxHops            | Int   	| -1   	  | The maximum number of hops in the traversal. 	|
  | relationshipFilter  | List 	| [ ]    	| List of relationships which the subgraph formation will follow. Relationships can be filtered using the notation described below.	|
  | labelFilter         | List 	| [ ]	    | List of labels which will define filtering. Labels can be filtered using the notation described below. |
@@ -577,7 +577,7 @@ If subgraph is not specified, the algorithm is computed on the entire graph by d
 
  | Name 	             | Type   | Default	| Description 	                                                |
  |-	                   |-	      |-	      |-	                                                            |
- | minHops            | Int 	  | 0	      | The minimum number of hops in the traversal. Set to `0` if the start node should be included in the subgraph, or `1` otherwise. 	|
+ | minHops            | Int 	  | 0	      | The minimum number of hops from the start node for a node to be included in the result. 	|
  | maxHops            | Int   	| -1   	  | The maximum number of hops in the traversal. 	|
  | relationshipFilter  | List 	| [ ]    	| List of relationships which the subgraph formation will follow. Explained in detail below.	|
  | labelFilter         | List 	| [ ]	    | List of labels which will define filtering. Explained in detail below. |


### PR DESCRIPTION
### Release note

Clarify the `minHops` parameter of `path.subgraph_all` and `path.subgraph_nodes`: it is now honored as a genuine minimum-hop filter (nodes closer than `minHops` are traversed but excluded from the result), replacing the old 0/1 start-node phrasing.

### Related product PRs

PRs from product repo this doc page is related to:
memgraph/memgraph#4447

### Checklist:

- [x] Add appropriate milestone (current release cycle)
- [x] Add `bugfix` or `feature` label, based on the product PR type you're documenting
- [ ] Make sure all relevant tech details are documented
    - [x] Update reference pages (e.g. [clauses](https://memgraph.com/docs/querying/clauses), [functions](https://memgraph.com/docs/querying/functions), [flags](https://memgraph.com/docs/database-management/configuration#list-of-configuration-flags), [experimental](https://memgraph.com/docs/database-management/experimental-features), [monitoring](https://memgraph.com/docs/database-management/monitoring), [Cypher differences](https://memgraph.com/docs/querying/differences-in-cypher-implementations))
    - [x] Search for the feature you are working on (mentions) and make updates if needed
    - [ ] Provide a basic example of usage
    - [ ] In case your feature is an Enterprise one, list it under [ME page](https://memgraph.com/docs/database-management/enabling-memgraph-enterprise) and mark its page with Enterprise ([example](https://memgraph.com/docs/database-management/authentication-and-authorization/role-based-access-control)).
- [ ] Check all content with Grammarly
- [ ] Perform a self-review of my code
- [ ] The build passes locally
- [ ] My changes generate no new warnings or errors