### PR TITLE
docs(path): document slice bound clamping and null path arguments

### DIFF
--- a/pages/advanced-algorithms/available-algorithms/path.mdx
+++ b/pages/advanced-algorithms/available-algorithms/path.mdx
@@ -44,7 +44,7 @@ node-relationship-node order.
 
 {<h4 className="custom-header"> Input: </h4>}
 
-- `path: Path` ➡ The given path.
+- `path: Path` ➡ The given path. If `null`, the function returns `null`.
 
 {<h4 className="custom-header"> Output: </h4>}
 
@@ -78,8 +78,10 @@ paths can't be combined.
 
 {<h4 className="custom-header"> Input: </h4>}
 
-- `first: Path` ➡ The first path.
-- `second: Path` ➡ The second path.
+- `first: Path` ➡ The first path. If `null`, the function returns the second path.
+- `second: Path` ➡ The second path. If `null`, the function returns the first path.
+
+If both paths are `null`, the function returns `null`.
 
 {<h4 className="custom-header"> Output: </h4>}
 
@@ -114,13 +116,25 @@ The function returns a subpath of the given path.
 
 {<h4 className="custom-header"> Input: </h4>}
 
-- `path: Path` ➡ The given path.
-- `offset: int = 0` ➡ The first node index from the given path to be included in the subpath.
-- `length: int = -1` ➡ Length of the subpath. If set to -1 the subpath will end on the final node of the given path.
+- `path: Path` ➡ The given path. If `null`, the function returns `null`.
+- `offset: int = 0` ➡ The first node index from the given path to be included in
+  the subpath. A negative offset is read as `0`, and an offset past the end of
+  the given path starts the subpath at its final node.
+- `length: int = -1` ➡ Length of the subpath. If set to -1 the subpath will end
+  on the final node of the given path. A length reaching past the end of the
+  given path ends the subpath on its final node, and any other negative length
+  returns a subpath with no relationships.
 
 {<h4 className="custom-header"> Output: </h4>}
 
 - `Path` ➡ The subpath of the given path.
+
+<Callout type="info">
+An offset or length outside the given path is adjusted to the nearest subpath
+rather than raising an error, so bounds computed from an expression such as
+`length(path)` can be passed without guarding them first. The shortest subpath
+the function returns is a single node.
+</Callout>
 
 {<h4 className="custom-header"> Usage: </h4>}
 
@@ -141,6 +155,27 @@ The result is returned in shortened form with () signifying nodes and [] signify
 +------------------------------------------------------------------------------------------------------+
 | (:Node2)-[:CONNECTED]->(:Node3)-[:CONNECTED]->(:Node4)-[:CONNECTED]->(:Node5)                        |
 +------------------------------------------------------------------------------------------------------+
+```
+
+Use the following query to see how bounds outside the given path are adjusted:
+
+```cypher
+MATCH path = (:Node1)-[:CONNECTED*4]->(:Node5)
+RETURN path.slice(path, -5, 2) AS negative_offset,
+       path.slice(path, 10, -1) AS offset_past_end,
+       path.slice(path, 1, -3) AS negative_length;
+```
+
+The negative offset starts the subpath at the first node, the offset past the
+end returns the final node on its own, and the negative length returns a
+subpath with no relationships:
+
+```plaintext
++--------------------------------------------------------+--------------------------------------------------------+--------------------------------------------------------+
+| negative_offset                                        | offset_past_end                                        | negative_length                                        |
++--------------------------------------------------------+--------------------------------------------------------+--------------------------------------------------------+
+| (:Node1)-[:CONNECTED]->(:Node2)-[:CONNECTED]->(:Node3) | (:Node5)                                               | (:Node2)                                               |
++--------------------------------------------------------+--------------------------------------------------------+--------------------------------------------------------+
 ```
 
 ## Procedures

--- a/pages/advanced-algorithms/available-algorithms/path.mdx
+++ b/pages/advanced-algorithms/available-algorithms/path.mdx
@@ -44,7 +44,7 @@ node-relationship-node order.
 
 {<h4 className="custom-header"> Input: </h4>}
 
-- `path: Path` ➡ The given path. If `null`, the function returns `null`.
+- `path: Path` ➡ The given path.
 
 {<h4 className="custom-header"> Output: </h4>}
 
@@ -116,7 +116,7 @@ The function returns a subpath of the given path.
 
 {<h4 className="custom-header"> Input: </h4>}
 
-- `path: Path` ➡ The given path. If `null`, the function returns `null`.
+- `path: Path` ➡ The given path.
 - `offset: int = 0` ➡ The first node index from the given path to be included in
   the subpath. A negative offset is read as `0`, and an offset past the end of
   the given path starts the subpath at its final node.


### PR DESCRIPTION
### Related product PRs

PRs from product repo this doc page is related to:
memgraph/memgraph#4552

### Checklist:

- [x] Add appropriate milestone (current release cycle)
- [x] Add `bugfix` or `feature` label, based on the product PR type you're documenting
- [x] Make sure all relevant tech details are documented
    - [x] Update reference pages (e.g. [clauses](https://memgraph.com/docs/querying/clauses), [functions](https://memgraph.com/docs/querying/functions), [flags](https://memgraph.com/docs/database-management/configuration#list-of-configuration-flags), [experimental](https://memgraph.com/docs/database-management/experimental-features), [monitoring](https://memgraph.com/docs/database-management/monitoring), [Cypher differences](https://memgraph.com/docs/querying/differences-in-cypher-implementations))
    - [x] Search for the feature you are working on (mentions) and make updates if needed
    - [x] Provide a basic example of usage
    - [ ] In case your feature is an Enterprise one, list it under [ME page](https://memgraph.com/docs/database-management/enabling-memgraph-enterprise) and mark its page with Enterprise ([example](https://memgraph.com/docs/database-management/authentication-and-authorization/role-based-access-control)).
- [ ] Check all content with Grammarly
- [x] Perform a self-review of my code
- [ ] The build passes locally
- [x] My changes generate no new warnings or errors

Example outputs in the new section were taken from a running Memgraph with the fix applied.

