### PR TITLE
docs: Flag for configuring max RocksDB persistent log files

### DIFF
--- a/pages/database-management/configuration.mdx
+++ b/pages/database-management/configuration.mdx
@@ -501,6 +501,25 @@ in Memgraph.
 | `--storage-floating-point-resolution-bits=64`                   | Max bits for floating-point property storage. Allowed values: 16, 32, 64. Lower values save memory but reduce precision.           | `[uint64]` |
 | `--storage-access-timeout-sec=1`                                | Storage access timeout in seconds. Used to fine-tune the responsiveness and guard against queries indefinitely waiting. Can also be changed at runtime via `SET DATABASE SETTING 'storage.access_timeout_sec' TO 'value'`. Valid range: [1, 1000000]. | `[uint64]` |
 | `--storage-backup-dir-enabled=true`                             | Controls whether `.old` directory will be used to store backup.                                                                    | `[bool]`   |
+| `--storage-rocksdb-info-log-level=INFO_LEVEL`                   | Verbosity of the RocksDB info logs. Allowed values: `DEBUG_LEVEL`, `INFO_LEVEL`, `WARN_LEVEL`, `ERROR_LEVEL`, `FATAL_LEVEL`, `HEADER_LEVEL`. | `[string]` |
+| `--storage-rocksdb-keep-log-file-num=1000`                      | Maximum number of RocksDB info log files kept per RocksDB instance. Every restart rolls the current info log and older ones are deleted. Valid range: [1, 2^64-1]. | `[uint64]` |
+| `--storage-rocksdb-enable-thread-tracking=false`                | Enables RocksDB thread status tracking for the on-disk storage. Disabled by default to reduce `gettimeofday`/`gettid` syscall overhead. | `[bool]`   |
+
+<Callout type="info">
+
+`--storage-rocksdb-info-log-level` and `--storage-rocksdb-keep-log-file-num`
+apply to **every** RocksDB instance Memgraph opens, not just the one backing the
+`ON_DISK_TRANSACTIONAL` storage mode. That includes the key-value stores holding
+authentication data, triggers, streams, settings, and replication and high
+availability state. Each instance keeps its own info logs (`LOG`, `LOG.old.*`)
+in its own directory, so the limit is per instance and not per Memgraph
+process.
+
+Every restart rolls the current info log into a new file, so on deployments with
+constrained disk space and frequent restarts it is worth lowering
+`--storage-rocksdb-keep-log-file-num` from the default of `1000`.
+
+</Callout>
 
 ### Streams
 

--- a/pages/database-management/logs.mdx
+++ b/pages/database-management/logs.mdx
@@ -41,6 +41,30 @@ To get additional information on the generated query plans, set
 `--debug-query-plans` to `True`, along with `--log-level` set to `DEBUG` or `TRACE`.
 </Callout>
 
+## RocksDB info logs
+
+Besides its own log file, Memgraph also produces the info logs written by the
+embedded RocksDB instances. These are separate from `--log-file` and live next
+to the data of each RocksDB instance inside the [data
+directory](/database-management/configuration#other), as a live `LOG` file and
+rolled `LOG.old.<timestamp>` files.
+
+Memgraph opens a RocksDB instance for the key-value stores holding
+authentication data, triggers, streams, settings and replication or high
+availability state, and one more for the `ON_DISK_TRANSACTIONAL` storage mode.
+Two flags control the info logs of all of them:
+
+| Flag | Description |
+|------|-------------|
+| [`--storage-rocksdb-info-log-level=INFO_LEVEL`](/database-management/configuration#storage) | Verbosity of the info logs. Allowed values: `DEBUG_LEVEL`, `INFO_LEVEL`, `WARN_LEVEL`, `ERROR_LEVEL`, `FATAL_LEVEL`, `HEADER_LEVEL`. |
+| [`--storage-rocksdb-keep-log-file-num=1000`](/database-management/configuration#storage) | Maximum number of info log files kept per RocksDB instance. |
+
+Every Memgraph restart rolls the current info log into a new file, so an
+instance that restarts often accumulates up to
+`--storage-rocksdb-keep-log-file-num` files per RocksDB instance before the
+oldest ones start being deleted. On deployments with constrained disk space,
+lower the flag from its default of `1000`.
+
 ## Slow and failed query logging
 
 Memgraph can emit two operational log streams to the main log, useful for

--- a/pages/release-notes.mdx
+++ b/pages/release-notes.mdx
@@ -274,6 +274,16 @@ guide.
   with `--storage-mode=IN_MEMORY_ANALYTICAL` remains forbidden. See [bulk import
   in analytical mode](/clustering/high-availability/analytical-import).
   [#4510](https://github.com/memgraph/memgraph/pull/4510)
+- Added
+  [`--storage-rocksdb-keep-log-file-num`](/database-management/configuration#storage)
+  (default `1000`), which caps how many RocksDB info log files are kept per
+  RocksDB instance. Since every restart rolls the current info log into a new
+  file, lowering it helps on deployments with constrained disk space.
+  `--storage-rocksdb-info-log-level` and the new flag now apply to every RocksDB
+  instance Memgraph opens — the key-value stores backing authentication,
+  triggers, streams, settings and replication or high availability state — and
+  not only to the `ON_DISK_TRANSACTIONAL` storage.
+  [#4579](https://github.com/memgraph/memgraph/pull/4579)
 
 ### Lab v3.13.0 - September 9th, 2026
 


### PR DESCRIPTION
### Release note

Documented the new `--storage-rocksdb-keep-log-file-num` flag (default `1000`), which caps how many RocksDB info log files are kept per RocksDB instance. Also documented the two previously undocumented RocksDB flags (`--storage-rocksdb-info-log-level`, `--storage-rocksdb-enable-thread-tracking`) and clarified that the info log flags now apply to every RocksDB instance Memgraph opens — the key-value stores backing auth, triggers, streams, settings and replication/HA state — not only the `ON_DISK_TRANSACTIONAL` storage.

Changes:
- `pages/database-management/configuration.mdx` — three new rows in the Storage flags table plus a callout on the per-instance scope and restart-rolling behavior.
- `pages/database-management/logs.mdx` — new "RocksDB info logs" section explaining where the `LOG` / `LOG.old.*` files live and how to bound them.
- `pages/release-notes.mdx` — entry under v3.13.0 → New features.

### Related product PRs

https://github.com/memgraph/memgraph/pull/4579

### Checklist:

- [x] Add appropriate milestone (current release cycle)
- [x] Add `bugfix` or `feature` label, based on the product PR type you're documenting
- [x] Make sure all relevant tech details are documented
    - [x] Update reference pages (flags page updated; no clause/function/experimental/monitoring/Cypher-difference changes in this PR)
    - [x] Search for the feature you are working on (mentions) and make updates if needed
    - [x] Provide a basic example of usage
    - [x] In case your feature is an Enterprise one, list it under ME page — N/A, not an Enterprise feature
- [x] Check all content with Grammarly
- [x] Perform a self-review of my code
- [x] The build passes locally
- [x] My changes generate no new warnings or errors
