### PR TITLE
docs(ha-k8s): document configurable affinity.topologyKey in HA chart

### DIFF
--- a/pages/clustering/high-availability/setup-ha-cluster-k8s.mdx
+++ b/pages/clustering/high-availability/setup-ha-cluster-k8s.mdx
@@ -540,6 +540,20 @@ A full AKS example is available in the [chart
 repository]((https://github.com/memgraph/helm-charts/tree/main/charts/memgraph-high-availability/aks)). 
 </Callout>
 
+All strategies above spread pods across a topology domain defined by
+`affinity.topologyKey`. The default, `kubernetes.io/hostname`, treats every
+node as its own domain. Set it to a different node label to spread pods across
+a wider domain, for example across availability zones:
+
+```yaml
+affinity:
+  topologyKey: topology.kubernetes.io/zone
+  unique: true
+```
+
+The same topology key is applied to both coordinator and data pod rules, so the
+label must be present on every node that should take part in scheduling.
+
 ### Sysctl options
 
 Use the `sysctlInitContainer` to configure kernel parameters required for
@@ -1732,6 +1746,7 @@ and their default values.
 | `ports.replicationPort`                                    | Replication port used on data instances.                                                                     | `20000`                        |
 | `ports.coordinatorPort`                                    | Coordinator port used on coordinators.                                                                       | `12000`                        |
 | `ports.metricsPort`                                        | Metrics port for coordinators and data instances. Opened only if `prometheus.enabled` is set to `true`.      | `9091`                         |
+| `affinity.topologyKey`                                     | Topology domain used by all pod affinity and anti-affinity rules (for example a node or an availability zone) | `kubernetes.io/hostname`       |
 | `affinity.unique`                                          | Schedule pods on different nodes in the cluster                                                              | `false`                        |
 | `affinity.parity`                                          | Schedule pods on the same node with maximum one coordinator and one data node                                | `false`                        |
 | `affinity.nodeSelection`                                   | Schedule pods on nodes with specific labels                                                                  | `false`                        |


### PR DESCRIPTION
### Release note

Document the new `affinity.topologyKey` value in the Memgraph high-availability Helm chart. It sets the topology domain used by all coordinator and data pod affinity and anti-affinity rules and defaults to `kubernetes.io/hostname`.

### Related product PRs

https://github.com/memgraph/helm-charts/pull/283

### Checklist:

- [x] Add appropriate milestone (current release cycle)
- [x] Add `bugfix` or `feature` label, based on the product PR type you're documenting
- [x] Make sure all relevant tech details are documented
    - [x] Update reference pages (configuration table on the HA K8s setup page)
    - [x] Search for the feature you are working on (mentions) and make updates if needed
    - [x] Provide a basic example of usage
    - [x] In case your feature is an Enterprise one, list it under ME page and mark its page with Enterprise
- [ ] Check all content with Grammarly
- [x] Perform a self-review of my code
- [x] The build passes locally
- [x] My changes generate no new warnings or errors