### PR TITLE
feat: make cross_database an enterprise feature

### DIFF
--- a/pages/advanced-algorithms/available-algorithms/cross_database.mdx
+++ b/pages/advanced-algorithms/available-algorithms/cross_database.mdx
@@ -7,7 +7,12 @@ import { Cards } from 'nextra/components'
 import GitHub from '/components/icons/GitHub'
 import { Callout } from 'nextra/components';
 
-# cross_database
+# cross_database (Enterprise)
+
+<Callout type="info">
+From Memgraph 3.13, the  `cross_database` module became a part of the Memgraph Enterprise license. 
+To use `cross_database`, you need to [enable Memgraph Enterprise license](/database-management/enabling-memgraph-enterprise). 
+</Callout>
 
 The `cross_database` module lets you reach into another database from a running Cypher query and stream
 its rows into Memgraph. Use it to migrate data, build hybrid OLTP/graph pipelines, or join graph data

--- a/pages/advanced-algorithms/available-algorithms/migrate.mdx
+++ b/pages/advanced-algorithms/available-algorithms/migrate.mdx
@@ -5,7 +5,7 @@ description: The migrate module was renamed to cross_database in Memgraph 3.11. 
 
 import { Callout } from 'nextra/components';
 
-# migrate
+# migrate (Enterprise)
 
 <Callout type="warning">
 **The `migrate` module was renamed to [`cross_database`](./cross_database) in Memgraph 3.11.**


### PR DESCRIPTION
### Release note

`cross_database` / `migrate` modules for MAGE are now an Enterprise feature.

### Related product PRs

PRs from product repo this doc page is related to: 
https://github.com/memgraph/memgraph/pull/4726

### Checklist:

- [ ] Add appropriate milestone (current release cycle)
- [ ] Add `bugfix` or `feature` label, based on the product PR type you're documenting
- [ ] Make sure all relevant tech details are documented
    - [ ] Update reference pages (e.g. [clauses](https://memgraph.com/docs/querying/clauses), [functions](https://memgraph.com/docs/querying/functions), [flags](https://memgraph.com/docs/database-management/configuration#list-of-configuration-flags), [experimental](https://memgraph.com/docs/database-management/experimental-features), [monitoring](https://memgraph.com/docs/database-management/monitoring), [Cypher differences](https://memgraph.com/docs/querying/differences-in-cypher-implementations))
    - [ ] Search for the feature you are working on (mentions) and make updates if needed
    - [ ] Provide a basic example of usage
    - [ ] In case your feature is an Enterprise one, list it under [ME page](https://memgraph.com/docs/database-management/enabling-memgraph-enterprise) and mark its page with Enterprise ([example](https://memgraph.com/docs/database-management/authentication-and-authorization/role-based-access-control)).
- [ ] Check all content with Grammarly
- [ ] Perform a self-review of my code
- [ ] The build passes locally
- [ ] My changes generate no new warnings or errors