### PR TITLE
docs: HA analytical mode bulk import

### DIFF
--- a/pages/clustering/high-availability.mdx
+++ b/pages/clustering/high-availability.mdx
@@ -49,6 +49,11 @@ recommended configuration patterns.
 Recommended practices for running a robust, reliable, and well-observed HA
 deployment.
 
+### [Bulk import in analytical mode](/clustering/high-availability/analytical-import)
+
+Import data into a cluster using the in-memory analytical storage mode, then
+switch back to transactional mode and register the replicas again.
+
 ### [HA commands reference guide](/clustering/high-availability/ha-commands-reference)
 
 A complete reference of all commands for managing coordinators, registering

--- a/pages/clustering/high-availability/_meta.ts
+++ b/pages/clustering/high-availability/_meta.ts
@@ -5,6 +5,7 @@ export default {
     "setup-ha-cluster-docker-compose": "Set up HA cluster with Docker Compose",
     "setup-ha-cluster-k8s": "Set up HA cluster with K8s",
     "best-practices": "Best practices",
+    "analytical-import": "Bulk import in analytical mode",
     "ha-commands-reference": "Reference commands",
     "ha-reference-architectures": "Reference architectures",
     "migrating-to-v3-9-ha": "Migrating to v3.9 HA",

--- a/pages/clustering/high-availability/analytical-import.mdx
+++ b/pages/clustering/high-availability/analytical-import.mdx
@@ -1,0 +1,222 @@
+---
+title: Bulk import in analytical mode
+description: Import data into a high availability cluster using the in-memory analytical storage mode, then switch back to transactional and register the replicas again.
+---
+
+import { Callout } from 'nextra/components'
+import { Steps } from 'nextra/components'
+import {CommunityLinks} from '/components/social-card/CommunityLinks'
+
+# Bulk import in analytical mode <sup style={{ fontSize: '0.6em', color: '#888' }}>Enterprise</sup>
+
+The [in-memory analytical storage
+mode](/fundamentals/storage-memory-usage#in-memory-analytical-storage-mode)
+imports data up to 6 times faster and with significantly lower memory usage than
+the transactional mode, because it does not create `Delta` objects. As of
+Memgraph v3.13, a data instance in a high availability cluster can use that mode
+for a bulk import: switch to `IN_MEMORY_ANALYTICAL`, import, switch back to
+`IN_MEMORY_TRANSACTIONAL` and register the replicas again.
+
+Analytical writes are **never written to the WAL**, so they cannot be
+replicated. The whole workflow is therefore built around a single rule: while
+any database on the instance is analytical, the instance must have no replicas
+attached to it.
+
+<Callout type="info">
+
+Before continuing, read the guides on [how high availability
+works](/clustering/high-availability/how-high-availability-works) and on
+[storage modes](/fundamentals/storage-memory-usage#storage-modes).
+
+</Callout>
+
+## Requirements
+
+A data instance can enter the analytical storage mode only when:
+
+- it holds the **MAIN** role — a REPLICA receives replicated writes, which
+  analytical mode cannot apply, and
+- it has **zero registered replicas**.
+
+Both conditions are instance-wide and all-or-nothing:
+
+- entering analytical mode on **any** database requires that no replica is
+  registered at all, and
+- while **any** database is in analytical mode, registering and unregistering
+  replicas is rejected.
+
+Because [`UNREGISTER
+INSTANCE`](/clustering/high-availability/ha-commands-reference#unregister-instance)
+refuses to remove the current MAIN, the instance you import into is the one data
+instance that stays in the cluster.
+
+<Callout type="warning">
+
+While the import runs, the cluster consists of a single data instance and has
+**no redundancy**: there is no replica to fail over to. Plan the import for a
+maintenance window and keep it as short as possible.
+
+</Callout>
+
+Starting a data instance with
+[`--storage-mode=IN_MEMORY_ANALYTICAL`](/database-management/configuration)
+remains forbidden. An instance started in analytical mode can never produce WAL
+files, not even after switching to transactional mode, which would permanently
+break replication. Analytical mode is reachable only through the runtime
+`STORAGE MODE` query from a transactional start.
+
+## Import workflow
+
+<Steps>
+
+### Unregister every replica
+
+On the **coordinator**, remove all data instances except the MAIN:
+
+```cypher
+UNREGISTER INSTANCE instance_2;
+```
+
+The unregistered instance keeps running and keeps its data — unregistering
+removes it from the cluster, it does not wipe it. You do **not** need to clear
+its data directory before registering it back.
+
+### Switch the MAIN to analytical mode
+
+On the **MAIN data instance**:
+
+```cypher
+STORAGE MODE IN_MEMORY_ANALYTICAL;
+```
+
+If a replica is still registered, the query fails and the storage mode is
+unchanged.
+
+### Import the data
+
+Run the import as usual, for example with [`LOAD
+CSV`](/data-migration/csv) or plain Cypher:
+
+```cypher
+LOAD CSV FROM "/import/nodes.csv" WITH HEADER AS row
+CREATE (:Node {id: row.id});
+```
+
+### Switch back to transactional mode
+
+```cypher
+STORAGE MODE IN_MEMORY_TRANSACTIONAL;
+```
+
+This writes a snapshot of the imported data synchronously, before the mode
+change completes. Do **not** run `CREATE SNAPSHOT` while still in analytical
+mode — see [Durability of the switch back](#durability-of-the-switch-back).
+
+### Register the replicas back
+
+On the **coordinator**:
+
+```cypher
+REGISTER INSTANCE instance_2 WITH CONFIG {
+  "bolt_server": "localhost:7688",
+  "management_server": "localhost:10012",
+  "replication_server": "localhost:10002"
+};
+```
+
+The replica recovers from the snapshot written in the previous step and ends up
+with exactly the data the MAIN holds. Verify with `SHOW INSTANCES` on the
+coordinator and by counting nodes on the replica's own Bolt endpoint.
+
+</Steps>
+
+## Durability of the switch back
+
+The `IN_MEMORY_ANALYTICAL` → `IN_MEMORY_TRANSACTIONAL` switch is the point at
+which the imported data becomes durable, so it does more than flip a flag:
+
+- **It writes a snapshot** stamped with a timestamp that covers the import, and
+  publishes that timestamp as the instance's last durable timestamp. This is
+  what a re-registered replica recovers from.
+- **If the snapshot cannot be written, the switch is aborted** and the query
+  throws. The database stays in analytical mode with its data and all durability
+  files untouched, so you can fix the cause (most often disk space) and retry.
+- **Superseded snapshots and WAL files are archived**. The switch-back snapshot
+  is a new durability base rather than an increment on the old one, so older
+  snapshots and all WAL files are moved to the `.old` directory — or deleted
+  when [`--storage-backup-dir-enabled`](/database-management/configuration) is
+  set to `false` — and WAL sequence numbering restarts from 0.
+- **The WAL is finalized when analytical mode is entered**, which is what lets
+  replica recovery detect that the imported data exists in no WAL file and must
+  be shipped as a snapshot.
+
+<Callout type="warning">
+
+Do not run `CREATE SNAPSHOT` between the import and the switch back. A snapshot
+taken while the instance is in analytical mode carries the **pre-import**
+durable timestamp, because analytical writes never advance it. It is redundant
+at best — the switch back writes a correctly stamped snapshot on its own.
+
+</Callout>
+
+## Re-registering a replica that holds old data
+
+A replica that was unregistered before the import keeps whatever it had at that
+moment, and it may be strictly behind the MAIN. When you register it back,
+Memgraph compares the newest snapshot's timestamp against the ranges of the WAL
+files. The analytical episode leaves a gap that no WAL covers, so recovery
+detects that the WAL chain cannot reproduce the imported data and sends the
+snapshot instead of the WAL files.
+
+The consequences for you as an operator:
+
+- There is **no need to wipe the replica's data directory** before registering
+  it back.
+- The detection is derived from the durability files, not from in-memory state,
+  so it also works if the MAIN is **restarted** between the import and the
+  re-registration.
+
+## Cluster changes while the MAIN is still analytical
+
+`REGISTER INSTANCE` and `UNREGISTER INSTANCE` are committed to the Raft log
+first and only then applied on the MAIN over RPC, so both queries still report
+success while the MAIN is analytical, even though the MAIN rejects the RPC and
+logs the reason:
+
+- **`REGISTER INSTANCE`** — the instance is part of the cluster state, but no
+  replication client is created for it, so it receives nothing.
+- **`UNREGISTER INSTANCE`** — the instance is removed from the cluster state,
+  but the MAIN keeps its replication client.
+
+In both cases the [reconciliation
+loop](/clustering/high-availability/how-high-availability-works#how-the-reconciliation-loop-works)
+resolves the difference on its own once every database is back in transactional
+mode. Still, a query reported as successful does not mean the replica is
+attached or detached yet: change the cluster composition only while the cluster
+is in transactional mode, and confirm the state with `SHOW INSTANCES` on the
+coordinator.
+
+## Errors
+
+| Query | Error | Cause |
+|-------|-------|-------|
+| `STORAGE MODE IN_MEMORY_ANALYTICAL` | `Only the MAIN data instance can use analytical mode.` | The instance holds the REPLICA role. |
+| `STORAGE MODE IN_MEMORY_ANALYTICAL` | `Cannot switch to analytical mode while replicas are registered (...)` | At least one replica is registered. The message lists the names. |
+| `STORAGE MODE IN_MEMORY_TRANSACTIONAL` | `Failed to create the snapshot required to leave IN_MEMORY_ANALYTICAL.` | The switch-back snapshot could not be written. The database stays analytical and unchanged. |
+| `REGISTER REPLICA` | `Couldn't register replica ... because a database is in analytical storage mode.` | Some database on the instance is analytical. |
+| `DROP REPLICA` | `Couldn't unregister replica ... because a database is in analytical storage mode.` | Some database on the instance is analytical. |
+
+The same gates apply to the RPCs the coordinator sends behind `REGISTER
+INSTANCE` and `UNREGISTER INSTANCE`; there the rejection is visible in the data
+instance's log rather than in the query result.
+
+## Plain replication clusters
+
+The gates are not specific to high availability. In a [replication
+cluster](/clustering/replication) without coordinators, a MAIN with registered
+replicas is likewise refused the switch to analytical mode, and `REGISTER
+REPLICA` / `DROP REPLICA` are refused while any database is analytical. Use the
+same workflow with `DROP REPLICA` and `REGISTER REPLICA` in place of the
+coordinator queries.
+
+<CommunityLinks/>

--- a/pages/clustering/high-availability/best-practices.mdx
+++ b/pages/clustering/high-availability/best-practices.mdx
@@ -189,6 +189,20 @@ the command line argument.
 </Callout>
 
 
+## Storage mode
+
+Data instances run in the `IN_MEMORY_TRANSACTIONAL` storage mode. Analytical
+writes are not written to the WAL and therefore cannot be replicated, so a data
+instance can enter `IN_MEMORY_ANALYTICAL` only when it holds the MAIN role and
+has no registered replicas, and replicas can be registered or unregistered only
+while every database is transactional.
+
+For a fast bulk import, unregister the replicas, switch the MAIN to analytical
+mode, import, switch back to transactional mode and register the replicas again.
+The full recipe, together with the durability guarantees of the switch back, is
+in [Bulk import in analytical
+mode](/clustering/high-availability/analytical-import).
+
 ## Observability
 
 Monitoring cluster health is essential. Key metrics include:

--- a/pages/clustering/high-availability/ha-commands-reference.mdx
+++ b/pages/clustering/high-availability/ha-commands-reference.mdx
@@ -175,6 +175,13 @@ REGISTER INSTANCE instanceName ( AS ASYNC | AS STRICT_SYNC ) ? WITH CONFIG {
 - In Kubernetes, use service DNS names (e.g.
   `memgraph-data-1.default.svc.cluster.local`).
 - Local development uses `localhost`.
+- Register instances only while every database on the MAIN is in the
+  `IN_MEMORY_TRANSACTIONAL` storage mode. If the MAIN is in analytical mode, the
+  query still returns success (the Raft commit is the success criterion) but the
+  replica is not attached until the MAIN switches back, at which point the
+  reconciliation loop attaches it. The data instance logs the reason for the
+  rejection. See [Bulk import in analytical
+  mode](/clustering/high-availability/analytical-import).
 
 {<h4 className="custom-header">Example </h4>}
 
@@ -205,6 +212,16 @@ UNREGISTER INSTANCE instanceName;
   the replica from MAIN fails, the [reconciliation
   loop](/clustering/high-availability/how-high-availability-works#how-the-reconciliation-loop-works)
   automatically retries the operation.
+- The unregistered instance keeps running and keeps all of its data. It is
+  removed from the cluster, not wiped, so you do not need to clear its data
+  directory before registering it back.
+- The MAIN refuses the unregister RPC while any of its databases is in the
+  `IN_MEMORY_ANALYTICAL` storage mode, and logs the reason. The instance is
+  still removed from the Raft state, but the MAIN keeps its replication client
+  until the reconciliation loop retries once every database is transactional
+  again. Unregister instances only while the cluster is in transactional mode —
+  see [Bulk import in analytical
+  mode](/clustering/high-availability/analytical-import).
 
 {<h4 className="custom-header"> Example </h4>}
 

--- a/pages/clustering/high-availability/how-high-availability-works.mdx
+++ b/pages/clustering/high-availability/how-high-availability-works.mdx
@@ -510,7 +510,7 @@ it undergoes a controlled recovery process:
   is reused on subsequent recoveries, meaning **only one backup copy is kept at
   a time**.
 
-Use the `--storage-enable-backup-dir` flag to control this behavior:
+Use the `--storage-backup-dir-enabled` flag to control this behavior:
 - `true` (default) - Old durability files are moved to `.old` directories
 - `false` - Old durability files are deleted immediately
 

--- a/pages/clustering/replication/best-practices.mdx
+++ b/pages/clustering/replication/best-practices.mdx
@@ -65,17 +65,6 @@ If you want to import data using **in-memory analytical mode**, you must:
 4. Switch the MAIN back to **in-memory transactional mode**  
 5. `REGISTER REPLICA` the replicas again  
 
-<Callout type="warning">
-
-**Breaking change in Memgraph v3.13**: a MAIN with registered replicas is now
-refused the switch to `IN_MEMORY_ANALYTICAL`, and `REGISTER REPLICA` /
-`DROP REPLICA` are refused while any database on the instance is in analytical
-mode. Previously the switch was allowed and silently produced replicas that
-missed the whole analytical episode. Unregister the replicas first, as described
-above.
-
-</Callout>
-
 Step 4 writes a snapshot of the imported data and archives the superseded
 durability files, so there is no need to run `CREATE SNAPSHOT` manually — and no
 need to wipe a replica's data directory before registering it back, because

--- a/pages/clustering/replication/best-practices.mdx
+++ b/pages/clustering/replication/best-practices.mdx
@@ -53,12 +53,36 @@ Invalid:
 
 Replication works **only** in the [in-memory transactional storage
 mode](/fundamentals/storage-memory-usage#in-memory-transactional-storage-mode-default).
+Writes performed in the [in-memory analytical storage
+mode](/fundamentals/storage-memory-usage#in-memory-analytical-storage-mode)
+never reach the WAL, so they cannot be replicated.
 
-If you imported data using **in-memory analytical mode**, you must:
+If you want to import data using **in-memory analytical mode**, you must:
 
-1. Import the data  
-2. Switch the instance to **in-memory transactional mode**  
-3. Then configure replication  
+1. `DROP REPLICA` every registered replica  
+2. Switch the MAIN to **in-memory analytical mode**  
+3. Import the data  
+4. Switch the MAIN back to **in-memory transactional mode**  
+5. `REGISTER REPLICA` the replicas again  
+
+<Callout type="warning">
+
+**Breaking change in Memgraph v3.13**: a MAIN with registered replicas is now
+refused the switch to `IN_MEMORY_ANALYTICAL`, and `REGISTER REPLICA` /
+`DROP REPLICA` are refused while any database on the instance is in analytical
+mode. Previously the switch was allowed and silently produced replicas that
+missed the whole analytical episode. Unregister the replicas first, as described
+above.
+
+</Callout>
+
+Step 4 writes a snapshot of the imported data and archives the superseded
+durability files, so there is no need to run `CREATE SNAPSHOT` manually — and no
+need to wipe a replica's data directory before registering it back, because
+recovery detects that the imported data exists in no WAL file and ships the
+snapshot instead. The same workflow for a high availability cluster is described
+in [Bulk import in analytical
+mode](/clustering/high-availability/analytical-import).
 
 
 ## Hardware requirements

--- a/pages/clustering/replication/replication-commands-reference.mdx
+++ b/pages/clustering/replication/replication-commands-reference.mdx
@@ -94,6 +94,18 @@ It should give you enough information to decide on which instance you can perfor
 
 ## Replica registration commands
 
+<Callout type="warning">
+
+`REGISTER REPLICA` and `DROP REPLICA` are refused while any database on the
+instance is in the [`IN_MEMORY_ANALYTICAL` storage
+mode](/fundamentals/storage-memory-usage#in-memory-analytical-storage-mode),
+because analytical writes are not replicated. Switch every database back to
+`IN_MEMORY_TRANSACTIONAL` and retry. For the analytical bulk import workflow,
+see [storage mode
+requirements](/clustering/replication/best-practices#storage-mode-requirements).
+
+</Callout>
+
 ### REGISTER REPLICA (SYNC)
 
 Registers a REPLICA instance with synchronous replication mode.

--- a/pages/database-management/backup-and-restore.mdx
+++ b/pages/database-management/backup-and-restore.mdx
@@ -357,7 +357,7 @@ his protects your data if the newly loaded snapshot turns out to be corrupted.
 
 Configuration:
 
-Use the `--storage-enable-backup-dir` flag to control this behavior:
+Use the `--storage-backup-dir-enabled` flag to control this behavior:
 - `true` (default) - Old durability files are moved to `.old` directories
 - `false` - Old durability files are deleted immediately
 

--- a/pages/database-management/configuration.mdx
+++ b/pages/database-management/configuration.mdx
@@ -489,7 +489,7 @@ in Memgraph.
 | `--storage-wal-enabled=true`                                    | Controls whether the storage uses write-ahead-logging. To enable WAL, periodic snapshots must be enabled.                          | `[bool]`   |
 | `--storage-wal-file-flush-every-n-tx=100000`                    | Issue a 'fsync' call after this amount of transactions are written to the WAL file. Set to 1 for fully synchronous operation.      | `[uint64]` |
 | `--storage-wal-file-size-kib=20480`                             | Minimum file size of each WAL file.                                                                                                | `[uint64]` |
-| `--storage-mode=IN_MEMORY_TRANSACTIONAL`                        | The storage mode Memgraph will run on startup. Can be IN_MEMORY_TRANSACTIONAL, IN_MEMORY_ANALYTICAL or ON_DISK_TRANSACTIONAL.      | `[string]` |
+| `--storage-mode=IN_MEMORY_TRANSACTIONAL`                        | The storage mode Memgraph will run on startup. Can be IN_MEMORY_TRANSACTIONAL, IN_MEMORY_ANALYTICAL or ON_DISK_TRANSACTIONAL. A data instance in a high availability cluster cannot start in IN_MEMORY_ANALYTICAL; it can only [switch to it at runtime](/clustering/high-availability/analytical-import). | `[string]` |
 | `--storage-enable-schema-metadata=false`                        | Facilitates the utilization of a specialized cache designed to store specific metadata related to the database.                    | `[bool]`   |
 | `--storage-enable-edges-metadata=false`                         | Utilizes additional memory to store metadata related to edges. This metadata is used to speed up id based lookups on edges.        | `[bool]`   |
 | `--storage-light-edge=false`                                    | Stores edges as lightweight objects to reduce memory footprint (saves ~24B per edge by removing the dedicated edge container). Implies `--storage-properties-on-edges=true`. Direct edge lookups by ID become slower; pair with `--storage-enable-edges-metadata=true` for such workloads. In-memory storage modes only. | `[bool]`   |
@@ -499,7 +499,7 @@ in Memgraph.
 | `--storage-property-store-compression-level=mid`                | Controls property store compression level. Allowed values: low, mid, high                                                          | `[string]` |
 | `--storage-floating-point-resolution-bits=64`                   | Max bits for floating-point property storage. Allowed values: 16, 32, 64. Lower values save memory but reduce precision.           | `[uint64]` |
 | `--storage-access-timeout-sec=1`                                | Storage access timeout in seconds. Used to fine-tune the responsiveness and guard against queries indefinitely waiting. Can also be changed at runtime via `SET DATABASE SETTING 'storage.access_timeout_sec' TO 'value'`. Valid range: [1, 1000000]. | `[uint64]` |
-| `--storage-enable-backup-dir=true`                              | Controls whether `.old` directory will be used to store backup.                                                                    | `[bool]`   |
+| `--storage-backup-dir-enabled=true`                             | Controls whether `.old` directory will be used to store backup.                                                                    | `[bool]`   |
 
 ### Streams
 

--- a/pages/fundamentals/data-durability.mdx
+++ b/pages/fundamentals/data-durability.mdx
@@ -401,7 +401,7 @@ RECOVER SNAPSHOT "/path/to/good.snapshot";
 On success, Memgraph clears the broken flag and the database resumes normal
 operation and background durability. The existing `RECOVER SNAPSHOT` behavior
 moves all prior/corrupt snapshots and WAL files to the `.old` directory (or
-deletes them when [`--storage-enable-backup-dir`](/database-management/configuration)
+deletes them when [`--storage-backup-dir-enabled`](/database-management/configuration)
 is off), leaving a clean single-snapshot directory. As a result, the database **recovers cleanly on the
 next restart and does not re-enter the broken state**.
 

--- a/pages/fundamentals/storage-memory-usage.mdx
+++ b/pages/fundamentals/storage-memory-usage.mdx
@@ -62,6 +62,11 @@ If some other transactions are running in your system, you will receive a
 warning message, so be sure to [set the log level at least to
 `WARNING`](/database-management/logs).
 
+Switching to `IN_MEMORY_ANALYTICAL` is refused when replicas are registered,
+because analytical writes are not replicated. See [In-memory analytical storage
+mode](#in-memory-analytical-storage-mode) and [Bulk import in analytical
+mode](/clustering/high-availability/analytical-import).
+
 Switching from the in-memory storage mode to the on-disk storage mode is allowed
 when there is only one active session and the database is empty. As Memgraph Lab
 uses multiple sessions to run queries in parallel, it is currently impossible to
@@ -223,23 +228,41 @@ SNAPSHOT;` Cypher query.
 In the analytical storage mode, WAL files and periodic snapshots are **not
 created**. 
 
-Before switching back to the in-memory transactional storage mode create a
-snapshot manually. In the in-memory analytical storage mode, Memgraph guarantees
-that creating a snapshot is **the only** transaction present in the system, and
-all the other transactions will wait until the snapshot is created to ensure its
-validity. Once Memgraph switches to the in-memory transactional mode, it will
-restore data from the snapshot file and create a WAL for all new updates, if not
-otherwise instructed by the [config
+Switching back to the in-memory transactional storage mode writes a snapshot on
+its own, synchronously and before the mode change completes, so there is no need
+to create one manually first. If that snapshot cannot be written, the switch is
+aborted and the query throws: the database stays in analytical mode with its
+data and durability files unchanged, so you can fix the cause and retry. When
+the snapshot succeeds, the superseded snapshots and WAL files are moved to the
+`.old` directory — or deleted when
+[`--storage-backup-dir-enabled`](/database-management/configuration) is set to
+`false` — and WAL sequence numbering restarts from 0, because the new snapshot is
+a new durability base rather than an increment on the old one. New updates are
+written to a WAL again, if not otherwise instructed by the [config
 file](/configuration/configuration-settings#storage).
 
+In the in-memory analytical storage mode, Memgraph guarantees that creating a
+snapshot is **the only** transaction present in the system, and all the other
+transactions will wait until the snapshot is created to ensure its validity.
+Avoid taking a manual snapshot in the middle of an import you intend to finish
+with a switch back to transactional mode, though: analytical writes do not
+advance the durable timestamp, so such a snapshot is stamped with the
+**pre-import** timestamp.
 
 These are some of the implications of not having ACID properties. But if you do
 not have write-heavy workload, and you want to run analytical queries that will
 not change the data, you can take advantage of the low memory costs of the
 analytical mode.
 
-At the moment, the in-memory analytical storage mode **doesn't support
-replication and high availability**.
+Analytical writes are never appended to the WAL, so they **cannot be
+replicated**. An instance can enter the analytical storage mode only when it is
+the MAIN and has no registered replicas, and replicas can be registered or
+unregistered only while every database is in transactional mode. Within those
+rules, analytical mode can be used for a bulk import on a
+[replication](/clustering/replication/best-practices#storage-mode-requirements)
+or [high availability](/clustering/high-availability/analytical-import) cluster:
+unregister the replicas, import, switch back to transactional mode and register
+them again.
 
 ### On-disk transactional storage mode
 

--- a/pages/release-notes.mdx
+++ b/pages/release-notes.mdx
@@ -58,15 +58,6 @@ guide.
   you need the previous Python behavior, or update consumers for the new
   structured / ISO-8601 JSON forms.
   [#4443](https://github.com/memgraph/memgraph/pull/4443)
-- A MAIN with registered replicas is now refused the switch to
-  `IN_MEMORY_ANALYTICAL`, and `REGISTER REPLICA` / `DROP REPLICA` are refused
-  while any database on the instance is in analytical mode. Previously the
-  switch was allowed and silently produced replicas that missed every write made
-  in analytical mode, since those writes never reach the WAL. Unregister the
-  replicas before switching and register them back after switching to
-  `IN_MEMORY_TRANSACTIONAL` — see [bulk import in analytical
-  mode](/clustering/high-availability/analytical-import).
-  [#4510](https://github.com/memgraph/memgraph/pull/4510)
 
 {<h4 className="custom-header">🐞 Bug fixes</h4>}
 

--- a/pages/release-notes.mdx
+++ b/pages/release-notes.mdx
@@ -58,6 +58,15 @@ guide.
   you need the previous Python behavior, or update consumers for the new
   structured / ISO-8601 JSON forms.
   [#4443](https://github.com/memgraph/memgraph/pull/4443)
+- A MAIN with registered replicas is now refused the switch to
+  `IN_MEMORY_ANALYTICAL`, and `REGISTER REPLICA` / `DROP REPLICA` are refused
+  while any database on the instance is in analytical mode. Previously the
+  switch was allowed and silently produced replicas that missed every write made
+  in analytical mode, since those writes never reach the WAL. Unregister the
+  replicas before switching and register them back after switching to
+  `IN_MEMORY_TRANSACTIONAL` — see [bulk import in analytical
+  mode](/clustering/high-availability/analytical-import).
+  [#4510](https://github.com/memgraph/memgraph/pull/4510)
 
 {<h4 className="custom-header">🐞 Bug fixes</h4>}
 
@@ -160,6 +169,17 @@ guide.
 - `CREATE RANGE INDEX FOR ... ON ...` now works for nodes and relationships and
   creates Memgraph’s usual property index.
   [#4486](https://github.com/memgraph/memgraph/pull/4486)
+- A data instance in a high availability cluster can now use the
+  `IN_MEMORY_ANALYTICAL` storage mode for a bulk import: unregister the
+  replicas, switch to analytical, import, switch back to
+  `IN_MEMORY_TRANSACTIONAL` and register the replicas again. The switch back
+  writes a snapshot of the imported data, archives the superseded durability
+  files and restarts WAL numbering, and replica recovery detects that the
+  imported data exists in no WAL file, so a re-registered replica catches up
+  from that snapshot without wiping its data directory. Starting a data instance
+  with `--storage-mode=IN_MEMORY_ANALYTICAL` remains forbidden. See [bulk import
+  in analytical mode](/clustering/high-availability/analytical-import).
+  [#4510](https://github.com/memgraph/memgraph/pull/4510)
 
 ### Lab v3.13.0 - September 9th, 2026
 
@@ -1221,7 +1241,7 @@ the `username()` and `roles()` built-in functions. These functions allow users
 to programmatically retrieve current authentication details, simplifying
 auditing and the development of dynamic, role-based logic within queries.
 [#3563](https://github.com/memgraph/memgraph/pull/3563)
-- Added `--storage-enable-backup-dir` flag to control whether the `.old`
+- Added `--storage-backup-dir-enabled` flag to control whether the `.old`
 directory is used for storing old durability files during potential data loss
 scenarios. When disabled, old durability files are deleted instead of backed up.
 [#3631](https://github.com/memgraph/memgraph/pull/3631)


### PR DESCRIPTION
### Release note

Document the analytical bulk-import workflow for data instances: switch to IN_MEMORY_ANALYTICAL, import, switch back to IN_MEMORY_TRANSACTIONAL and register the replicas again.

- New page clustering/high-availability/analytical-import.mdx with the requirements (MAIN role, zero registered replicas, instance-wide), the step-by-step recipe, the durability guarantees of the switch back, replica re-registration without wiping, and the user-facing error messages.
- Storage modes page: drop the "doesn't support replication and high availability" claim, correct the stale "create a snapshot manually before switching back" advice, describe the switch-back snapshot, .old archiving and WAL sequence restart.
- Replication and HA command references and best practices: registration and unregistration belong in transactional mode only.
- Release notes: breaking change and new feature entries for v3.13.0.
- Fix the flag name --storage-enable-backup-dir -> --storage-backup-dir-enabled, which never existed under the documented name.


### Related product PRs

PRs from product repo this doc page is related to: 
https://github.com/memgraph/memgraph/pull/4510

### Checklist:

- [x] Add appropriate milestone (current release cycle)
- [x] Add `bugfix` or `feature` label, based on the product PR type you're documenting
- [x] Make sure all relevant tech details are documented
    - [x] Update reference pages (e.g. [clauses](https://memgraph.com/docs/querying/clauses), [functions](https://memgraph.com/docs/querying/functions), [flags](https://memgraph.com/docs/database-management/configuration#list-of-configuration-flags), [experimental](https://memgraph.com/docs/database-management/experimental-features), [monitoring](https://memgraph.com/docs/database-management/monitoring), [Cypher differences](https://memgraph.com/docs/querying/differences-in-cypher-implementations))
    - [x] Search for the feature you are working on (mentions) and make updates if needed
    - [x] Provide a basic example of usage
    - [x] In case your feature is an Enterprise one, list it under [ME page](https://memgraph.com/docs/database-management/enabling-memgraph-enterprise) and mark its page with Enterprise ([example](https://memgraph.com/docs/database-management/authentication-and-authorization/role-based-access-control)).
- [x] Check all content with Grammarly
- [x] Perform a self-review of my code
- [x] The build passes locally
- [x] My changes generate no new warnings or errors