### PR TITLE
docs: support RANGE keyword in CREATE INDEX ... FOR syntax

### DIFF
--- a/pages/querying/differences-in-cypher-implementations.mdx
+++ b/pages/querying/differences-in-cypher-implementations.mdx
@@ -41,7 +41,7 @@ CREATE RANGE INDEX FOR (n:Person) ON (n.surname);
 CREATE RANGE INDEX FOR ()-[r:KNOWS]-() ON (r.since);
 ```
 
-Neo4j's `RANGE` index is its general-purpose ordered property index, used for equality, range and prefix lookups — the same role Memgraph's label-property and edge-type property indexes already fill. `RANGE` is therefore accepted as a synonym: it maps onto the existing index with no new index type and no change in behavior. It is only valid in the `FOR ... ON` form; the native `CREATE RANGE INDEX ON :Person(surname)` syntax is not accepted.
+Neo4j's `RANGE` index is its general-purpose ordered property index, used for equality, range and prefix lookups — the same role Memgraph's label-property and edge-type property indexes already fill. `RANGE` is therefore accepted as a synonym: it maps onto the existing index with no new index type and no change in behavior.
 
 The native Memgraph syntax remains supported as well:
 

--- a/pages/querying/differences-in-cypher-implementations.mdx
+++ b/pages/querying/differences-in-cypher-implementations.mdx
@@ -34,6 +34,15 @@ CREATE INDEX FOR (n:Person) ON (n.age, n.country);
 CREATE INDEX FOR ()-[r:KNOWS]-() ON (r.since);
 ```
 
+The optional `RANGE` keyword is also accepted in the `FOR ... ON` syntax, for both nodes and relationships:
+
+```cypher
+CREATE RANGE INDEX FOR (n:Person) ON (n.surname);
+CREATE RANGE INDEX FOR ()-[r:KNOWS]-() ON (r.since);
+```
+
+Neo4j's `RANGE` index is its general-purpose ordered property index, used for equality, range and prefix lookups — the same role Memgraph's label-property and edge-type property indexes already fill. `RANGE` is therefore accepted as a synonym: it maps onto the existing index with no new index type and no change in behavior. It is only valid in the `FOR ... ON` form; the native `CREATE RANGE INDEX ON :Person(surname)` syntax is not accepted.
+
 The native Memgraph syntax remains supported as well:
 
 ```cypher


### PR DESCRIPTION
### Release note

Documented support for the `RANGE` keyword in the `CREATE INDEX ... FOR` syntax, so Neo4j DDL such as `CREATE RANGE INDEX FOR (n:Person) ON (n.id)` runs unchanged in Memgraph — `RANGE` is accepted as a synonym for the existing label-property / edge-type property index.

### Related product PRs

PRs from product repo this doc page is related to:
memgraph/memgraph#4486

### Checklist:

- [x] Add appropriate milestone (current release cycle)
- [x] Add `bugfix` or `feature` label, based on the product PR type you're documenting
- [ ] Make sure all relevant tech details are documented
    - [x] Update reference pages (e.g. [clauses](https://memgraph.com/docs/querying/clauses), [functions](https://memgraph.com/docs/querying/functions), [flags](https://memgraph.com/docs/database-management/configuration#list-of-configuration-flags), [experimental](https://memgraph.com/docs/database-management/experimental-features), [monitoring](https://memgraph.com/docs/database-management/monitoring), [Cypher differences](https://memgraph.com/docs/querying/differences-in-cypher-implementations))
    - [x] Search for the feature you are working on (mentions) and make updates if needed
    - [x] Provide a basic example of usage
    - [ ] In case your feature is an Enterprise one, list it under [ME page](https://memgraph.com/docs/database-management/enabling-memgraph-enterprise) and mark its page with Enterprise ([example](https://memgraph.com/docs/database-management/authentication-and-authorization/role-based-access-control)).
- [ ] Check all content with Grammarly
- [x] Perform a self-review of my code
- [ ] The build passes locally
- [ ] My changes generate no new warnings or errors
