### PR TITLE
docs: phrase prefix and slop in text search

### DIFF
--- a/pages/querying/text-search.mdx
+++ b/pages/querying/text-search.mdx
@@ -249,6 +249,73 @@ Result:
 +-------------+-------------+
 ```
 
+### Phrase prefix and proximity search
+
+The `search_query` of `text_search.search` supports two additional
+[Tantivy phrase modifiers](https://docs.rs/tantivy/latest/tantivy/query/struct.QueryParser.html):
+**phrase prefix** (`"…"*`) and **slop** (`"…"~N`). They apply to the properties you
+name (prefixed with `data.`), and also to `text_search.search_all` and the `_edges`
+variants.
+
+{<h4 className="custom-header">Phrase prefix: `"…"*`</h4>}
+
+A phrase prefix query matches an ordered, adjacent phrase in which the leading terms
+match exactly and the **last** term is matched as a prefix. It is the exact-match
+counterpart of [`text_search.fuzzy_phrase_search`](#fuzzy-phrase-search): use `"…"*`
+for ordered "search-as-you-type" matching without typo tolerance, and
+`fuzzy_phrase_search` when you also need typo tolerance.
+
+```cypher
+CREATE TEXT INDEX docs ON :Doc;
+CREATE (:Doc {title: 'big bad wolf'});
+CREATE (:Doc {title: 'big bad world'});
+CREATE (:Doc {title: 'big brave wolf'});
+
+CALL text_search.search('docs', 'data.title:"big bad wo"*')
+YIELD node
+RETURN node.title AS title
+ORDER BY title;
+```
+
+Result:
+```
++-----------------+
+| title           |
++-----------------+
+| "big bad wolf"  |
+| "big bad world" |
++-----------------+
+```
+
+`big brave wolf` does not match: the leading terms (`big bad`) are matched exactly
+and in order, and only the last term (`wo`) is a prefix. A phrase prefix needs at
+least two terms — a single-token phrase such as `data.title:"wo"*` is rejected.
+
+{<h4 className="custom-header">Slop (proximity): `"…"~N`</h4>}
+
+A slop query matches the terms of a phrase when they occur within `N` positions of
+each other, tolerating intervening words.
+
+```cypher
+CALL text_search.search('docs', 'data.title:"big wolf"~1')
+YIELD node
+RETURN node.title AS title
+ORDER BY title;
+```
+
+Result:
+```
++------------------+
+| title            |
++------------------+
+| "big bad wolf"   |
+| "big brave wolf" |
++------------------+
+```
+
+Both titles match because `big` and `wolf` are one position apart; the exact phrase
+query `data.title:"big wolf"` (without `~1`) matches neither.
+
 ### Fuzzy search
 
 Fuzzy matching lets a search tolerate typos and partial terms. Using the


### PR DESCRIPTION
### Release note

Document the `"…"*` (phrase prefix) and `"…"~N` (slop / proximity) Tantivy query modifiers in `text_search.search`. A new **Phrase prefix and proximity search** section on the [text search](https://memgraph.com/docs/querying/text-search) page explains that phrase prefix matches an ordered phrase whose leading terms are exact and last term is a prefix (the exact-match counterpart of `fuzzy_phrase_search`, min two terms), and that slop matches phrase terms within `N` positions of each other. Both apply to named (`data.`-prefixed) properties as well as `search_all` and the `_edges` variants.

### Related product PRs

PRs from product repo this doc page is related to:

⚠️ **Blocked — keep in draft until the dependency lands.** There is no Memgraph product PR yet. Per-property (`data.<prop>:`) phrase-prefix/slop currently degrades silently because the modifiers are dropped on Tantivy JSON fields; the fix is upstream in Tantivy:

- https://github.com/quickwit-oss/tantivy/pull/2966

Merging this doc requires that fix to ship in a Tantivy release and a bump of the pinned `tantivy` version in `mgcxx/text_search/Cargo.toml` (we pin `0.25.0`). No Memgraph C++/Rust changes are needed beyond the version bump — all search paths already route through `QueryParser::parse_query`.

### Checklist:

- [ ] Add appropriate milestone (current release cycle)
- [ ] Add `bugfix` or `feature` label, based on the product PR type you're documenting
- [x] Make sure all relevant tech details are documented
    - [x] Update reference pages (e.g. [clauses](https://memgraph.com/docs/querying/clauses), [functions](https://memgraph.com/docs/querying/functions), [flags](https://memgraph.com/docs/database-management/configuration#list-of-configuration-flags), [experimental](https://memgraph.com/docs/database-management/experimental-features), [monitoring](https://memgraph.com/docs/database-management/monitoring), [Cypher differences](https://memgraph.com/docs/querying/differences-in-cypher-implementations))
    - [x] Search for the feature you are working on (mentions) and make updates if needed
    - [x] Provide a basic example of usage
    - [ ] In case your feature is an Enterprise one, list it under [ME page](https://memgraph.com/docs/database-management/enabling-memgraph-enterprise) and mark its page with Enterprise ([example](https://memgraph.com/docs/database-management/authentication-and-authorization/role-based-access-control))
- [ ] Check all content with Grammarly
- [x] Perform a self-review of my code
- [ ] The build passes locally
- [ ] My changes generate no new warnings or errors