### PR TITLE
docs(kshortest): document the filter lambda for KSHORTEST

### DIFF
--- a/pages/advanced-algorithms/deep-path-traversal.mdx
+++ b/pages/advanced-algorithms/deep-path-traversal.mdx
@@ -876,6 +876,37 @@ RETURN path;
 
 This will only return paths with a length between 2 and 4 hops (inclusive).
 
+### Constraining the expansion based on property values
+
+K shortest paths expansion allows an arbitrary expression filter that determines
+if an expansion is allowed over a certain relationship to a certain node. The
+filter is defined as a lambda function over `r` and `n`, which denotes the
+relationship expanded over and the node expanded to. The paths returned are the
+K shortest paths of the subgraph the filter leaves behind.
+
+Using the dataset above, the following example allows expansion only to nodes
+other than `B`, which leaves a single path from `A` to `E`:
+
+```cypher
+MATCH (a:Node {name: "A"}), (e:Node {name: "E"})
+WITH a, e
+MATCH path=(a)-[*KSHORTEST (r, n | n.name <> "B")]->(e)
+RETURN path;
+```
+
+The filter can be combined with the path limit and the length constraints:
+
+```cypher
+MATCH (a:Node {name: "A"}), (e:Node {name: "E"})
+WITH a, e
+MATCH path=(a)-[*KSHORTEST 2..4 |3 (r, n | n.name <> "D")]->(e)
+RETURN path;
+```
+
+Unlike the other deep path traversal algorithms, K shortest paths does not
+support the three-argument `(r, n, p | ...)` form that exposes the already
+collected path. Using it raises an error.
+
 ### When to use K shortest paths?
 
 Use the K shortest paths algorithm when you need to:
@@ -893,8 +924,11 @@ Use the K shortest paths algorithm when you need to:
 
 - **Predefined nodes**: Both source and target nodes must be matched first using
   a `WITH` clause
-- **No filter lambdas**: K shortest paths does not support user-defined
-  filtering during expansion
+- **Unweighted**: Paths are ordered by the number of hops. Relationship
+  properties are never treated as weights, and no weight lambda is accepted
+- **No accumulated path in the filter lambda**: the two-argument
+  `(r, n | ...)` filter is supported, the three-argument `(r, n, p | ...)` form
+  is not
 
 
 <CommunityLinks/>

--- a/pages/advanced-algorithms/deep-path-traversal.mdx
+++ b/pages/advanced-algorithms/deep-path-traversal.mdx
@@ -825,6 +825,33 @@ RETURN path;
 
 This will return at most 3 shortest paths between the source and target nodes.
 
+The limit applies **per source-target pair**, not to the query as a whole. A query
+that matches several pairs returns up to `k` paths for each of them, so the example
+below returns up to six paths across three pairs:
+
+```cypher
+MATCH (source:Node), (target:Node)
+WHERE source.group = target.group
+WITH source, target
+MATCH path=(source)-[*KSHORTEST|2]->(target)
+RETURN source, target, path;
+```
+
+The limit can be any expression that evaluates to an integer, including one that
+reads the current row, so different pairs can ask for a different number of paths:
+
+```cypher
+MATCH (source:Node), (target:Node)
+WITH source, target
+MATCH path=(source)-[*KSHORTEST|coalesce(source.paths_wanted, 1)]->(target)
+RETURN path;
+```
+
+The limit is evaluated once per pair and must be an integer on every one of them,
+so guard an optional property with `coalesce` as above - a `null` limit raises an
+error. A limit of `0` returns no paths for that pair without searching, and a
+negative limit raises an error.
+
 ### Example
 
 
@@ -875,6 +902,10 @@ RETURN path;
 ```
 
 This will only return paths with a length between 2 and 4 hops (inclusive).
+
+A negative minimum depth and a maximum depth below 1 both raise an error. A range
+whose minimum exceeds its maximum, such as `4..3`, is empty and returns no paths
+without searching.
 
 ### Constraining the expansion based on property values
 
@@ -929,6 +960,8 @@ Use the K shortest paths algorithm when you need to:
 - **No accumulated path in the filter lambda**: the two-argument
   `(r, n | ...)` filter is supported, the three-argument `(r, n, p | ...)` form
   is not
+- **Filter results**: the filter must evaluate to a boolean or `null`. `null`
+  prunes the expansion, as `false` does; any other type raises an error
 
 
 <CommunityLinks/>

--- a/pages/advanced-algorithms/deep-path-traversal.mdx
+++ b/pages/advanced-algorithms/deep-path-traversal.mdx
@@ -890,7 +890,7 @@ negative limit raises an error.
 </Tabs>
 
 
-### Path length constraints
+### Constraining the path's length
 
 You can constrain the path length using the range syntax:
 


### PR DESCRIPTION
### Release note

KSHORTEST path expansion now accepts a filter lambda. Documents the `(r, n | ...)` syntax with runnable examples, and replaces the "No filter lambdas" limitation with the two that remain: KSHORTEST orders by hop count and takes no weight lambda, and the three-argument `(r, n, p | ...)` form is not supported.

### Related product PRs

PRs from product repo this doc page is related to:
memgraph/memgraph#4559

### Checklist:

- [x] Add appropriate milestone (current release cycle)
- [x] Add `bugfix` or `feature` label, based on the product PR type you're documenting
- [ ] Make sure all relevant tech details are documented
    - [x] Update reference pages (e.g. [clauses](https://memgraph.com/docs/querying/clauses), [functions](https://memgraph.com/docs/querying/functions), [flags](https://memgraph.com/docs/database-management/configuration#list-of-configuration-flags), [experimental](https://memgraph.com/docs/database-management/experimental-features), [monitoring](https://memgraph.com/docs/database-management/monitoring), [Cypher differences](https://memgraph.com/docs/querying/differences-in-cypher-implementations))
    - [x] Search for the feature you are working on (mentions) and make updates if needed
    - [x] Provide a basic example of usage
    - [ ] In case your feature is an Enterprise one, list it under [ME page](https://memgraph.com/docs/database-management/enabling-memgraph-enterprise) and mark its page with Enterprise ([example](https://memgraph.com/docs/database-management/authentication-and-authorization/role-based-access-control)) — not Enterprise-only
- [ ] Check all content with Grammarly
- [x] Perform a self-review of my code
- [ ] The build passes locally
- [ ] My changes generate no new warnings or errors

---

Notes for the reviewer:

- The only KSHORTEST mention outside this page is the "K shortest paths" section of [Cypher differences](https://memgraph.com/docs/querying/differences-in-cypher-implementations), which makes no claim about lambdas — checked, no edit needed.
- Both new examples were run against a build of memgraph/memgraph#4559 using the dataset already on the page: `(r, n | n.name <> "B")` leaves the single path `A → C → E`, and `2..4 |3 (r, n | n.name <> "D")` leaves `A → C → E` and `A → B → C → E`.
