### PR TITLE
docs(querying): document the NULL predicate in a list comprehension

### DIFF
--- a/pages/querying/expressions.mdx
+++ b/pages/querying/expressions.mdx
@@ -312,6 +312,19 @@ The general syntax for list comprehension in Cypher is:
 - **`predicate`** (optional): A condition that filters elements; only elements satisfying this condition are processed.
 - **`expression`**: An expression applied to each filtered element; the results form the new list.
 
+When the predicate is `null` for an element, that element is skipped and the
+other elements are still returned, the same as when the predicate is `false`.
+A list that contains `null`, or a property that an element does not have, does
+not turn the whole result into `null`:
+
+```cypher
+RETURN [x IN [1, null, 3] WHERE x > 0 | x] AS positives
+```
+
+**Result:** `[1, 3]`
+
+If the list itself is `null`, the result is `null`.
+
 **Examples:**
 
 1. **Transforming a list:**


### PR DESCRIPTION
### Release note

Please briefly explain the changes you made which will be added to the changelog.

### Related product PRs

PRs from product repo this doc page is related to:
https://github.com/memgraph/memgraph/pull/4665

### Checklist:

- [ ] Add appropriate milestone (current release cycle)
- [ ] Add `bugfix` or `feature` label, based on the product PR type you're documenting
- [x] Make sure all relevant tech details are documented
    - [x] Update reference pages (e.g. [clauses](https://memgraph.com/docs/querying/clauses), [functions](https://memgraph.com/docs/querying/functions), [flags](https://memgraph.com/docs/database-management/configuration#list-of-configuration-flags), [experimental](https://memgraph.com/docs/database-management/experimental-features), [monitoring](https://memgraph.com/docs/database-management/monitoring), [Cypher differences](https://memgraph.com/docs/querying/differences-in-cypher-implementations))
    - [x] Search for the feature you are working on (mentions) and make updates if needed
    - [x] Provide a basic example of usage
    - [x] In case your feature is an Enterprise one, list it under [ME page](https://memgraph.com/docs/database-management/enabling-memgraph-enterprise) and mark its page with Enterprise ([example](https://memgraph.com/docs/database-management/authentication-and-authorization/role-based-access-control)).
- [ ] Check all content with Grammarly
- [x] Perform a self-review of my code
- [ ] The build passes locally
- [ ] My changes generate no new warnings or errors