### PR TITLE
Update Ruby driver link 

### DIFF
--- a/pages/index.mdx
+++ b/pages/index.mdx
@@ -149,7 +149,7 @@ libraries and follow their getting started guide.
   <Cards.Card
     icon={<Ruby />}
     title="Ruby"
-    href="https://github.com/neo4jrb/activegraph"
+    href="https://github.com/seuros/activecypher"
   />
   <Cards.Card
     icon={<Rust />}


### PR DESCRIPTION
### Release note

We missed a link change here -> https://github.com/memgraph/documentation/pull/1282, this caused Ruby driver to have two distinct links to a two different projects, so changing it on the second place now. 
