### PR TITLE
docs: document the EXISTS, COUNT and COLLECT subquery expressions

### DIFF
--- a/pages/querying/_meta.ts
+++ b/pages/querying/_meta.ts
@@ -6,6 +6,7 @@ export default {
   "clauses": "Clauses",
   "functions": "Functions",
   "expressions": "Expressions",
+  "subquery-expressions": "Subquery expressions",
   "schema": "Schema",
   "text-search": "Text search",
   "vector-search": "Vector search",

--- a/pages/querying/clauses/case.mdx
+++ b/pages/querying/clauses/case.mdx
@@ -148,3 +148,15 @@ Result:
 
 This approach ensures that `null` values are handled clearly and avoid being
 interpreted as `false` by default.
+
+## Subquery expressions in CASE
+
+A `CASE` may test a [subquery expression](/querying/subquery-expressions) — `EXISTS { … }`,
+`COUNT { … }` or `COLLECT { … }` — as well as the [`exists(pattern)`
+function](/querying/functions#pattern-functions):
+
+```cypher
+MATCH (p:Person)
+RETURN p.name,
+       CASE WHEN EXISTS { MATCH (p)-[:ACTED_IN]->() } THEN 'actor' ELSE 'crew' END AS role;
+```

--- a/pages/querying/clauses/where.md
+++ b/pages/querying/clauses/where.md
@@ -26,13 +26,7 @@ order to avoid problems with performance or results.
    1.8. [Filter with pattern expressions](#18-filter-with-pattern-expressions)<br />
 2. [String matching](#2-string-matching)<br />
 3. [Regular Expressions](#3-regular-expressions)
-4. [Existential subqueries](#4-existential-subqueries)<br />
-   4.1. [Basic EXISTS in WHERE](#41-basic-exists-in-where)<br />
-   4.2. [Negation with NOT EXISTS](#42-negation-with-not-exists)<br />
-   4.3. [When to use EXISTS instead of pattern expressions](#43-when-to-use-exists-instead-of-pattern-expressions)<br />
-   4.4. [RETURN in EXISTS subqueries](#44-return-in-exists-subqueries)<br />
-   4.5. [EXISTS with UNION](#45-exists-with-union)<br />
-   4.6. [Outer scope variables and WITH](#46-outer-scope-variables-and-with)
+4. [Existential subqueries](#4-existential-subqueries)
 
 ## Dataset
 
@@ -179,7 +173,9 @@ RETURN p.name
 ORDER BY p.name;
 ```
 
-The [`exists()` function](/querying/functions#pattern-functions) can be used only with the `WHERE` clause.
+The [`exists()` function](/querying/functions#pattern-functions) is also accepted in a `WITH`/`RETURN`
+projection, an `ORDER BY`, a `CASE` and an aggregation argument — see [Subquery
+expressions](/querying/subquery-expressions#5-where-you-can-use-a-subquery-expression).
 
 Output:
 
@@ -272,11 +268,9 @@ document](https://en.cppreference.com/w/cpp/regex/ecmascript).
 
 ## 4. Existential subqueries
 
-Existential subqueries allow you to use `EXISTS { ... }` within `WHERE` (or as a standalone expression) to test whether a subquery returns at least one row. The subquery can reference variables from the outer scope (correlated subquery), while variables created inside the subquery are not visible outside of it.
-
-### 4.1. Basic EXISTS in WHERE
-
-Return people who live in Germany:
+`EXISTS { ... }` tests whether a subquery returns at least one row, and can be used as a filter here.
+The subquery can reference variables from the outer scope (correlated subquery), while variables created
+inside it are not visible outside of it.
 
 ```cypher
 MATCH (p:Person)
@@ -298,154 +292,9 @@ Output:
 +---------+
 ```
 
-### 4.2. Negation with NOT EXISTS
-
-Return people who do not live in the United Kingdom:
-
-```cypher
-MATCH (p:Person)
-WHERE NOT EXISTS {
-  MATCH (p)-[:LIVING_IN]->(:Country {name: 'United Kingdom'})
-}
-RETURN p.name
-ORDER BY p.name;
-```
-
-Output:
-
-```nocopy
-+---------+
-| p.name  |
-+---------+
-| John    |
-+---------+
-```
-
-### 4.3. When to use EXISTS instead of pattern expressions
-
-Pattern expressions like `exists( (p)-[:FRIENDS_WITH]-() )` are convenient for simple existence checks, but they cannot contain additional clauses such as `WHERE`, `WITH`/aggregation, or multiple pattern parts. `EXISTS { ... }` supports this additional logic.
-
-For example, return people who have at least two friendships (uses aggregation inside the subquery):
-
-```cypher
-MATCH (p:Person)
-WHERE EXISTS {
-  MATCH (p)-[:FRIENDS_WITH]-(:Person)
-  WITH count(*) AS friendsCount
-  WHERE friendsCount >= 2
-}
-RETURN p.name
-ORDER BY p.name;
-```
-
-Output:
-
-```nocopy
-+---------+
-| p.name  |
-+---------+
-| Anna    |
-| Harry   |
-| John    |
-+---------+
-```
-
-You can also include property predicates on relationships inside the subquery. For example, people connected by a friendship that started before 2012:
-
-```cypher
-MATCH (p:Person)
-WHERE EXISTS {
-  MATCH (p)-[r:FRIENDS_WITH]-(:Person)
-  WHERE r.date_of_start < 2012
-}
-RETURN p.name
-ORDER BY p.name;
-```
-
-Output:
-
-```nocopy
-+---------+
-| p.name  |
-+---------+
-| Harry   |
-| John    |
-+---------+
-```
-
-### 4.4. RETURN in EXISTS subqueries
-
-EXISTS subqueries do not require a `RETURN` clause. If one is present, it does not need to be aliased (unlike `CALL` subqueries), and any variables returned within the `EXISTS` subquery are not available after the subquery finishes.
-
-```cypher
-MATCH (person:Person)
-WHERE EXISTS {
-    MATCH (person)-[:LIVING_IN]->(country:Country)
-    RETURN country.name
-}
-RETURN person.name AS name
-```
-
-Output:
-
-```nocopy
-+---------+
-| name    |
-+---------+
-| Anna    |
-| Harry   |
-| John    |
-+---------+
-```
-
-### 4.5. EXISTS with UNION
-
-EXISTS can be used with a `UNION` clause, and the `RETURN` clauses are not required. If one branch has a `RETURN` clause, then all branches require one. If any `UNION` branch returns at least one row, the entire `EXISTS` expression evaluates to `true`.
-
-```cypher
-MATCH (person:Person)
-WHERE EXISTS {
-        MATCH (person)-[:LIVING_IN]->(:Country {name: 'Germany'})
-        UNION
-        MATCH (person)-[:WORKING_IN]->(:Country {name: 'United Kingdom'})
-    }
-RETURN person.name AS name
-```
-
-Output:
-
-```nocopy
-+---------+
-| name    |
-+---------+
-| Anna    |
-| Harry   |
-+---------+
-```
-
-### 4.6. Outer scope variables and WITH
-
-Variables from the outside scope are visible for the entire subquery, even when using a `WITH` clause. Shadowing these variables is not allowed. An outside scope variable is shadowed when a newly introduced variable within the inner scope is defined with the same name. The example below shadows the outer variable `countryName` and will therefore throw an error.
-
-```cypher
-WITH 'United Kingdom' as countryName
-MATCH (person:Person)-[:LIVING_IN]->(c:Country {name: countryName})
-WHERE EXISTS {
-    WITH "Germany" AS countryName
-    MATCH (person)-[:LIVING_IN]->(d:Country)
-    WHERE d.name = countryName
-}
-RETURN person.name AS name
-```
-
-```nocopy
-+---------+
-| name    |
-+---------+
-| Anna    |
-| John    |
-+---------+
-```
+`EXISTS { ... }` is documented in full, together with its `COUNT { ... }` and `COLLECT { ... }` siblings,
+on the [Subquery expressions](/querying/subquery-expressions) page — the positions all three are accepted
+in, the clauses their bodies support, correlation and shadowing rules, `UNION` bodies, and nesting.
 
 
 ## Dataset queries

--- a/pages/querying/clauses/where.md
+++ b/pages/querying/clauses/where.md
@@ -175,7 +175,7 @@ ORDER BY p.name;
 
 The [`exists()` function](/querying/functions#pattern-functions) is not limited to `WHERE` — see [where
 you can use a subquery
-expression](/querying/subquery-expressions#4-where-you-can-use-a-subquery-expression).
+expression](/querying/subquery-expressions#where-you-can-use-a-subquery-expression).
 
 Output:
 

--- a/pages/querying/clauses/where.md
+++ b/pages/querying/clauses/where.md
@@ -175,7 +175,7 @@ ORDER BY p.name;
 
 The [`exists()` function](/querying/functions#pattern-functions) is also accepted in a `WITH`/`RETURN`
 projection, an `ORDER BY`, a `CASE` and an aggregation argument — see [Subquery
-expressions](/querying/subquery-expressions#5-where-you-can-use-a-subquery-expression).
+expressions](/querying/subquery-expressions#4-where-you-can-use-a-subquery-expression).
 
 Output:
 

--- a/pages/querying/clauses/where.md
+++ b/pages/querying/clauses/where.md
@@ -173,9 +173,9 @@ RETURN p.name
 ORDER BY p.name;
 ```
 
-The [`exists()` function](/querying/functions#pattern-functions) is also accepted in a `WITH`/`RETURN`
-projection, an `ORDER BY`, a `CASE` and an aggregation argument — see [Subquery
-expressions](/querying/subquery-expressions#4-where-you-can-use-a-subquery-expression).
+The [`exists()` function](/querying/functions#pattern-functions) is not limited to `WHERE` — see [where
+you can use a subquery
+expression](/querying/subquery-expressions#4-where-you-can-use-a-subquery-expression).
 
 Output:
 
@@ -268,7 +268,7 @@ document](https://en.cppreference.com/w/cpp/regex/ecmascript).
 
 ## 4. Existential subqueries
 
-`EXISTS { ... }` tests whether a subquery returns at least one row, and can be used as a filter here.
+`EXISTS { … }` tests whether a subquery returns at least one row, and can be used as a filter here.
 The subquery can reference variables from the outer scope (correlated subquery), while variables created
 inside it are not visible outside of it.
 
@@ -292,9 +292,9 @@ Output:
 +---------+
 ```
 
-`EXISTS { ... }` is documented in full, together with its `COUNT { ... }` and `COLLECT { ... }` siblings,
-on the [Subquery expressions](/querying/subquery-expressions) page — the positions all three are accepted
-in, the clauses their bodies support, correlation and shadowing rules, `UNION` bodies, and nesting.
+`EXISTS { … }` is documented in full, together with its `COUNT { … }` and `COLLECT { … }` siblings, on
+the [Subquery expressions](/querying/subquery-expressions) page — the positions all three are accepted
+in, the clauses their bodies follow, correlation, `UNION` bodies, and nesting.
 
 
 ## Dataset queries

--- a/pages/querying/differences-in-cypher-implementations.mdx
+++ b/pages/querying/differences-in-cypher-implementations.mdx
@@ -182,11 +182,12 @@ LIMIT 5
 ### Unsupported constructs
 
 {<h4 className="custom-header">Patterns in expressions</h4>}
-Patterns in expressions are supported in Memgraph in particular functions, like `exists(pattern)`.
+Patterns in expressions are supported in Memgraph in particular functions, like `exists(pattern)`, and
+directly inside the [`EXISTS { }` and `COUNT { }` subquery
+expressions](/querying/subquery-expressions), which accept a bare pattern.
 Memgraph also supports filtering based on patterns, like `MATCH (n) WHERE NOT (n)-->()`.
-In other cases, Memgraph does not yet support patterns in functions, e.g. `size((n)-->())`.
-Most of the time, the same functionalities can be expressed differently in Memgraph
-using `OPTIONAL` expansions, function calls, etc.
+In other cases, Memgraph does not yet support patterns in functions, e.g. `size((n)-->())` — use
+`COUNT { (n)-->() }` instead, which counts the matches without building a list.
 
 ### Unsupported expressions
 

--- a/pages/querying/differences-in-cypher-implementations.mdx
+++ b/pages/querying/differences-in-cypher-implementations.mdx
@@ -181,12 +181,6 @@ LIMIT 5
 
 ### Unsupported constructs
 
-{<h4 className="custom-header">COUNT subqueries</h4>}
-Such a construct is not supported in Memgraph, but you can use `count()` [aggregation function](/querying/functions#aggregation-functions) to count the number of non-null values returned by the expression. 
-
-{<h4 className="custom-header">COLLECT subqueries</h4>}
-Such a construct is not supported in Memgraph, but you can use `collect()` [aggregation function](/querying/functions#aggregation-functions) to return a single aggregated list from provided values.
-
 {<h4 className="custom-header">Patterns in expressions</h4>}
 Patterns in expressions are supported in Memgraph in particular functions, like `exists(pattern)`.
 Memgraph also supports filtering based on patterns, like `MATCH (n) WHERE NOT (n)-->()`.

--- a/pages/querying/expressions.mdx
+++ b/pages/querying/expressions.mdx
@@ -205,18 +205,26 @@ RETURN CASE WHEN n.height < 30 THEN "short" WHEN n.height > 300 THEN "tall" END;
 Most expressions that take `null` as input will produce `null`. This includes boolean expressions that are used as
 predicates. In this case, anything that is not true is interpreted as being false. This also concludes that logically `null!=null`.
 
-The [`exists()`](/querying/functions#pattern-functions) function cannot be used with the CASE clause.
+The [`exists()`](/querying/functions#pattern-functions) function and the `EXISTS { … }`, `COUNT { … }` and
+`COLLECT { … }` [subquery expressions](/querying/subquery-expressions) can all be used inside `CASE`.
 
 ## Pattern existence (exists(pattern))
 
-For simple pattern existence checks inside `WHERE` using `exists(pattern)`, see
-[Filter with pattern expressions](/querying/clauses/where#17-filter-with-pattern-expressions) for dataset-backed examples.
+`exists(pattern)` is a short form for a simple pattern existence check. It is accepted in the same
+positions as `EXISTS { … }` — a `WITH`/`RETURN` projection, a `WHERE`, an `ORDER BY`, a `CASE` and an
+aggregation argument. For dataset-backed examples, see [Filter with EXISTS
+expressions](/querying/clauses/where#17-filter-with-exists-expressions).
 
-## Existential subqueries (EXISTS)
+## Subquery expressions (EXISTS, COUNT, COLLECT)
 
-For a comprehensive guide to existential subqueries with `EXISTS` in the `WHERE` clause — including `NOT EXISTS`,
-optional `RETURN` inside subqueries, usage with `UNION`, and
-`WITH` variable visibility rules — see [Existential subqueries in WHERE](/querying/clauses/where#4-existential-subqueries).
+`EXISTS { … }` tests whether a subquery body produces any rows, `COUNT { … }` returns how many it
+produces, and `COLLECT { … }` gathers its single return column into a list. All three run the body once
+per row of the enclosing query, may correlate with the enclosing query's variables, and are accepted in a
+`WITH`/`RETURN` projection, a `WHERE`, an `ORDER BY`, a `CASE` and an aggregation argument. See
+[Subquery expressions](/querying/subquery-expressions).
+
+For `EXISTS` used specifically as a filter, see [Existential subqueries in
+WHERE](/querying/clauses/where#4-existential-subqueries).
 
 ## Pattern comprehension
 

--- a/pages/querying/expressions.mdx
+++ b/pages/querying/expressions.mdx
@@ -211,17 +211,18 @@ The [`exists()`](/querying/functions#pattern-functions) function and the `EXISTS
 ## Pattern existence (exists(pattern))
 
 `exists(pattern)` is a short form for a simple pattern existence check. It is accepted in the same
-positions as `EXISTS { … }` — a `WITH`/`RETURN` projection, a `WHERE`, an `ORDER BY`, a `CASE` and an
-aggregation argument. For dataset-backed examples, see [Filter with EXISTS
+positions as `EXISTS { … }` — see [where you can use a subquery
+expression](/querying/subquery-expressions#4-where-you-can-use-a-subquery-expression). For a
+dataset-backed example, see [Filter with EXISTS
 expressions](/querying/clauses/where#17-filter-with-exists-expressions).
 
 ## Subquery expressions (EXISTS, COUNT, COLLECT)
 
 `EXISTS { … }` tests whether a subquery body produces any rows, `COUNT { … }` returns how many it
 produces, and `COLLECT { … }` gathers its single return column into a list. All three run the body once
-per row of the enclosing query, may correlate with the enclosing query's variables, and are accepted in a
-`WITH`/`RETURN` projection, a `WHERE`, an `ORDER BY`, a `CASE` and an aggregation argument. See
-[Subquery expressions](/querying/subquery-expressions).
+per row of the enclosing query and may correlate with the enclosing query's variables. See [Subquery
+expressions](/querying/subquery-expressions) for the positions they are accepted in and the rules their
+bodies follow.
 
 For `EXISTS` used specifically as a filter, see [Existential subqueries in
 WHERE](/querying/clauses/where#4-existential-subqueries).

--- a/pages/querying/expressions.mdx
+++ b/pages/querying/expressions.mdx
@@ -212,7 +212,7 @@ The [`exists()`](/querying/functions#pattern-functions) function and the `EXISTS
 
 `exists(pattern)` is a short form for a simple pattern existence check. It is accepted in the same
 positions as `EXISTS { … }` — see [where you can use a subquery
-expression](/querying/subquery-expressions#4-where-you-can-use-a-subquery-expression). For a
+expression](/querying/subquery-expressions#where-you-can-use-a-subquery-expression). For a
 dataset-backed example, see [Filter with EXISTS
 expressions](/querying/clauses/where#17-filter-with-exists-expressions).
 

--- a/pages/querying/functions.mdx
+++ b/pages/querying/functions.mdx
@@ -77,7 +77,7 @@ This section contains the list of supported functions.
 ### Pattern functions
  | Name            | Signature                                                                                      | Description                                                                                                                                                                                                                                  |
  | --------------- | ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
- | `exists`           | `exists(pattern: Pattern)`                                                                  | Checks if a pattern exists as part of the filtering clause. Symbols provided in the MATCH clause can also be used here. The function can be used only with the [`WHERE` clause](/querying/clauses/where#17-filter-with-pattern-expressions). |
+ | `exists`           | `exists(pattern: Pattern)`                                                                  | Checks if a pattern exists. Symbols provided in the MATCH clause can also be used here. Accepted in a `WHERE`, a `WITH`/`RETURN` projection, an `ORDER BY`, a `CASE` and an aggregation argument &mdash; see [subquery expressions](/querying/subquery-expressions#5-where-you-can-use-a-subquery-expression). |
 
  ### Lists
 

--- a/pages/querying/functions.mdx
+++ b/pages/querying/functions.mdx
@@ -77,7 +77,7 @@ This section contains the list of supported functions.
 ### Pattern functions
  | Name            | Signature                                                                                      | Description                                                                                                                                                                                                                                  |
  | --------------- | ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
- | `exists`           | `exists(pattern: Pattern)`                                                                  | Checks if a pattern exists. Symbols provided in the MATCH clause can also be used here. Accepted in a `WHERE`, a `WITH`/`RETURN` projection, an `ORDER BY`, a `CASE` and an aggregation argument &mdash; see [subquery expressions](/querying/subquery-expressions#4-where-you-can-use-a-subquery-expression). |
+ | `exists`           | `exists(pattern: Pattern)`                                                                  | Checks if a pattern exists. Symbols provided in the MATCH clause can also be used here. Accepted in the same positions as `EXISTS { … }` — see [where you can use a subquery expression](/querying/subquery-expressions#4-where-you-can-use-a-subquery-expression). |
 
  ### Lists
 

--- a/pages/querying/functions.mdx
+++ b/pages/querying/functions.mdx
@@ -77,7 +77,7 @@ This section contains the list of supported functions.
 ### Pattern functions
  | Name            | Signature                                                                                      | Description                                                                                                                                                                                                                                  |
  | --------------- | ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
- | `exists`           | `exists(pattern: Pattern)`                                                                  | Checks if a pattern exists. Symbols provided in the MATCH clause can also be used here. Accepted in a `WHERE`, a `WITH`/`RETURN` projection, an `ORDER BY`, a `CASE` and an aggregation argument &mdash; see [subquery expressions](/querying/subquery-expressions#5-where-you-can-use-a-subquery-expression). |
+ | `exists`           | `exists(pattern: Pattern)`                                                                  | Checks if a pattern exists. Symbols provided in the MATCH clause can also be used here. Accepted in a `WHERE`, a `WITH`/`RETURN` projection, an `ORDER BY`, a `CASE` and an aggregation argument &mdash; see [subquery expressions](/querying/subquery-expressions#4-where-you-can-use-a-subquery-expression). |
 
  ### Lists
 

--- a/pages/querying/functions.mdx
+++ b/pages/querying/functions.mdx
@@ -77,7 +77,7 @@ This section contains the list of supported functions.
 ### Pattern functions
  | Name            | Signature                                                                                      | Description                                                                                                                                                                                                                                  |
  | --------------- | ---------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
- | `exists`           | `exists(pattern: Pattern)`                                                                  | Checks if a pattern exists. Symbols provided in the MATCH clause can also be used here. Accepted in the same positions as `EXISTS { … }` — see [where you can use a subquery expression](/querying/subquery-expressions#4-where-you-can-use-a-subquery-expression). |
+ | `exists`           | `exists(pattern: Pattern)`                                                                  | Checks if a pattern exists. Symbols provided in the MATCH clause can also be used here. Accepted in the same positions as `EXISTS { … }` — see [where you can use a subquery expression](/querying/subquery-expressions#where-you-can-use-a-subquery-expression). |
 
  ### Lists
 

--- a/pages/querying/subquery-expressions.mdx
+++ b/pages/querying/subquery-expressions.mdx
@@ -24,45 +24,44 @@ A subquery body can reference variables of the enclosing query, which makes it
 *correlated* — it is re-evaluated per row against the values that row holds.
 Variables the body introduces stay inside the body.
 
-- [EXISTS](#exists) — and [how it compares with a pattern expression](#exists-versus-a-pattern-expression)<br />
-- [COUNT](#count)<br />
-- [COLLECT](#collect) — and [how it compares with `collect()`](#collect-compared-with-collect)<br />
-- [Where you can use a subquery expression](#where-you-can-use-a-subquery-expression)<br />
-- [The subquery body](#the-subquery-body) — [clauses](#supported-clauses),
-  [correlation](#correlation-with-the-enclosing-query), [the body's
-  RETURN](#the-bodys-return-decides-the-result), [UNION](#union)<br />
-- [Nesting](#nesting)
-
 ## Dataset
 
 The examples on this page run against a small graph of `Person` nodes joined by `KNOWS`, and `Movie`
 nodes they are joined to by `ACTED_IN`. Only some of the people have a `nickname`. You can create it locally by executing the queries at the end of
 the page: [Dataset queries](#dataset-queries).
 
-## EXISTS
+## The three side by side
 
-`EXISTS { … }` is `true` when its body produces at least one row.
+The same body, reduced three ways. Carol and Dave match nothing, so each
+expression falls back to its empty value rather than to `null`:
 
 ```cypher
 MATCH (p:Person)
-RETURN p.name AS name, EXISTS { MATCH (p)-[:ACTED_IN]->(m:Movie) } AS acted
+RETURN p.name AS name,
+       EXISTS  { MATCH (p)-[:ACTED_IN]->(m) }                AS acted,
+       COUNT   { MATCH (p)-[:ACTED_IN]->(m) }                AS credits,
+       COLLECT { MATCH (p)-[:ACTED_IN]->(m) RETURN m.title } AS titles
 ORDER BY name;
 ```
 
 Output:
 
 ```nocopy
-+---------+-------+
-| name    | acted |
-+---------+-------+
-| "Alice" | true  |
-| "Bob"   | true  |
-| "Carol" | false |
-| "Dave"  | false |
-+---------+-------+
++---------+-------+---------+----------------------------------------------+
+| name    | acted | credits | titles                                       |
++---------+-------+---------+----------------------------------------------+
+| "Alice" | true  | 3       | ["The Matrix", "Johnny Mnemonic", "Jumanji"] |
+| "Bob"   | true  | 1       | ["Jumanji"]                                  |
+| "Carol" | false | 0       | []                                           |
+| "Dave"  | false | 0       | []                                           |
++---------+-------+---------+----------------------------------------------+
 ```
 
-Used as a filter, with `NOT` to invert it:
+## EXISTS
+
+`EXISTS { … }` is `true` when its body produces at least one row. Over a single
+pattern it can be written as a [bare pattern](#the-bare-pattern-shorthand). With
+`NOT` it filters for the absence of a match:
 
 ```cypher
 MATCH (p:Person)
@@ -82,28 +81,6 @@ Output:
 +---------+
 ```
 
-`EXISTS` also accepts a bare pattern instead of a full body, which is a shorter
-way to write the same existence check. The pattern cannot introduce names of its
-own — a variable already bound outside may appear in it, and acts as a join:
-
-```cypher
-MATCH (p:Person)
-WHERE EXISTS { (p)-[:KNOWS]->() }
-RETURN p.name AS name
-ORDER BY name;
-```
-
-Output:
-
-```nocopy
-+---------+
-| name    |
-+---------+
-| "Alice" |
-| "Bob"   |
-+---------+
-```
-
 ### EXISTS versus a pattern expression
 
 The [`exists(pattern)` function](/querying/functions#pattern-functions) and a bare
@@ -117,27 +94,8 @@ subqueries](/querying/clauses/where#4-existential-subqueries).
 
 ## COUNT
 
-`COUNT { … }` returns the number of rows its body produces.
-
-```cypher
-MATCH (p:Person)
-RETURN p.name AS name, COUNT { MATCH (p)-[:KNOWS]->(f) } AS friends
-ORDER BY name;
-```
-
-Output:
-
-```nocopy
-+---------+---------+
-| name    | friends |
-+---------+---------+
-| "Alice" | 2       |
-| "Bob"   | 1       |
-| "Carol" | 0       |
-| "Dave"  | 0       |
-+---------+---------+
-```
-
+`COUNT { … }` returns the number of rows its body produces, and over a single
+pattern it can be written as a [bare pattern](#the-bare-pattern-shorthand).
 Because the result is an integer, it can be compared directly in a `WHERE`:
 
 ```cypher
@@ -155,27 +113,6 @@ Output:
 +---------+
 | "Alice" |
 +---------+
-```
-
-`COUNT` accepts the same bare-pattern form as `EXISTS`:
-
-```cypher
-MATCH (p:Person)
-RETURN p.name AS name, COUNT { (p)-[:ACTED_IN]->() } AS movies
-ORDER BY name;
-```
-
-Output:
-
-```nocopy
-+---------+--------+
-| name    | movies |
-+---------+--------+
-| "Alice" | 3      |
-| "Bob"   | 1      |
-| "Carol" | 0      |
-| "Dave"  | 0      |
-+---------+--------+
 ```
 
 `DISTINCT` in the body counts distinct rows. Alice acted in three movies, but
@@ -210,26 +147,6 @@ comprehension](/querying/expressions#pattern-comprehension) with
 `COLLECT { … }` returns the body's single return column as a list, in the order
 the body produced its rows. Its body must end in a `RETURN` of exactly one
 column.
-
-```cypher
-MATCH (p:Person)
-RETURN p.name AS name,
-       COLLECT { MATCH (p)-[:ACTED_IN]->(m) RETURN m.title } AS titles
-ORDER BY name;
-```
-
-Output:
-
-```nocopy
-+---------+----------------------------------------------+
-| name    | titles                                       |
-+---------+----------------------------------------------+
-| "Alice" | ["The Matrix", "Johnny Mnemonic", "Jumanji"] |
-| "Bob"   | ["Jumanji"]                                  |
-| "Carol" | []                                           |
-| "Dave"  | []                                           |
-+---------+----------------------------------------------+
-```
 
 Because the body's own order becomes the list's order, `ORDER BY` inside the body
 sorts the list:
@@ -277,31 +194,6 @@ Output:
 | "Carol" | []                  |
 | "Dave"  | []                  |
 +---------+---------------------+
-```
-
-`DISTINCT` deduplicates the list:
-
-```cypher
-MATCH (p:Person)
-RETURN p.name AS name,
-       COLLECT {
-         MATCH (p)-[:ACTED_IN]->(m)
-         RETURN DISTINCT m.released ORDER BY m.released
-       } AS years
-ORDER BY name;
-```
-
-Output:
-
-```nocopy
-+---------+--------------+
-| name    | years        |
-+---------+--------------+
-| "Alice" | [1995, 1999] |
-| "Bob"   | [1995]       |
-| "Carol" | []           |
-| "Dave"  | []           |
-+---------+--------------+
 ```
 
 ### COLLECT compared with collect()
@@ -506,6 +398,39 @@ Output:
 | "Alice" |
 +---------+
 ```
+
+### The bare pattern shorthand
+
+`EXISTS` and `COUNT` accept a bare pattern in place of a full body, which is a
+shorter way to write a check or a count over one pattern. The pattern cannot
+introduce names of its own — a variable already bound outside may appear in it,
+and acts as a join:
+
+```cypher
+MATCH (p:Person)
+RETURN p.name AS name,
+       EXISTS { (p)-[:KNOWS]->() } AS knows,
+       COUNT  { (p)-[:ACTED_IN]->() } AS credits
+ORDER BY name;
+```
+
+Output:
+
+```nocopy
++---------+-------+---------+
+| name    | knows | credits |
++---------+-------+---------+
+| "Alice" | true  | 3       |
+| "Bob"   | true  | 1       |
+| "Carol" | false | 0       |
+| "Dave"  | false | 0       |
++---------+-------+---------+
+```
+
+The shorthand holds a pattern and nothing else, so a filter or any other clause
+needs the `MATCH` form — `COUNT { MATCH (p)-[r:KNOWS]->() WHERE r.since < 2015 }`.
+`COLLECT` has no shorthand, since a bare pattern returns no column for it to
+gather.
 
 ### Correlation with the enclosing query
 

--- a/pages/querying/subquery-expressions.mdx
+++ b/pages/querying/subquery-expressions.mdx
@@ -86,8 +86,8 @@ Output:
 ```
 
 `EXISTS` also accepts a bare pattern instead of a full body, which is a shorter
-way to write the same existence check. The nodes and relationships in it stay
-anonymous:
+way to write the same existence check. The pattern cannot introduce names of its
+own — a variable already bound outside may appear in it, and acts as a join:
 
 ```cypher
 MATCH (p:Person)
@@ -116,8 +116,7 @@ for `EXISTS { … }` when the check needs a `WHERE`, a `WITH` with an aggregatio
 or more than one pattern part — as in [section 5.1](#51-supported-clauses).
 
 For `EXISTS` as a filter in the `WHERE` clause, see also [Existential
-subqueries](/querying/clauses/where#4-existential-subqueries) and [Filter with
-EXISTS expressions](/querying/clauses/where#17-filter-with-exists-expressions).
+subqueries](/querying/clauses/where#4-existential-subqueries).
 
 ## 2. COUNT
 
@@ -265,22 +264,22 @@ MATCH (p:Person)
 RETURN p.name AS name,
        COLLECT {
          MATCH (p)-[:ACTED_IN]->(m)
-         RETURN m.title ORDER BY m.released DESC LIMIT 1
-       } AS newest
+         RETURN m.title ORDER BY m.title LIMIT 1
+       } AS first
 ORDER BY name;
 ```
 
 Output:
 
 ```nocopy
-+---------+----------------+
-| name    | newest         |
-+---------+----------------+
-| "Alice" | ["The Matrix"] |
-| "Bob"   | ["Jumanji"]    |
-| "Carol" | []             |
-| "Dave"  | []             |
-+---------+----------------+
++---------+---------------------+
+| name    | first               |
++---------+---------------------+
+| "Alice" | ["Johnny Mnemonic"] |
+| "Bob"   | ["Jumanji"]         |
+| "Carol" | []                  |
+| "Dave"  | []                  |
++---------+---------------------+
 ```
 
 `DISTINCT` deduplicates the list:
@@ -322,14 +321,13 @@ positions:
 - an `ORDER BY`
 - a [`CASE` expression](/querying/expressions#case)
 - an argument of an [aggregation function](/querying/functions#aggregation-functions)
-- a per-element predicate such as `all()`, `any()`, `none()` or `single()`
 
-Ordering on one:
+Ordering on one — fewest credits first:
 
 ```cypher
 MATCH (p:Person)
 RETURN p.name AS name
-ORDER BY COUNT { MATCH (p)-[:ACTED_IN]->() } DESC, name;
+ORDER BY COUNT { MATCH (p)-[:ACTED_IN]->() } ASC, name;
 ```
 
 Output:
@@ -338,10 +336,10 @@ Output:
 +---------+
 | name    |
 +---------+
-| "Alice" |
-| "Bob"   |
 | "Carol" |
 | "Dave"  |
+| "Bob"   |
+| "Alice" |
 +---------+
 ```
 
@@ -388,8 +386,9 @@ Output:
 
 ### 5.1. Supported clauses
 
-A body may use `MATCH`, `WHERE`, `WITH`, `RETURN` and `UNION`. A subquery
-expression is read-only, so the body does not write to the graph.
+A body is a read-only query — it never writes to the graph. It matches with
+`MATCH`, filters with `WHERE`, aggregates through `WITH`, and may end in a
+`RETURN`; it may also be a [`UNION`](#54-union) of such branches.
 
 `WITH` lets the body aggregate and then filter on the aggregate — here, people
 who acted in at least two movies:
@@ -437,7 +436,8 @@ Output:
 ### 5.2. Correlation with the enclosing query
 
 Variables of the enclosing query are visible throughout the body, including after
-a `WITH` inside it, and including in the body's `WHERE` alone:
+a `WITH` inside it. The correlation may live in the body's `WHERE` rather than in
+its pattern:
 
 ```cypher
 MATCH (p:Person)
@@ -480,33 +480,6 @@ Output:
 Variables introduced inside the body are scoped to it and are not available after
 the subquery expression.
 
-A body may also introduce a variable with the same name as one from the enclosing
-query, which shadows it: inside the body, the name refers to the inner value.
-Below, the outer `name` selects the people who know Carol, and the inner `name`
-asks which of them also know Bob:
-
-```cypher
-WITH 'Carol' AS name
-MATCH (p:Person)-[:KNOWS]->(f:Person {name: name})
-WHERE EXISTS {
-  WITH 'Bob' AS name
-  MATCH (p)-[:KNOWS]->(g)
-  WHERE g.name = name
-}
-RETURN p.name AS person
-ORDER BY person;
-```
-
-Output:
-
-```nocopy
-+---------+
-| person  |
-+---------+
-| "Alice" |
-+---------+
-```
-
 ### 5.3. The body's RETURN decides the result
 
 The body is a query, and its final `RETURN` shapes the row set that the
@@ -544,8 +517,9 @@ needs a column to gather.
 
 ### 5.4. UNION
 
-A body may be a `UNION` of branches, and the expression reduces over the rows of
-all of them together:
+A body may be a `UNION` of branches. `UNION` reduces over the branches' rows with
+duplicates removed, while `UNION ALL` keeps every row — so for `COUNT` and
+`COLLECT` the choice decides the answer:
 
 ```cypher
 MATCH (p:Person)
@@ -571,25 +545,47 @@ Output:
 +---------+---------+
 ```
 
-For `COLLECT`, every branch returns its one column under the same name:
+Every branch must return its one column under the same name. Alice and Bob both
+know Carol, so `UNION` reports her once:
 
 ```cypher
 MATCH (p:Person {name: 'Alice'})
 RETURN COLLECT {
          MATCH (p)-[:KNOWS]->(f) RETURN f.name AS n
          UNION
-         MATCH (p)-[:ACTED_IN]->(m) RETURN m.title AS n
-       } AS related;
+         MATCH (:Person {name: 'Bob'})-[:KNOWS]->(f) RETURN f.name AS n
+       } AS people;
 ```
 
 Output:
 
 ```nocopy
-+--------------------------------------------------------------+
-| related                                                      |
-+--------------------------------------------------------------+
-| ["Bob", "Carol", "The Matrix", "Johnny Mnemonic", "Jumanji"] |
-+--------------------------------------------------------------+
++------------------+
+| people           |
++------------------+
+| ["Bob", "Carol"] |
++------------------+
+```
+
+The same body with `UNION ALL` keeps the repeat:
+
+```cypher
+MATCH (p:Person {name: 'Alice'})
+RETURN COLLECT {
+         MATCH (p)-[:KNOWS]->(f) RETURN f.name AS n
+         UNION ALL
+         MATCH (:Person {name: 'Bob'})-[:KNOWS]->(f) RETURN f.name AS n
+       } AS people;
+```
+
+Output:
+
+```nocopy
++---------------------------+
+| people                    |
++---------------------------+
+| ["Bob", "Carol", "Carol"] |
++---------------------------+
 ```
 
 ## 6. Nesting
@@ -648,6 +644,8 @@ We encourage you to try out the examples by yourself.
 You can get the dataset locally by executing the following query block.
 
 ```cypher
+MATCH (n) DETACH DELETE n;
+
 CREATE (alice:Person {name: 'Alice'});
 CREATE (bob:Person {name: 'Bob'});
 CREATE (carol:Person {name: 'Carol'});

--- a/pages/querying/subquery-expressions.mdx
+++ b/pages/querying/subquery-expressions.mdx
@@ -24,25 +24,22 @@ A subquery body can reference variables of the enclosing query, which makes it
 *correlated* — it is re-evaluated per row against the values that row holds.
 Variables the body introduces stay inside the body.
 
-1. [EXISTS](#1-exists)<br />
-   1.1. [EXISTS versus a pattern expression](#11-exists-versus-a-pattern-expression)<br />
-2. [COUNT](#2-count)<br />
-3. [COLLECT](#3-collect)<br />
-4. [Where you can use a subquery expression](#4-where-you-can-use-a-subquery-expression)<br />
-5. [The subquery body](#5-the-subquery-body)<br />
-   5.1. [Supported clauses](#51-supported-clauses)<br />
-   5.2. [Correlation with the enclosing query](#52-correlation-with-the-enclosing-query)<br />
-   5.3. [The body's RETURN decides the result](#53-the-bodys-return-decides-the-result)<br />
-   5.4. [UNION](#54-union)<br />
-6. [Nesting](#6-nesting)
+- [EXISTS](#exists) — and [how it compares with a pattern expression](#exists-versus-a-pattern-expression)<br />
+- [COUNT](#count)<br />
+- [COLLECT](#collect) — and [how it compares with `collect()`](#collect-compared-with-collect)<br />
+- [Where you can use a subquery expression](#where-you-can-use-a-subquery-expression)<br />
+- [The subquery body](#the-subquery-body) — [clauses](#supported-clauses),
+  [correlation](#correlation-with-the-enclosing-query), [the body's
+  RETURN](#the-bodys-return-decides-the-result), [UNION](#union)<br />
+- [Nesting](#nesting)
 
 ## Dataset
 
 The examples on this page run against a small graph of `Person` nodes joined by `KNOWS`, and `Movie`
-nodes they are joined to by `ACTED_IN`. You can create it locally by executing the queries at the end of
+nodes they are joined to by `ACTED_IN`. Only some of the people have a `nickname`. You can create it locally by executing the queries at the end of
 the page: [Dataset queries](#dataset-queries).
 
-## 1. EXISTS
+## EXISTS
 
 `EXISTS { … }` is `true` when its body produces at least one row.
 
@@ -107,18 +104,18 @@ Output:
 +---------+
 ```
 
-### 1.1. EXISTS versus a pattern expression
+### EXISTS versus a pattern expression
 
 The [`exists(pattern)` function](/querying/functions#pattern-functions) and a bare
 pattern filter such as `MATCH (n) WHERE (n)-->()` are convenient for a simple
 existence check, but a pattern on its own cannot carry additional clauses. Reach
 for `EXISTS { … }` when the check needs a `WHERE`, a `WITH` with an aggregation,
-or more than one pattern part — as in [section 5.1](#51-supported-clauses).
+or more than one pattern part — as in [supported clauses](#supported-clauses).
 
 For `EXISTS` as a filter in the `WHERE` clause, see also [Existential
 subqueries](/querying/clauses/where#4-existential-subqueries).
 
-## 2. COUNT
+## COUNT
 
 `COUNT { … }` returns the number of rows its body produces.
 
@@ -208,7 +205,7 @@ Prefer `COUNT { … }` to counting a [pattern
 comprehension](/querying/expressions#pattern-comprehension) with
 `size([(p)-[:KNOWS]->(f) | f])`, which builds the whole list before measuring it.
 
-## 3. COLLECT
+## COLLECT
 
 `COLLECT { … }` returns the body's single return column as a list, in the order
 the body produced its rows. Its body must end in a `RETURN` of exactly one
@@ -307,11 +304,66 @@ Output:
 +---------+--------------+
 ```
 
+### COLLECT compared with collect()
+
+`COLLECT { … }` gathers every row its body returns, including the rows whose
+value is `null`. The [`collect()` aggregation
+function](/querying/functions#aggregation-functions) drops them. Two of the four
+people have a `nickname`:
+
+```cypher
+MATCH (p:Person)
+RETURN collect(p.nickname) AS nicknames;
+```
+
+Output:
+
+```nocopy
++-----------------+
+| nicknames       |
++-----------------+
+| ["Al", "Bobby"] |
++-----------------+
+```
+
+```cypher
+RETURN COLLECT { MATCH (p:Person) RETURN p.nickname ORDER BY p.name } AS nicknames;
+```
+
+Output:
+
+```nocopy
++-----------------------------+
+| nicknames                   |
++-----------------------------+
+| ["Al", "Bobby", Null, Null] |
++-----------------------------+
+```
+
+Filter in the body to leave them out:
+
+```cypher
+RETURN COLLECT {
+         MATCH (p:Person) WHERE p.nickname IS NOT NULL
+         RETURN p.nickname ORDER BY p.name
+       } AS nicknames;
+```
+
+Output:
+
+```nocopy
++-----------------+
+| nicknames       |
++-----------------+
+| ["Al", "Bobby"] |
++-----------------+
+```
+
 The `COLLECT` keyword does not reserve the name: `collect` remains usable as a
 variable, alias, property key and label, and `collect(x)` remains the [list
 aggregation function](/querying/functions#aggregation-functions).
 
-## 4. Where you can use a subquery expression
+## Where you can use a subquery expression
 
 `EXISTS { … }`, `COUNT { … }` and `COLLECT { … }` are accepted in the same
 positions:
@@ -365,6 +417,28 @@ Output:
 +---------+---------+
 ```
 
+A subquery expression in a projection alongside an aggregation becomes part of the
+grouping key, so it decides how the rows are grouped — here, people grouped by how
+many credits they have:
+
+```cypher
+MATCH (p:Person)
+RETURN COUNT { (p)-[:ACTED_IN]->() } AS credits, collect(p.name) AS people
+ORDER BY credits;
+```
+
+Output:
+
+```nocopy
++---------+-------------------+
+| credits | people            |
++---------+-------------------+
+| 0       | ["Carol", "Dave"] |
+| 1       | ["Bob"]           |
+| 3       | ["Alice"]         |
++---------+-------------------+
+```
+
 As an aggregation argument:
 
 ```cypher
@@ -382,13 +456,13 @@ Output:
 +-------+
 ```
 
-## 5. The subquery body
+## The subquery body
 
-### 5.1. Supported clauses
+### Supported clauses
 
 A body is a read-only query — it never writes to the graph. It matches with
 `MATCH`, filters with `WHERE`, aggregates through `WITH`, and may end in a
-`RETURN`; it may also be a [`UNION`](#54-union) of such branches.
+`RETURN`; it may also be a [`UNION`](#union) of such branches.
 
 `WITH` lets the body aggregate and then filter on the aggregate — here, people
 who acted in at least two movies:
@@ -433,7 +507,7 @@ Output:
 +---------+
 ```
 
-### 5.2. Correlation with the enclosing query
+### Correlation with the enclosing query
 
 Variables of the enclosing query are visible throughout the body, including after
 a `WITH` inside it. The correlation may live in the body's `WHERE` rather than in
@@ -480,7 +554,7 @@ Output:
 Variables introduced inside the body are scoped to it and are not available after
 the subquery expression.
 
-### 5.3. The body's RETURN decides the result
+### The body's RETURN decides the result
 
 The body is a query, and its final `RETURN` shapes the row set that the
 expression reduces. `DISTINCT`, `SKIP`, `LIMIT` and aggregation in the body all
@@ -510,12 +584,12 @@ Output:
 ```
 
 To test whether anything matched, leave the aggregation out and let the `MATCH`
-decide, as in [section 1](#1-exists).
+decide, as in the [EXISTS section](#exists).
 
 `EXISTS` and `COUNT` do not require a `RETURN` at all; `COLLECT` does, because it
 needs a column to gather.
 
-### 5.4. UNION
+### UNION
 
 A body may be a `UNION` of branches. `UNION` reduces over the branches' rows with
 duplicates removed, while `UNION ALL` keeps every row — so for `COUNT` and
@@ -588,7 +662,7 @@ Output:
 +---------------------------+
 ```
 
-## 6. Nesting
+## Nesting
 
 A body may itself contain subquery expressions. Here `EXISTS` filters on a nested
 `EXISTS` — people who know an actor:
@@ -646,8 +720,8 @@ You can get the dataset locally by executing the following query block.
 ```cypher
 MATCH (n) DETACH DELETE n;
 
-CREATE (alice:Person {name: 'Alice'});
-CREATE (bob:Person {name: 'Bob'});
+CREATE (alice:Person {name: 'Alice', nickname: 'Al'});
+CREATE (bob:Person {name: 'Bob', nickname: 'Bobby'});
 CREATE (carol:Person {name: 'Carol'});
 CREATE (dave:Person {name: 'Dave'});
 CREATE (:Movie {title: 'The Matrix', released: 1999});

--- a/pages/querying/subquery-expressions.mdx
+++ b/pages/querying/subquery-expressions.mdx
@@ -24,48 +24,25 @@ A subquery body can reference variables of the enclosing query, which makes it
 *correlated* — it is re-evaluated per row against the values that row holds.
 Variables the body introduces stay inside the body.
 
-1. [Dataset](#dataset)<br />
-2. [EXISTS](#2-exists)<br />
-   2.1. [EXISTS versus a pattern expression](#21-exists-versus-a-pattern-expression)<br />
-3. [COUNT](#3-count)<br />
-4. [COLLECT](#4-collect)<br />
-5. [Where you can use a subquery expression](#5-where-you-can-use-a-subquery-expression)<br />
-6. [The subquery body](#6-the-subquery-body)<br />
-   6.1. [Supported clauses](#61-supported-clauses)<br />
-   6.2. [Correlation with the enclosing query](#62-correlation-with-the-enclosing-query)<br />
-   6.3. [The body's RETURN decides the result](#63-the-bodys-return-decides-the-result)<br />
-   6.4. [UNION](#64-union)<br />
-7. [Nesting](#7-nesting)
+1. [EXISTS](#1-exists)<br />
+   1.1. [EXISTS versus a pattern expression](#11-exists-versus-a-pattern-expression)<br />
+2. [COUNT](#2-count)<br />
+3. [COLLECT](#3-collect)<br />
+4. [Where you can use a subquery expression](#4-where-you-can-use-a-subquery-expression)<br />
+5. [The subquery body](#5-the-subquery-body)<br />
+   5.1. [Supported clauses](#51-supported-clauses)<br />
+   5.2. [Correlation with the enclosing query](#52-correlation-with-the-enclosing-query)<br />
+   5.3. [The body's RETURN decides the result](#53-the-bodys-return-decides-the-result)<br />
+   5.4. [UNION](#54-union)<br />
+6. [Nesting](#6-nesting)
 
 ## Dataset
 
-The examples on this page run against the following dataset:
+The examples on this page run against a small graph of `Person` nodes joined by `KNOWS`, and `Movie`
+nodes they are joined to by `ACTED_IN`. You can create it locally by executing the queries at the end of
+the page: [Dataset queries](#dataset-queries).
 
-```cypher
-CREATE (alice:Person {name: 'Alice'});
-CREATE (bob:Person {name: 'Bob'});
-CREATE (carol:Person {name: 'Carol'});
-CREATE (dave:Person {name: 'Dave'});
-CREATE (:Movie {title: 'The Matrix', released: 1999});
-CREATE (:Movie {title: 'Jumanji', released: 1995});
-CREATE (:Movie {title: 'Johnny Mnemonic', released: 1995});
-MATCH (a:Person {name: 'Alice'}), (b:Person {name: 'Bob'})
-CREATE (a)-[:KNOWS {since: 2010}]->(b);
-MATCH (a:Person {name: 'Alice'}), (c:Person {name: 'Carol'})
-CREATE (a)-[:KNOWS {since: 2015}]->(c);
-MATCH (b:Person {name: 'Bob'}), (c:Person {name: 'Carol'})
-CREATE (b)-[:KNOWS {since: 2018}]->(c);
-MATCH (a:Person {name: 'Alice'}), (m:Movie {title: 'The Matrix'})
-CREATE (a)-[:ACTED_IN]->(m);
-MATCH (a:Person {name: 'Alice'}), (m:Movie {title: 'Johnny Mnemonic'})
-CREATE (a)-[:ACTED_IN]->(m);
-MATCH (a:Person {name: 'Alice'}), (m:Movie {title: 'Jumanji'})
-CREATE (a)-[:ACTED_IN]->(m);
-MATCH (b:Person {name: 'Bob'}), (m:Movie {title: 'Jumanji'})
-CREATE (b)-[:ACTED_IN]->(m);
-```
-
-## 2. EXISTS
+## 1. EXISTS
 
 `EXISTS { … }` is `true` when its body produces at least one row.
 
@@ -130,19 +107,19 @@ Output:
 +---------+
 ```
 
-### 2.1. EXISTS versus a pattern expression
+### 1.1. EXISTS versus a pattern expression
 
 The [`exists(pattern)` function](/querying/functions#pattern-functions) and a bare
 pattern filter such as `MATCH (n) WHERE (n)-->()` are convenient for a simple
 existence check, but a pattern on its own cannot carry additional clauses. Reach
 for `EXISTS { … }` when the check needs a `WHERE`, a `WITH` with an aggregation,
-or more than one pattern part — as in [section 6.1](#61-supported-clauses).
+or more than one pattern part — as in [section 5.1](#51-supported-clauses).
 
 For `EXISTS` as a filter in the `WHERE` clause, see also [Existential
 subqueries](/querying/clauses/where#4-existential-subqueries) and [Filter with
 EXISTS expressions](/querying/clauses/where#17-filter-with-exists-expressions).
 
-## 3. COUNT
+## 2. COUNT
 
 `COUNT { … }` returns the number of rows its body produces.
 
@@ -232,7 +209,7 @@ Prefer `COUNT { … }` to counting a [pattern
 comprehension](/querying/expressions#pattern-comprehension) with
 `size([(p)-[:KNOWS]->(f) | f])`, which builds the whole list before measuring it.
 
-## 4. COLLECT
+## 3. COLLECT
 
 `COLLECT { … }` returns the body's single return column as a list, in the order
 the body produced its rows. Its body must end in a `RETURN` of exactly one
@@ -335,7 +312,7 @@ The `COLLECT` keyword does not reserve the name: `collect` remains usable as a
 variable, alias, property key and label, and `collect(x)` remains the [list
 aggregation function](/querying/functions#aggregation-functions).
 
-## 5. Where you can use a subquery expression
+## 4. Where you can use a subquery expression
 
 `EXISTS { … }`, `COUNT { … }` and `COLLECT { … }` are accepted in the same
 positions:
@@ -407,9 +384,9 @@ Output:
 +-------+
 ```
 
-## 6. The subquery body
+## 5. The subquery body
 
-### 6.1. Supported clauses
+### 5.1. Supported clauses
 
 A body may use `MATCH`, `WHERE`, `WITH`, `RETURN` and `UNION`. A subquery
 expression is read-only, so the body does not write to the graph.
@@ -457,7 +434,7 @@ Output:
 +---------+
 ```
 
-### 6.2. Correlation with the enclosing query
+### 5.2. Correlation with the enclosing query
 
 Variables of the enclosing query are visible throughout the body, including after
 a `WITH` inside it, and including in the body's `WHERE` alone:
@@ -530,7 +507,7 @@ Output:
 +---------+
 ```
 
-### 6.3. The body's RETURN decides the result
+### 5.3. The body's RETURN decides the result
 
 The body is a query, and its final `RETURN` shapes the row set that the
 expression reduces. `DISTINCT`, `SKIP`, `LIMIT` and aggregation in the body all
@@ -560,12 +537,12 @@ Output:
 ```
 
 To test whether anything matched, leave the aggregation out and let the `MATCH`
-decide, as in [section 2](#2-exists).
+decide, as in [section 1](#1-exists).
 
 `EXISTS` and `COUNT` do not require a `RETURN` at all; `COLLECT` does, because it
 needs a column to gather.
 
-### 6.4. UNION
+### 5.4. UNION
 
 A body may be a `UNION` of branches, and the expression reduces over the rows of
 all of them together:
@@ -615,7 +592,7 @@ Output:
 +--------------------------------------------------------------+
 ```
 
-## 7. Nesting
+## 6. Nesting
 
 A body may itself contain subquery expressions. Here `EXISTS` filters on a nested
 `EXISTS` — people who know an actor:
@@ -663,6 +640,35 @@ Output:
 | "Carol" | []           |
 | "Dave"  | []           |
 +---------+--------------+
+```
+
+## Dataset queries
+
+We encourage you to try out the examples by yourself.
+You can get the dataset locally by executing the following query block.
+
+```cypher
+CREATE (alice:Person {name: 'Alice'});
+CREATE (bob:Person {name: 'Bob'});
+CREATE (carol:Person {name: 'Carol'});
+CREATE (dave:Person {name: 'Dave'});
+CREATE (:Movie {title: 'The Matrix', released: 1999});
+CREATE (:Movie {title: 'Jumanji', released: 1995});
+CREATE (:Movie {title: 'Johnny Mnemonic', released: 1995});
+MATCH (a:Person {name: 'Alice'}), (b:Person {name: 'Bob'})
+CREATE (a)-[:KNOWS {since: 2010}]->(b);
+MATCH (a:Person {name: 'Alice'}), (c:Person {name: 'Carol'})
+CREATE (a)-[:KNOWS {since: 2015}]->(c);
+MATCH (b:Person {name: 'Bob'}), (c:Person {name: 'Carol'})
+CREATE (b)-[:KNOWS {since: 2018}]->(c);
+MATCH (a:Person {name: 'Alice'}), (m:Movie {title: 'The Matrix'})
+CREATE (a)-[:ACTED_IN]->(m);
+MATCH (a:Person {name: 'Alice'}), (m:Movie {title: 'Johnny Mnemonic'})
+CREATE (a)-[:ACTED_IN]->(m);
+MATCH (a:Person {name: 'Alice'}), (m:Movie {title: 'Jumanji'})
+CREATE (a)-[:ACTED_IN]->(m);
+MATCH (b:Person {name: 'Bob'}), (m:Movie {title: 'Jumanji'})
+CREATE (b)-[:ACTED_IN]->(m);
 ```
 
 <CommunityLinks/>

--- a/pages/querying/subquery-expressions.mdx
+++ b/pages/querying/subquery-expressions.mdx
@@ -1,0 +1,668 @@
+---
+title: Subquery expressions
+description: Use EXISTS, COUNT and COLLECT subquery expressions to test, count or gather the rows of a subquery inline in a Cypher query, without leaving the clause you are writing.
+---
+
+import {CommunityLinks} from '/components/social-card/CommunityLinks'
+
+# Subquery expressions
+
+A subquery expression runs a query body once for every row of the enclosing query
+and reduces the rows that body produces to a single value. Memgraph supports three
+of them, which differ only in what they reduce to:
+
+| Expression      | Returns   | Body matched nothing |
+| --------------- | --------- | -------------------- |
+| `EXISTS { … }`  | Boolean   | `false`              |
+| `COUNT { … }`   | Integer   | `0`                  |
+| `COLLECT { … }` | List      | `[]`                 |
+
+None of them ever returns `null`, so the result is always safe to compare, sort or
+aggregate on.
+
+A subquery body can reference variables of the enclosing query, which makes it
+*correlated* — it is re-evaluated per row against the values that row holds.
+Variables the body introduces stay inside the body.
+
+1. [Dataset](#dataset)<br />
+2. [EXISTS](#2-exists)<br />
+   2.1. [EXISTS versus a pattern expression](#21-exists-versus-a-pattern-expression)<br />
+3. [COUNT](#3-count)<br />
+4. [COLLECT](#4-collect)<br />
+5. [Where you can use a subquery expression](#5-where-you-can-use-a-subquery-expression)<br />
+6. [The subquery body](#6-the-subquery-body)<br />
+   6.1. [Supported clauses](#61-supported-clauses)<br />
+   6.2. [Correlation with the enclosing query](#62-correlation-with-the-enclosing-query)<br />
+   6.3. [The body's RETURN decides the result](#63-the-bodys-return-decides-the-result)<br />
+   6.4. [UNION](#64-union)<br />
+7. [Nesting](#7-nesting)
+
+## Dataset
+
+The examples on this page run against the following dataset:
+
+```cypher
+CREATE (alice:Person {name: 'Alice'});
+CREATE (bob:Person {name: 'Bob'});
+CREATE (carol:Person {name: 'Carol'});
+CREATE (dave:Person {name: 'Dave'});
+CREATE (:Movie {title: 'The Matrix', released: 1999});
+CREATE (:Movie {title: 'Jumanji', released: 1995});
+CREATE (:Movie {title: 'Johnny Mnemonic', released: 1995});
+MATCH (a:Person {name: 'Alice'}), (b:Person {name: 'Bob'})
+CREATE (a)-[:KNOWS {since: 2010}]->(b);
+MATCH (a:Person {name: 'Alice'}), (c:Person {name: 'Carol'})
+CREATE (a)-[:KNOWS {since: 2015}]->(c);
+MATCH (b:Person {name: 'Bob'}), (c:Person {name: 'Carol'})
+CREATE (b)-[:KNOWS {since: 2018}]->(c);
+MATCH (a:Person {name: 'Alice'}), (m:Movie {title: 'The Matrix'})
+CREATE (a)-[:ACTED_IN]->(m);
+MATCH (a:Person {name: 'Alice'}), (m:Movie {title: 'Johnny Mnemonic'})
+CREATE (a)-[:ACTED_IN]->(m);
+MATCH (a:Person {name: 'Alice'}), (m:Movie {title: 'Jumanji'})
+CREATE (a)-[:ACTED_IN]->(m);
+MATCH (b:Person {name: 'Bob'}), (m:Movie {title: 'Jumanji'})
+CREATE (b)-[:ACTED_IN]->(m);
+```
+
+## 2. EXISTS
+
+`EXISTS { … }` is `true` when its body produces at least one row.
+
+```cypher
+MATCH (p:Person)
+RETURN p.name AS name, EXISTS { MATCH (p)-[:ACTED_IN]->(m:Movie) } AS acted
+ORDER BY name;
+```
+
+Output:
+
+```nocopy
++---------+-------+
+| name    | acted |
++---------+-------+
+| "Alice" | true  |
+| "Bob"   | true  |
+| "Carol" | false |
+| "Dave"  | false |
++---------+-------+
+```
+
+Used as a filter, with `NOT` to invert it:
+
+```cypher
+MATCH (p:Person)
+WHERE NOT EXISTS { MATCH (p)-[:KNOWS]->() }
+RETURN p.name AS name
+ORDER BY name;
+```
+
+Output:
+
+```nocopy
++---------+
+| name    |
++---------+
+| "Carol" |
+| "Dave"  |
++---------+
+```
+
+`EXISTS` also accepts a bare pattern instead of a full body, which is a shorter
+way to write the same existence check. The nodes and relationships in it stay
+anonymous:
+
+```cypher
+MATCH (p:Person)
+WHERE EXISTS { (p)-[:KNOWS]->() }
+RETURN p.name AS name
+ORDER BY name;
+```
+
+Output:
+
+```nocopy
++---------+
+| name    |
++---------+
+| "Alice" |
+| "Bob"   |
++---------+
+```
+
+### 2.1. EXISTS versus a pattern expression
+
+The [`exists(pattern)` function](/querying/functions#pattern-functions) and a bare
+pattern filter such as `MATCH (n) WHERE (n)-->()` are convenient for a simple
+existence check, but a pattern on its own cannot carry additional clauses. Reach
+for `EXISTS { … }` when the check needs a `WHERE`, a `WITH` with an aggregation,
+or more than one pattern part — as in [section 6.1](#61-supported-clauses).
+
+For `EXISTS` as a filter in the `WHERE` clause, see also [Existential
+subqueries](/querying/clauses/where#4-existential-subqueries) and [Filter with
+EXISTS expressions](/querying/clauses/where#17-filter-with-exists-expressions).
+
+## 3. COUNT
+
+`COUNT { … }` returns the number of rows its body produces.
+
+```cypher
+MATCH (p:Person)
+RETURN p.name AS name, COUNT { MATCH (p)-[:KNOWS]->(f) } AS friends
+ORDER BY name;
+```
+
+Output:
+
+```nocopy
++---------+---------+
+| name    | friends |
++---------+---------+
+| "Alice" | 2       |
+| "Bob"   | 1       |
+| "Carol" | 0       |
+| "Dave"  | 0       |
++---------+---------+
+```
+
+Because the result is an integer, it can be compared directly in a `WHERE`:
+
+```cypher
+MATCH (p:Person)
+WHERE COUNT { MATCH (p)-[:KNOWS]->(f) } > 1
+RETURN p.name AS name
+ORDER BY name;
+```
+
+Output:
+
+```nocopy
++---------+
+| name    |
++---------+
+| "Alice" |
++---------+
+```
+
+`COUNT` accepts the same bare-pattern form as `EXISTS`:
+
+```cypher
+MATCH (p:Person)
+RETURN p.name AS name, COUNT { (p)-[:ACTED_IN]->() } AS movies
+ORDER BY name;
+```
+
+Output:
+
+```nocopy
++---------+--------+
+| name    | movies |
++---------+--------+
+| "Alice" | 3      |
+| "Bob"   | 1      |
+| "Carol" | 0      |
+| "Dave"  | 0      |
++---------+--------+
+```
+
+`DISTINCT` in the body counts distinct rows. Alice acted in three movies, but
+they were released in two distinct years:
+
+```cypher
+MATCH (p:Person)
+RETURN p.name AS name,
+       COUNT { MATCH (p)-[:ACTED_IN]->(m) RETURN DISTINCT m.released } AS years
+ORDER BY name;
+```
+
+Output:
+
+```nocopy
++---------+-------+
+| name    | years |
++---------+-------+
+| "Alice" | 2     |
+| "Bob"   | 1     |
+| "Carol" | 0     |
+| "Dave"  | 0     |
++---------+-------+
+```
+
+Prefer `COUNT { … }` to counting a [pattern
+comprehension](/querying/expressions#pattern-comprehension) with
+`size([(p)-[:KNOWS]->(f) | f])`, which builds the whole list before measuring it.
+
+## 4. COLLECT
+
+`COLLECT { … }` returns the body's single return column as a list, in the order
+the body produced its rows. Its body must end in a `RETURN` of exactly one
+column.
+
+```cypher
+MATCH (p:Person)
+RETURN p.name AS name,
+       COLLECT { MATCH (p)-[:ACTED_IN]->(m) RETURN m.title } AS titles
+ORDER BY name;
+```
+
+Output:
+
+```nocopy
++---------+----------------------------------------------+
+| name    | titles                                       |
++---------+----------------------------------------------+
+| "Alice" | ["The Matrix", "Johnny Mnemonic", "Jumanji"] |
+| "Bob"   | ["Jumanji"]                                  |
+| "Carol" | []                                           |
+| "Dave"  | []                                           |
++---------+----------------------------------------------+
+```
+
+Because the body's own order becomes the list's order, `ORDER BY` inside the body
+sorts the list:
+
+```cypher
+MATCH (p:Person)
+RETURN p.name AS name,
+       COLLECT { MATCH (p)-[:ACTED_IN]->(m) RETURN m.title ORDER BY m.title } AS titles
+ORDER BY name;
+```
+
+Output:
+
+```nocopy
++---------+----------------------------------------------+
+| name    | titles                                       |
++---------+----------------------------------------------+
+| "Alice" | ["Johnny Mnemonic", "Jumanji", "The Matrix"] |
+| "Bob"   | ["Jumanji"]                                  |
+| "Carol" | []                                           |
+| "Dave"  | []                                           |
++---------+----------------------------------------------+
+```
+
+`SKIP` and `LIMIT` apply too, which is how you pick the top *n* per row:
+
+```cypher
+MATCH (p:Person)
+RETURN p.name AS name,
+       COLLECT {
+         MATCH (p)-[:ACTED_IN]->(m)
+         RETURN m.title ORDER BY m.released DESC LIMIT 1
+       } AS newest
+ORDER BY name;
+```
+
+Output:
+
+```nocopy
++---------+----------------+
+| name    | newest         |
++---------+----------------+
+| "Alice" | ["The Matrix"] |
+| "Bob"   | ["Jumanji"]    |
+| "Carol" | []             |
+| "Dave"  | []             |
++---------+----------------+
+```
+
+`DISTINCT` deduplicates the list:
+
+```cypher
+MATCH (p:Person)
+RETURN p.name AS name,
+       COLLECT {
+         MATCH (p)-[:ACTED_IN]->(m)
+         RETURN DISTINCT m.released ORDER BY m.released
+       } AS years
+ORDER BY name;
+```
+
+Output:
+
+```nocopy
++---------+--------------+
+| name    | years        |
++---------+--------------+
+| "Alice" | [1995, 1999] |
+| "Bob"   | [1995]       |
+| "Carol" | []           |
+| "Dave"  | []           |
++---------+--------------+
+```
+
+The `COLLECT` keyword does not reserve the name: `collect` remains usable as a
+variable, alias, property key and label, and `collect(x)` remains the [list
+aggregation function](/querying/functions#aggregation-functions).
+
+## 5. Where you can use a subquery expression
+
+`EXISTS { … }`, `COUNT { … }` and `COLLECT { … }` are accepted in the same
+positions:
+
+- a `WITH` or `RETURN` projection
+- a `WHERE`, whether it hangs off `MATCH`, `OPTIONAL MATCH` or `WITH`
+- an `ORDER BY`
+- a [`CASE` expression](/querying/expressions#case)
+- an argument of an [aggregation function](/querying/functions#aggregation-functions)
+- a per-element predicate such as `all()`, `any()`, `none()` or `single()`
+
+Ordering on one:
+
+```cypher
+MATCH (p:Person)
+RETURN p.name AS name
+ORDER BY COUNT { MATCH (p)-[:ACTED_IN]->() } DESC, name;
+```
+
+Output:
+
+```nocopy
++---------+
+| name    |
++---------+
+| "Alice" |
+| "Bob"   |
+| "Carol" |
+| "Dave"  |
++---------+
+```
+
+Inside a `CASE`:
+
+```cypher
+MATCH (p:Person)
+RETURN p.name AS name,
+       CASE WHEN EXISTS { MATCH (p)-[:ACTED_IN]->() } THEN 'actor' ELSE 'crew' END AS role
+ORDER BY name;
+```
+
+Output:
+
+```nocopy
++---------+---------+
+| name    | role    |
++---------+---------+
+| "Alice" | "actor" |
+| "Bob"   | "actor" |
+| "Carol" | "crew"  |
+| "Dave"  | "crew"  |
++---------+---------+
+```
+
+As an aggregation argument:
+
+```cypher
+MATCH (p:Person)
+RETURN sum(COUNT { MATCH (p)-[:KNOWS]->(f) }) AS total;
+```
+
+Output:
+
+```nocopy
++-------+
+| total |
++-------+
+| 3     |
++-------+
+```
+
+## 6. The subquery body
+
+### 6.1. Supported clauses
+
+A body may use `MATCH`, `WHERE`, `WITH`, `RETURN` and `UNION`. A subquery
+expression is read-only, so the body does not write to the graph.
+
+`WITH` lets the body aggregate and then filter on the aggregate — here, people
+who acted in at least two movies:
+
+```cypher
+MATCH (p:Person)
+WHERE EXISTS {
+  MATCH (p)-[:ACTED_IN]->(m)
+  WITH count(*) AS c
+  WHERE c >= 2
+}
+RETURN p.name AS name
+ORDER BY name;
+```
+
+Output:
+
+```nocopy
++---------+
+| name    |
++---------+
+| "Alice" |
++---------+
+```
+
+A `WHERE` in the body can test relationship properties:
+
+```cypher
+MATCH (p:Person)
+WHERE EXISTS { MATCH (p)-[r:KNOWS]->(f) WHERE r.since < 2015 }
+RETURN p.name AS name
+ORDER BY name;
+```
+
+Output:
+
+```nocopy
++---------+
+| name    |
++---------+
+| "Alice" |
++---------+
+```
+
+### 6.2. Correlation with the enclosing query
+
+Variables of the enclosing query are visible throughout the body, including after
+a `WITH` inside it, and including in the body's `WHERE` alone:
+
+```cypher
+MATCH (p:Person)
+RETURN p.name AS name,
+       COUNT { MATCH (f:Person) WHERE (p)-[:KNOWS]->(f) } AS friends
+ORDER BY name;
+```
+
+Output:
+
+```nocopy
++---------+---------+
+| name    | friends |
++---------+---------+
+| "Alice" | 2       |
+| "Bob"   | 1       |
+| "Carol" | 0       |
+| "Dave"  | 0       |
++---------+---------+
+```
+
+A body need not be correlated at all. An uncorrelated body produces the same
+value for every row:
+
+```cypher
+RETURN COUNT { MATCH (m:Movie) } AS movies,
+       COLLECT { MATCH (m:Movie) RETURN m.title ORDER BY m.title } AS titles;
+```
+
+Output:
+
+```nocopy
++--------+----------------------------------------------+
+| movies | titles                                       |
++--------+----------------------------------------------+
+| 3      | ["Johnny Mnemonic", "Jumanji", "The Matrix"] |
++--------+----------------------------------------------+
+```
+
+Variables introduced inside the body are scoped to it and are not available after
+the subquery expression.
+
+A body may also introduce a variable with the same name as one from the enclosing
+query, which shadows it: inside the body, the name refers to the inner value.
+Below, the outer `name` selects the people who know Carol, and the inner `name`
+asks which of them also know Bob:
+
+```cypher
+WITH 'Carol' AS name
+MATCH (p:Person)-[:KNOWS]->(f:Person {name: name})
+WHERE EXISTS {
+  WITH 'Bob' AS name
+  MATCH (p)-[:KNOWS]->(g)
+  WHERE g.name = name
+}
+RETURN p.name AS person
+ORDER BY person;
+```
+
+Output:
+
+```nocopy
++---------+
+| person  |
++---------+
+| "Alice" |
++---------+
+```
+
+### 6.3. The body's RETURN decides the result
+
+The body is a query, and its final `RETURN` shapes the row set that the
+expression reduces. `DISTINCT`, `SKIP`, `LIMIT` and aggregation in the body all
+count.
+
+This matters most for aggregation. An aggregating `RETURN` produces one row even
+when nothing matched, so an `EXISTS` over it is always `true`:
+
+```cypher
+MATCH (p:Person)
+RETURN p.name AS name,
+       EXISTS { MATCH (p)-[:ACTED_IN]->(m) RETURN count(m) } AS v
+ORDER BY name;
+```
+
+Output:
+
+```nocopy
++---------+------+
+| name    | v    |
++---------+------+
+| "Alice" | true |
+| "Bob"   | true |
+| "Carol" | true |
+| "Dave"  | true |
++---------+------+
+```
+
+To test whether anything matched, leave the aggregation out and let the `MATCH`
+decide, as in [section 2](#2-exists).
+
+`EXISTS` and `COUNT` do not require a `RETURN` at all; `COLLECT` does, because it
+needs a column to gather.
+
+### 6.4. UNION
+
+A body may be a `UNION` of branches, and the expression reduces over the rows of
+all of them together:
+
+```cypher
+MATCH (p:Person)
+RETURN p.name AS name,
+       COUNT {
+         MATCH (p)-[:KNOWS]->(x) RETURN x
+         UNION
+         MATCH (p)-[:ACTED_IN]->(x) RETURN x
+       } AS related
+ORDER BY name;
+```
+
+Output:
+
+```nocopy
++---------+---------+
+| name    | related |
++---------+---------+
+| "Alice" | 5       |
+| "Bob"   | 2       |
+| "Carol" | 0       |
+| "Dave"  | 0       |
++---------+---------+
+```
+
+For `COLLECT`, every branch returns its one column under the same name:
+
+```cypher
+MATCH (p:Person {name: 'Alice'})
+RETURN COLLECT {
+         MATCH (p)-[:KNOWS]->(f) RETURN f.name AS n
+         UNION
+         MATCH (p)-[:ACTED_IN]->(m) RETURN m.title AS n
+       } AS related;
+```
+
+Output:
+
+```nocopy
++--------------------------------------------------------------+
+| related                                                      |
++--------------------------------------------------------------+
+| ["Bob", "Carol", "The Matrix", "Johnny Mnemonic", "Jumanji"] |
++--------------------------------------------------------------+
+```
+
+## 7. Nesting
+
+A body may itself contain subquery expressions. Here `EXISTS` filters on a nested
+`EXISTS` — people who know an actor:
+
+```cypher
+MATCH (p:Person)
+WHERE EXISTS {
+  MATCH (p)-[:KNOWS]->(f)
+  WHERE EXISTS { MATCH (f)-[:ACTED_IN]->() }
+}
+RETURN p.name AS name
+ORDER BY name;
+```
+
+Output:
+
+```nocopy
++---------+
+| name    |
++---------+
+| "Alice" |
++---------+
+```
+
+They can also be combined, for example collecting a per-friend count:
+
+```cypher
+MATCH (p:Person)
+RETURN p.name AS name,
+       COLLECT {
+         MATCH (p)-[:KNOWS]->(f)
+         RETURN COUNT { (f)-[:ACTED_IN]->() } ORDER BY f.name
+       } AS friendMovies
+ORDER BY name;
+```
+
+Output:
+
+```nocopy
++---------+--------------+
+| name    | friendMovies |
++---------+--------------+
+| "Alice" | [1, 0]       |
+| "Bob"   | [0]          |
+| "Carol" | []           |
+| "Dave"  | []           |
++---------+--------------+
+```
+
+<CommunityLinks/>


### PR DESCRIPTION
### Release note

Documents the `EXISTS { … }`, `COUNT { … }` and `COLLECT { … }` subquery expressions shipped in 3.13.

A new [Subquery expressions](/querying/subquery-expressions) page covers all three together — they share
a body grammar, a set of accepted positions and a correlation model, and differ only in what they reduce
the body's rows to. It opens with one example putting all three on the same body, then documents each
construct, the bare-pattern shorthand, the positions all three are accepted in (`WITH`/`RETURN` projection, `WHERE`, `ORDER BY`, `CASE`, aggregation argument), the
body's supported clauses, correlation with the enclosing query, how the body's `RETURN` shapes the
result, `UNION` bodies, and nesting.

Alongside it, corrections to pages that contradicted the shipped behaviour:

- `COUNT` and `COLLECT` subqueries were listed under **Unsupported constructs** in *Differences in Cypher
  implementations*. Both entries are removed.
- `exists()` was documented as usable *only* with `WHERE`, and as unusable inside `CASE`. Neither holds —
  it is accepted in the same positions as `EXISTS { … }`. Corrected on the *Expressions* and *Functions*
  pages and in `WHERE` §1.7.
- `WHERE` §4 carried a six-part EXISTS guide that the new page now covers, so it keeps one filter example
  and points there; the heading stays so existing links to `#4-existential-subqueries` still resolve. Two
  of its subsections described behaviour the engine does not have, and the replacements on the new page
  are the corrected versions: a body `RETURN` is planned rather than discarded (so `DISTINCT`, `SKIP`,
  `LIMIT` and aggregation in the body decide the answer), and shadowing an outer-scope variable does not
  throw — the inner binding wins. The old shadowing example returned one row, not the two it printed.

The structure follows the reference's, which gives `EXISTS`, `COUNT` and `COLLECT` a home of their own
rather than filing them under a clause — except that it splits them across three pages and repeats about
a third of each, so the shared material (positions, body clauses, correlation, `UNION`, nesting) lives
here once. Net effect on the existing pages is 134 lines removed, plus the new page.

All 24 Cypher examples on the new page and their output blocks, and the example kept in `WHERE`, were
executed against a 3.13 build and compared cell by cell.

### Related product PRs

- memgraph/memgraph#4504 — `EXISTS` in `WITH`/`RETURN` projections, `WITH … WHERE` and `ORDER BY`
- memgraph/memgraph#4596 — `EXISTS` inside a `CASE` expression
- memgraph/memgraph#4598 — `COUNT { … }`
- memgraph/memgraph#4632 — `COLLECT { … }`

Three further PRs in the same stack are labelled `Docs - changelog only` and carry no doc link, but two
of them are why prose on the existing pages had to change: memgraph/memgraph#4597 made a body `RETURN`
decide the answer, and memgraph/memgraph#4560 fixed a body that plans to no operators.

### Checklist:

- [x] Add appropriate milestone (current release cycle)
- [x] Add `bugfix` or `feature` label, based on the product PR type you're documenting
- [ ] Make sure all relevant tech details are documented
    - [x] Update reference pages (e.g. [clauses](https://memgraph.com/docs/querying/clauses), [functions](https://memgraph.com/docs/querying/functions), [flags](https://memgraph.com/docs/database-management/configuration#list-of-configuration-flags), [experimental](https://memgraph.com/docs/database-management/experimental-features), [monitoring](https://memgraph.com/docs/database-management/monitoring), [Cypher differences](https://memgraph.com/docs/querying/differences-in-cypher-implementations))
    - [x] Search for the feature you are working on (mentions) and make updates if needed
    - [x] Provide a basic example of usage
    - [ ] In case your feature is an Enterprise one, list it under [ME page](https://memgraph.com/docs/database-management/enabling-memgraph-enterprise) and mark its page with Enterprise ([example](https://memgraph.com/docs/database-management/authentication-and-authorization/role-based-access-control))
- [ ] Check all content with Grammarly
- [x] Perform a self-review of my code
- [x] The build passes locally
- [x] My changes generate no new warnings or errors



