### PR TITLE
docs: add the generic Result::SetValue(const Value &) overload to the C++ API

### DIFF
--- a/pages/custom-query-modules/cpp/cpp-api.md
+++ b/pages/custom-query-modules/cpp/cpp-api.md
@@ -455,6 +455,10 @@ Sets a return value of given type.
   void SetValue(const Enum &value)
 ```
 
+```cpp
+  void SetValue(const Value &value)
+```
+
 ##### SetErrorMessage
 
 Sets the given error message.


### PR DESCRIPTION
### Release note

Documents the generic `mgp::Result::SetValue(const mgp::Value &)` overload in the C++ query-module API reference. The `Result` class listed one entry per concrete type, so there was nothing telling a module author that a value whose type is only known at runtime can be returned directly instead of dispatching on `Value::Type()`.

### Related product PRs

PRs from product repo this doc page is related to:
memgraph/memgraph#4436

### Checklist:

- [x] Add appropriate milestone (current release cycle)
- [x] Add `bugfix` or `feature` label, based on the product PR type you're documenting
- [ ] Make sure all relevant tech details are documented
    - [x] Update reference pages (e.g. [clauses](https://memgraph.com/docs/querying/clauses), [functions](https://memgraph.com/docs/querying/functions), [flags](https://memgraph.com/docs/database-management/configuration#list-of-configuration-flags), [experimental](https://memgraph.com/docs/database-management/experimental-features), [monitoring](https://memgraph.com/docs/database-management/monitoring), [Cypher differences](https://memgraph.com/docs/querying/differences-in-cypher-implementations))
    - [x] Search for the feature you are working on (mentions) and make updates if needed
    - [ ] Provide a basic example of usage
    - [ ] In case your feature is an Enterprise one, list it under [ME page](https://memgraph.com/docs/database-management/enabling-memgraph-enterprise) and mark its page with Enterprise ([example](https://memgraph.com/docs/database-management/authentication-and-authorization/role-based-access-control)).
- [ ] Check all content with Grammarly
- [x] Perform a self-review of my code
- [ ] The build passes locally
- [ ] My changes generate no new warnings or errors

`SetValue` is documented as a bare overload list with no per-overload prose, so this entry mirrors that exactly. The other `SetValue` mention (`pages/custom-query-modules/cpp/cpp-example.mdx:503`) uses a typed overload and needs no change.
