### PR TITLE
docs: RBAC for text and vector search

### DIFF
--- a/pages/querying/text-search.mdx
+++ b/pages/querying/text-search.mdx
@@ -616,6 +616,71 @@ Result:
 +-------------------------------+
 ```
 
+## Access control <sup style={{ fontSize: '0.6em', color: '#888' }}>Enterprise</sup>
+
+When [fine-grained access control](/database-management/authentication-and-authorization/role-based-access-control#fine-grained-access-control)
+is active for the user running the query, text search respects their read
+permissions: a match is returned only if the user could read it with a normal
+query. Content the user is not allowed to read is never revealed through the
+search results or their relevance scores.
+
+A node or relationship appears in the results only when **both** of these hold:
+
+- **The node or relationship is readable.** The user has `READ` on its
+  [labels](/database-management/authentication-and-authorization/role-based-access-control#label-based-access-control)
+  — or, for a relationship, on its
+  [type](/database-management/authentication-and-authorization/role-based-access-control#relationship-permissions)
+  and on both of its endpoint nodes. Permissions are evaluated against the
+  entity's *actual* labels, so a `DENY` on any of them removes it from the
+  results.
+- **The matched property is readable.** Which properties must be readable
+  depends on the procedure:
+  - `text_search.search` and `text_search.search_edges` search a property named
+    in the query (for example `data.name:Alice`), so only that
+    [property](/database-management/authentication-and-authorization/role-based-access-control#property-based-access-control)
+    must be readable. The match surfaces even if the entity has other properties
+    the user cannot read.
+  - `text_search.search_all`, `text_search.regex_search` and their `_edges`
+    variants search across every indexed property, so **all** indexed text
+    properties the entity has must be readable — if even one is denied, the
+    entity is dropped, because the match could have come from it.
+
+A hit whose match depends on a property the user cannot read is **silently
+dropped**: the results are simply empty, just as a
+[denied property](/database-management/authentication-and-authorization/role-based-access-control#how-denied-properties-behave)
+reads back as `Null` in a normal query. No error is raised.
+
+For example, with a text index on `:Employee` and an analyst who can read
+employees and their properties, except `ssn`:
+
+```cypher
+GRANT READ ON NODES CONTAINING LABELS :Employee TO analyst;
+GRANT READ {*} ON NODES CONTAINING LABELS :Employee TO analyst;
+DENY READ {ssn} ON NODES CONTAINING LABELS :Employee TO analyst;
+```
+
+- `CALL text_search.search('employees', 'data.name:Alice')` returns matching
+  employees — `name` is readable.
+- `CALL text_search.search('employees', 'data.ssn:123456789')` returns nothing —
+  the queried property is denied.
+- `CALL text_search.search_all('employees', 'Alice')` returns nothing for an
+  employee whose indexed `ssn` is set, because the match could have come from the
+  denied property.
+
+<Callout type="warning">
+`text_search.aggregate` and `text_search.aggregate_edges` run inside the search
+engine and cannot filter individual results, so they cannot apply per-row
+permissions. When the caller has a fine-grained restriction on the index's
+properties, the aggregation returns an error message instead of a result — use
+the search procedures above when you need permission-aware results.
+</Callout>
+
+<Callout type="info">
+These checks apply only when fine-grained access control is active for the user.
+An unrestricted user (for example an administrator) and Memgraph Community
+edition see all matches.
+</Callout>
+
 ## Drop text index
 
 Text indices are dropped with the `DROP TEXT INDEX` command. You need to give the name of the index to be deleted.

--- a/pages/querying/vector-search.mdx
+++ b/pages/querying/vector-search.mdx
@@ -307,6 +307,52 @@ Alternative options, such as `f16` for lower memory usage, allow you to fine-tun
 | `i16`     | 16-bit signed integer.                                     |
 | `i8`      | 8-bit signed integer.                                      |
 
+## Access control <sup style={{ fontSize: '0.6em', color: '#888' }}>Enterprise</sup>
+
+When [fine-grained access control](/database-management/authentication-and-authorization/role-based-access-control#fine-grained-access-control)
+is active for the user running the query, vector search respects their read
+permissions: `vector_search.search` and `vector_search.search_edges` return a
+node or relationship only if the user could read it with a normal query.
+
+A result is included only when **both** of these hold:
+
+- **The node or relationship is readable.** The user has `READ` on its
+  [labels](/database-management/authentication-and-authorization/role-based-access-control#label-based-access-control)
+  — or, for a relationship, on its
+  [type](/database-management/authentication-and-authorization/role-based-access-control#relationship-permissions)
+  and on both endpoint nodes. Permissions are evaluated against the entity's
+  *actual* labels, so a `DENY` on any of them removes it.
+- **The indexed property is readable.** The user must be able to read the
+  [property](/database-management/authentication-and-authorization/role-based-access-control#property-based-access-control)
+  the index is built on (the embedding). If it is denied, the result is dropped —
+  otherwise the match and its similarity score would reveal the vector.
+
+Results the user is not allowed to see are **silently dropped** (no error is
+raised), so a search may return fewer than the requested number of results. For
+an index that spans several labels or edge types — including a
+[wildcard index](/querying/vector-search#index-on-multiple-labels-or-edge-types) —
+this check runs per result, so one index returns only the entities the user is
+permitted to read.
+
+For example, with a wildcard vector index `docs` on `(embedding)` and a reader
+who may see public documents but not confidential ones:
+
+```cypher
+GRANT READ ON NODES CONTAINING LABELS :Public TO reader;
+DENY READ ON NODES CONTAINING LABELS :Confidential TO reader;
+GRANT READ {*} ON NODES CONTAINING LABELS * TO reader;
+```
+
+`CALL vector_search.search('docs', 5, [0.1, 0.2])` returns only the `:Public`
+documents among the nearest neighbours; `:Confidential` ones are dropped even if
+they are closer.
+
+<Callout type="info">
+These checks apply only when fine-grained access control is active for the user.
+An unrestricted user (for example an administrator) and Memgraph Community
+edition see all matches.
+</Callout>
+
 ## Monitor vector index memory
 
 Memgraph tracks vector index memory separately from the rest of the graph data. You can inspect both from `SHOW STORAGE INFO`:


### PR DESCRIPTION
### Release note

Document how fine-grained access control (RBAC) applies to text search and vector search. Results are now filtered per node/relationship: an entity is returned only if the caller can read it (its labels or edge type, and both endpoints for relationships) and the property the match came from (the queried property for `search`, every indexed property for `search_all`/`regex_search`, the embedding for vector search). Denied hits are silently dropped, and `text_search.aggregate` returns an error under fine-grained restrictions.

### Related product PRs

PRs from product repo this doc page is related to: 
https://github.com/memgraph/memgraph/pull/4316

### Checklist:

- [ ] Add appropriate milestone (current release cycle)
- [ ] Add `bugfix` or `feature` label, based on the product PR type you're documenting
- [x] Make sure all relevant tech details are documented
    - [x] Update reference pages (e.g. [clauses](https://memgraph.com/docs/querying/clauses), [functions](https://memgraph.com/docs/querying/functions), [flags](https://memgraph.com/docs/database-management/configuration#list-of-configuration-flags), [experimental](https://memgraph.com/docs/database-management/experimental-features), [monitoring](https://memgraph.com/docs/database-management/monitoring), [Cypher differences](https://memgraph.com/docs/querying/differences-in-cypher-implementations))
    - [x] Search for the feature you are working on (mentions) and make updates if needed
    - [x] Provide a basic example of usage
    - [ ] In case your feature is an Enterprise one, list it under [ME page](https://memgraph.com/docs/database-management/enabling-memgraph-enterprise) and mark its page with Enterprise ([example](https://memgraph.com/docs/database-management/authentication-and-authorization/role-based-access-control))
- [ ] Check all content with Grammarly
- [x] Perform a self-review of my code
- [ ] The build passes locally
- [ ] My changes generate no new warnings or errors
