### PR TITLE
docs: SHOW VERSION query on coordinators

### DIFF
--- a/pages/clustering/high-availability/coordinator-authentication.mdx
+++ b/pages/clustering/high-availability/coordinator-authentication.mdx
@@ -93,6 +93,7 @@ satisfies a `COORDINATOR_READ` requirement, but not the other way round.
 | `SHOW ROLES` | `COORDINATOR_READ` |
 | `SHOW PRIVILEGES FOR ROLE <role>` | `COORDINATOR_READ` |
 | `SHOW CONFIG`, `SHOW SETTING`, system info queries | `COORDINATOR_READ` |
+| [`SHOW VERSION`](/database-management/server-stats#instance-version) | `COORDINATOR_READ` |
 | `SHOW CURRENT USER`, `SHOW CURRENT ROLE` | **None** (self-service, see [below](#self-service-identity-queries)) |
 | [`REGISTER INSTANCE`](/clustering/high-availability/ha-commands-reference#register-instance) / [`UNREGISTER INSTANCE`](/clustering/high-availability/ha-commands-reference#unregister-instance) | `COORDINATOR_WRITE` |
 | [`SET INSTANCE ... TO MAIN`](/clustering/high-availability/ha-commands-reference#set-instance--to-main) / [`DEMOTE INSTANCE`](/clustering/high-availability/ha-commands-reference#demote-instance) | `COORDINATOR_WRITE` |

--- a/pages/clustering/high-availability/how-high-availability-works.mdx
+++ b/pages/clustering/high-availability/how-high-availability-works.mdx
@@ -116,9 +116,9 @@ The COORDINATOR instance is a **very restricted instance**, and it will
 not respond to any queries that are not related to management of the cluster.
 That means, you cannot run any data queries on the coordinator directly (we
 will talk more about routing data queries in the next sections). However,
-system information queries such as `SHOW CONFIG`, `SHOW LICENSE INFO`,
-`SHOW BUILD INFO` and `SHOW STORAGE INFO` are supported on coordinators, as
-well as `SET DATABASE SETTING`, `RELOAD BOLT_SERVER TLS` and
+system information queries such as `SHOW CONFIG`, `SHOW VERSION`,
+`SHOW LICENSE INFO`, `SHOW BUILD INFO` and `SHOW STORAGE INFO` are supported on
+coordinators, as well as `SET DATABASE SETTING`, `RELOAD BOLT_SERVER TLS` and
 `RELOAD INTRA_CLUSTER TLS`.
 </Callout>
 

--- a/pages/database-management/authentication-and-authorization/query-privileges.mdx
+++ b/pages/database-management/authentication-and-authorization/query-privileges.mdx
@@ -143,7 +143,7 @@ Memgraph's privilege system controls access to various database operations throu
 | `SHOW SNAPSHOTS` | `DURABILITY` | `SHOW SNAPSHOTS` |
 | `SHOW NEXT SNAPSHOT` | `DURABILITY` | `SHOW NEXT SNAPSHOT` |
 | `SET SETTING` | `CONFIG` | `SET SETTING ...` |
-| `SHOW VERSION` | `STATS` | `SHOW VERSION` |
+| `SHOW VERSION` | `STATS` | `SHOW VERSION` — on coordinators it requires `COORDINATOR_READ` instead, see [Coordinator operations](#coordinator-operations). |
 | `SHOW TRANSACTIONS` | `TRANSACTION_MANAGEMENT` | `SHOW TRANSACTIONS` |
 | `TERMINATE TRANSACTIONS` | `TRANSACTION_MANAGEMENT` | `TERMINATE TRANSACTIONS 'transaction_id'` |
 | `RELOAD BOLT_SERVER TLS` | `RELOAD_TLS` | `RELOAD BOLT_SERVER TLS` |
@@ -210,6 +210,7 @@ coordinator with basic auth carries both implicitly.
 | `SHOW REPLICATION LAG` | `COORDINATOR_READ` | `SHOW REPLICATION LAG` |
 | `SHOW ROLES` / `SHOW PRIVILEGES FOR ROLE` | `COORDINATOR_READ` | `SHOW PRIVILEGES FOR ROLE dba` |
 | `SHOW CONFIG`, `SHOW SETTING`, system info queries | `COORDINATOR_READ` | `SHOW CONFIG` |
+| `SHOW VERSION` | `COORDINATOR_READ` | `SHOW VERSION` |
 | `SHOW CURRENT USER` / `SHOW CURRENT ROLE` | **None** | Self-service identity queries. |
 | Cluster management operations | `COORDINATOR_WRITE` | `REGISTER INSTANCE`, `SET INSTANCE ... TO MAIN`, `ADD COORDINATOR`, `YIELD LEADERSHIP`, `FORCE RESET CLUSTER STATE`, … |
 | `SET COORDINATOR SETTING` / `SET SETTING` | `COORDINATOR_WRITE` | `SET COORDINATOR SETTING 'sync_failover_only' TO 'true'` |

--- a/pages/database-management/server-stats.mdx
+++ b/pages/database-management/server-stats.mdx
@@ -18,6 +18,13 @@ To get the version of the instance being queried, run the following query:
 SHOW VERSION;
 ```
 
+The query can be run on data instances and on
+[coordinators](/clustering/high-availability), so you can check the version of
+every instance in a high-availability cluster without connecting through the
+MAIN. On data instances it requires the `STATS` privilege; on coordinators it is
+a read-only query that requires
+[`COORDINATOR_READ`](/clustering/high-availability/coordinator-authentication#which-privilege-each-query-requires).
+
 ## Storage information
 
 `SHOW STORAGE INFO` comes in two flavors:

--- a/pages/release-notes.mdx
+++ b/pages/release-notes.mdx
@@ -198,6 +198,12 @@ guide.
   coordinator restart is needed to roll SSO out, and it reopens if the license
   becomes invalid so a coordinator can never lock every session out.
   [#4399](https://github.com/memgraph/memgraph/pull/4399)
+- `SHOW VERSION` can now be run on coordinators, alongside the other read-only
+  introspection queries such as `SHOW CONFIG` and `SHOW BUILD INFO`. It
+  previously failed with `Coordinator can run only coordinator queries!`. On
+  coordinators it is a `COORDINATOR_READ` query, so an SSO role with only
+  `COORDINATOR_READ` granted can run it.
+  [#4535](https://github.com/memgraph/memgraph/pull/4535)
 
 ### Lab v3.13.0 - September 9th, 2026
 


### PR DESCRIPTION
### Release note

Documented SHOW VERSION query which can now be run on coordinators as well

### Related product PRs

PRs from product repo this doc page is related to: 
https://github.com/memgraph/memgraph/pull/4535

### Checklist:

- [x] Add appropriate milestone (current release cycle)
- [x] Add `bugfix` or `feature` label, based on the product PR type you're documenting
- [x] Make sure all relevant tech details are documented
    - [x] Update reference pages (e.g. [clauses](https://memgraph.com/docs/querying/clauses), [functions](https://memgraph.com/docs/querying/functions), [flags](https://memgraph.com/docs/database-management/configuration#list-of-configuration-flags), [experimental](https://memgraph.com/docs/database-management/experimental-features), [monitoring](https://memgraph.com/docs/database-management/monitoring), [Cypher differences](https://memgraph.com/docs/querying/differences-in-cypher-implementations))
    - [x] Search for the feature you are working on (mentions) and make updates if needed
    - [x] Provide a basic example of usage
    - [x] In case your feature is an Enterprise one, list it under [ME page](https://memgraph.com/docs/database-management/enabling-memgraph-enterprise) and mark its page with Enterprise ([example](https://memgraph.com/docs/database-management/authentication-and-authorization/role-based-access-control)).
- [x] Check all content with Grammarly
- [x] Perform a self-review of my code
- [x] The build passes locally
- [x] My changes generate no new warnings or errors