### PR TITLE
docs: SHOW ROUTING TABLE query

### DIFF
--- a/pages/clustering/high-availability/ha-commands-reference.mdx
+++ b/pages/clustering/high-availability/ha-commands-reference.mdx
@@ -412,6 +412,60 @@ SHOW REPLICATION LAG;
 - Useful during manual failover to evaluate risk of data loss.
 
 
+### `SHOW ROUTING TABLE`
+
+Shows the routing table that a coordinator hands out to
+[`bolt+routing`](/clustering/high-availability/querying-the-cluster-in-high-availability)
+clients for the default database.
+
+```cypher
+SHOW ROUTING TABLE;
+```
+
+{<h4 className="custom-header"> Output includes </h4>}
+
+Each row contains a `role` and the list of Bolt `servers` serving that role:
+
+| `role`  | `servers`                                                          |
+| ------- | ------------------------------------------------------------------ |
+| `WRITE` | Bolt endpoint of the current MAIN.                                 |
+| `READ`  | Bolt endpoints of all REPLICAs, plus MAIN if [`enabled_reads_on_main`](#enabled_reads_on_main) is set to `true`. |
+| `ROUTE` | Bolt endpoints of all coordinators.                                |
+
+Example output on a cluster with three coordinators, one MAIN and two REPLICAs:
+
+```plaintext
++---------+------------------------------------------------------------------+
+| role    | servers                                                          |
++---------+------------------------------------------------------------------+
+| "WRITE" | ["localhost:7687"]                                               |
+| "READ"  | ["localhost:7688", "localhost:7689"]                             |
+| "ROUTE" | ["localhost:7690", "localhost:7691", "localhost:7692"]           |
++---------+------------------------------------------------------------------+
+```
+
+{<h4 className="custom-header"> Behavior </h4>}
+
+- The query can only be run on a coordinator. Running it on a data instance
+  fails with `Only coordinator can run SHOW ROUTING TABLE query.`
+- The query is always answered from the leader's state, so every coordinator
+  returns the same routing table. If the leader cannot be contacted, an empty
+  routing table is returned.
+- Roles with no servers are omitted. For example, if no data instance is
+  registered yet, only the `ROUTE` row is returned.
+- The routing table is reported for the default database, which is the same
+  database `bolt+routing` clients are routed to.
+
+{<h4 className="custom-header"> Implications </h4>}
+
+- Useful for verifying which instance clients will send writes to, and which
+  instances they can read from, without inspecting driver internals.
+- Because drivers cache the routing table for up to 5 minutes, the output of
+  this query can differ from what a connected client is currently using. See
+  [routing table TTL and refresh
+  behavior](/clustering/high-availability/querying-the-cluster-in-high-availability#routing-table-ttl-and-refresh-behavior).
+
+
 ## Coordinator runtime settings
 
 Coordinator runtime settings are Raft-replicated and can be changed on a live

--- a/pages/clustering/high-availability/how-high-availability-works.mdx
+++ b/pages/clustering/high-availability/how-high-availability-works.mdx
@@ -169,7 +169,7 @@ Below is a cleaned-up categorization.
 | `DemoteInstanceRpc`      | Follower requests demoting an instance.      | Sent by a follower coordinator to the leader coordinator when a user executes `DEMOTE INSTANCE` through the follower.      |
 | `UpdateConfigRpc`        | Follower requests updating config.           | Sent by a follower coordinator to the leader coordinator when a user executes `UPDATE CONFIG` through the follower.        |
 | `ForceResetRpc`          | Follower requests resetting cluster state.   | Sent by a follower coordinator to the leader coordinator when a user executes `FORCE RESET` through the follower.          |
-| `GetRoutingTableRpc`     | Follower requests a routing table.           | Sent by a follower coordinator to the leader coordinator when a user connects using `bolt+routing` through the follower.   |
+| `GetRoutingTableRpc`     | Follower requests a routing table.           | Sent by a follower coordinator to the leader coordinator when a user connects using `bolt+routing` or executes `SHOW ROUTING TABLE` through the follower. |
 | `CoordReplicationLagRpc` | Follower requests replication lag info.      | Sent by a follower coordinator to the leader coordinator when a user executes `SHOW REPLICATION LAG` through the follower. |
 
 

--- a/pages/clustering/high-availability/querying-the-cluster-in-high-availability.mdx
+++ b/pages/clustering/high-availability/querying-the-cluster-in-high-availability.mdx
@@ -75,6 +75,22 @@ This ensures:
 - **Transparency:** Clients work seamlessly whether they connect to leaders or
   followers.
 
+### Inspecting the routing table
+
+The routing table a coordinator hands out can be inspected manually with the
+[`SHOW ROUTING TABLE`](/clustering/high-availability/ha-commands-reference#show-routing-table)
+query:
+
+```cypher
+SHOW ROUTING TABLE;
+```
+
+It returns one row per role (`WRITE`, `READ`, `ROUTE`) with the Bolt endpoints
+serving that role, for the default database. The query can only be run on a
+coordinator, and it is always answered from the leader's state, so every
+coordinator returns the same result. If the leader cannot be contacted, an empty
+routing table is returned.
+
 ### Routing table TTL and refresh behavior
 
 Because routing is entirely client-side, the driver caches the routing table and

--- a/pages/database-management/authentication-and-authorization/query-privileges.mdx
+++ b/pages/database-management/authentication-and-authorization/query-privileges.mdx
@@ -195,6 +195,7 @@ Memgraph's privilege system controls access to various database operations throu
 |------------|-------------------|---------|
 | `COORDINATOR` operations | `COORDINATOR` | Various coordinator commands. |
 | `SHOW COORDINATOR SETTINGS` | `COORDINATOR` | `SHOW COORDINATOR SETTINGS` |
+| `SHOW ROUTING TABLE` | `COORDINATOR` | `SHOW ROUTING TABLE` |
 
 ## Schema information
 

--- a/pages/release-notes.mdx
+++ b/pages/release-notes.mdx
@@ -160,6 +160,11 @@ guide.
 - `CREATE RANGE INDEX FOR ... ON ...` now works for nodes and relationships and
   creates Memgraph’s usual property index.
   [#4486](https://github.com/memgraph/memgraph/pull/4486)
+- Added the `SHOW ROUTING TABLE` query, which shows the routing table a
+  coordinator hands out to `bolt+routing` clients as `WRITE`, `READ` and `ROUTE`
+  rows. It can only be run on a coordinator, is always answered from the
+  leader's state, and returns an empty table if the leader cannot be contacted.
+  [#4502](https://github.com/memgraph/memgraph/pull/4502)
 
 ### Lab v3.13.0 - September 9th, 2026
 


### PR DESCRIPTION
### Release note

Added docs for SHOW ROUTING TABLE query.

### Related product PRs

PRs from product repo this doc page is related to: 
https://github.com/memgraph/memgraph/pull/4502

### Checklist:

- [x] Add appropriate milestone (current release cycle)
- [x] Add `bugfix` or `feature` label, based on the product PR type you're documenting
- [x] Make sure all relevant tech details are documented
    - [x] Update reference pages (e.g. [clauses](https://memgraph.com/docs/querying/clauses), [functions](https://memgraph.com/docs/querying/functions), [flags](https://memgraph.com/docs/database-management/configuration#list-of-configuration-flags), [experimental](https://memgraph.com/docs/database-management/experimental-features), [monitoring](https://memgraph.com/docs/database-management/monitoring), [Cypher differences](https://memgraph.com/docs/querying/differences-in-cypher-implementations))
    - [x] Search for the feature you are working on (mentions) and make updates if needed
    - [x] Provide a basic example of usage
    - [x] In case your feature is an Enterprise one, list it under [ME page](https://memgraph.com/docs/database-management/enabling-memgraph-enterprise) and mark its page with Enterprise ([example](https://memgraph.com/docs/database-management/authentication-and-authorization/role-based-access-control)).
- [x] Check all content with Grammarly
- [x] Perform a self-review of my code
- [x] The build passes locally
- [x] My changes generate no new warnings or errors